### PR TITLE
Add dbname/db aliases to remaining database-taking tools

### DIFF
--- a/togo_mcp/admin.py
+++ b/togo_mcp/admin.py
@@ -27,16 +27,28 @@ def generate_MIE_file(database: Annotated[str, Field(description=DATABASE_DESCRI
 
 
 @mcp.tool(name="get_shex", description="Get the ShEx schema for a specific RDF database.")
-async def get_shex(database: Annotated[str, Field(description=DATABASE_DESCRIPTION)]) -> str:
+async def get_shex(
+    database: Annotated[
+        str, Field(description=DATABASE_DESCRIPTION, default="")
+    ] = "",
+    dbname: str = "",
+    db: str = "",
+) -> str:
     """
     Get the ShEx schema for a specific RDF database.
 
     Args:
-        database(str): The name of the database for which to retrieve the ShEx schema. Supported values are {', '.join(SPARQL_ENDPOINT.keys())}.
+        database(str): The name of the database for which to retrieve the ShEx schema.
+            Accepts aliases `dbname` and `db`. Supported values are {', '.join(SPARQL_ENDPOINT.keys())}.
+        dbname (str, optional): Alias for `database`.
+        db (str, optional): Alias for `database`.
 
     Returns:
         str: The ShEx schema in ShEx format.
     """
+    database = database or dbname or db
+    if not database:
+        return "Error: Missing required argument `database` (aliases: `dbname`, `db`)."
     shex_file = Path("shex").joinpath(f"{database}.shex")
     if not shex_file.exists():
         return f"Error: The shex file for '{database}' was not found."
@@ -92,17 +104,30 @@ def get_sparql_example(
     description="Save the provided MIE content to a file named after the database.",
 )
 def save_MIE_file(
-    database: Annotated[str, Field(description=DATABASE_DESCRIPTION)],
+    database: Annotated[
+        str, Field(description=DATABASE_DESCRIPTION, default="")
+    ] = "",
     mie_content: Annotated[
         str, Field(description="The content of the MIE file to save.", default="#empty MIE file")
-    ],
+    ] = "#empty MIE file",
+    dbname: str = "",
+    db: str = "",
 ) -> str:
     """
     Saves the provided MIE content to a file named after the database.
 
+    Args:
+        database (str): The database name. Accepts aliases `dbname` and `db`.
+        mie_content (str): The content of the MIE file to save.
+        dbname (str, optional): Alias for `database`.
+        db (str, optional): Alias for `database`.
+
     Returns:
         str: A confirmation message indicating the result of the save operation.
     """
+    database = database or dbname or db
+    if not database:
+        return "Error: Missing required argument `database` (aliases: `dbname`, `db`)."
     try:
         # Ensure the MIE directory exists
         mie_dir = Path(MIE_DIR)

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -126,18 +126,28 @@ async def run_sparql(
     description="Get a list of named graphs in a specific RDF database.",
 )
 async def get_graph_list(
-    database: Annotated[str, Field(description=DATABASE_DESCRIPTION)],
+    database: Annotated[
+        str, Field(description=DATABASE_DESCRIPTION, default="")
+    ] = "",
+    dbname: str = "",
+    db: str = "",
 ) -> str:
     f"""
     Get a list of named graphs in a specific RDF database.
 
     Args:
-        database (str): The name of the database for which to retrieve the named graphs. Supported values are {", ".join(SPARQL_ENDPOINT.keys())}.
+        database (str): The name of the database for which to retrieve the named graphs.
+            Accepts aliases `dbname` and `db`. Supported values are {", ".join(SPARQL_ENDPOINT.keys())}.
+        dbname (str, optional): Alias for `database`.
+        db (str, optional): Alias for `database`.
 
     Returns:
         str: CSV-formatted list of named graphs.
     """
     toolcall_log("get_graph_list")
+    database = database or dbname or db
+    if not database:
+        return "Error: Missing required argument `database` (aliases: `dbname`, `db`)."
     sparql_query = """
 SELECT DISTINCT ?graph WHERE {
   GRAPH ?graph {
@@ -152,18 +162,28 @@ SELECT DISTINCT ?graph WHERE {
     description="**At the start of any task, identify ALL databases needed and call this tool for EACH of them before writing any SPARQL queries.** Do not query a database until its MIE file has been read. Get the MIE (Metadata Interoperability Exchange) file containing the ShEx schema, RDF and SPARQL examples of a specific RDF database.",
 )
 async def get_MIE_file(
-    database: Annotated[str, Field(description=DATABASE_DESCRIPTION)],
+    database: Annotated[
+        str, Field(description=DATABASE_DESCRIPTION, default="")
+    ] = "",
+    dbname: str = "",
+    db: str = "",
 ) -> str:
     f"""
     Get the MIE file containing the ShEx schema, RDF and SPARQL examples of a specific RDF database in YAML format, which can be used as a hint to build SPARQL queries.
 
     Args:
-        database (str): The name of the database for which to retrieve the shape expression. Supported values are {", ".join(SPARQL_ENDPOINT.keys())}."
+        database (str): The name of the database for which to retrieve the shape expression.
+            Accepts aliases `dbname` and `db`. Supported values are {", ".join(SPARQL_ENDPOINT.keys())}.
+        dbname (str, optional): Alias for `database`.
+        db (str, optional): Alias for `database`.
 
     Returns:
         str: The MIE file containing the RDF schema information in YAML format.
     """
     toolcall_log("get_MIE_file")
+    database = database or dbname or db
+    if not database:
+        return "Error: Missing required argument `database` (aliases: `dbname`, `db`)."
     mie_file = Path(MIE_DIR).joinpath(f"{database}.yaml")
     if not mie_file.exists():
         raise FileNotFoundError(f"MIE file not found for database: '{database}'")


### PR DESCRIPTION
## Summary
The previous `dbname` → `database` rename added `dbname`/`db` aliases to `run_sparql` and `get_sparql_example`, but left `get_graph_list`, `get_MIE_file`, `get_shex`, and `save_MIE_file` with a bare required `database` parameter. Calling any of these with `dbname="..."` produced a pydantic `missing required argument` / `unexpected keyword argument` error.

- Add `dbname` and `db` aliases to all four tools, matching the existing pattern.
- Return a clean `Error: Missing required argument ...` message when none is supplied, instead of a pydantic stack trace.

## Test plan
- [x] `uv run pytest tests/test_server.py` — 13/13 pass.
- [x] Verified end-to-end: `get_MIE_file(dbname="supercon")` and `get_MIE_file(db="supercon")` both return MIE content; `get_MIE_file()` with no arg returns the sanitized error.
- [x] `togo_mcp.admin` and `togo_mcp.rdf_portal` both import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)