### PR TITLE
Remove xafs database and sanitize MIE-not-found error

### DIFF
--- a/togo_mcp/data/resources/endpoints.csv
+++ b/togo_mcp/data/resources/endpoints.csv
@@ -23,4 +23,3 @@ medgen,https://rdfportal.org/ncbi/sparql,ncbi,ncbi_esearch
 ddbj,https://rdfportal.org/ddbj/sparql,ddbj,sparql
 glycosmos,https://ts.glycosmos.org/sparql,glycosmos,sparql
 supercon,https://rdfportal.org/nims/sparql,nims,sparql
-xafs,https://materials-open-rdf.nims.go.jp/sparql,xafs,sparql

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -270,12 +270,20 @@ def list_databases() -> list[dict[str, Any]]:
                     "description": f"Error processing YAML file: {e}",
                 }
             )
+        except FileNotFoundError:
+            all_schemas_info.append(
+                {
+                    "database": db_name,
+                    "title": "No title found.",
+                    "description": f"MIE file not found: {filename}",
+                }
+            )
         except OSError as e:
             all_schemas_info.append(
                 {
                     "database": db_name,
                     "title": "No title found.",
-                    "description": f"Error reading file: {e}",
+                    "description": f"Error reading {filename}: {e.strerror or 'unknown error'}",
                 }
             )
 


### PR DESCRIPTION
## Summary
- Drop the `xafs` row from `endpoints.csv` — its MIE YAML was never shipped, so `list_databases()` returned an error entry that exposed the developer's local absolute path.
- Harden `list_databases()` in `rdf_portal.py` so any future missing or unreadable MIE file reports only the bare filename, not the full path.

## Test plan
- [x] `uv run pytest` — 23 server-side tests pass; 8 pre-existing `test_api_tools.py` failures are unrelated (FunctionTool wrapping, documented in CLAUDE.md).
- [x] `list_databases()` no longer contains a `xafs` entry.
- [x] Simulated a missing MIE file: description reads `MIE file not found: <db>.yaml` with no path leak.
- [x] `run_sparql(database="xafs", ...)` and `run_sparql(endpoint_name="xafs", ...)` now return the standard "invalid value" error (no retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)