### PR TITLE
Add Preprint section to TogoMCP intro page

### DIFF
--- a/togo_mcp/data/docs/make_intro.md
+++ b/togo_mcp/data/docs/make_intro.md
@@ -7,6 +7,7 @@ It is developed by DBCLS.
 ## Goal
 Create an HTML page for researchers in biology and medicine who are not necessarily familiar with bioinformatics, explaining what TogoMCP is and how it can help their research. It should contain the following.
 - Summary of TogoMCP
+- Preprint
 - Usage examples
 - Setup guide
 - List of available databases
@@ -16,6 +17,13 @@ Create an HTML page for researchers in biology and medicine who are not necessar
 - Source code
 
 ## Summary
+
+## Preprint
+Cite the preprint using the reference from the top-level `README.md`:
+
+> Kinjo, A. R., Yamamoto, Y., Bustamante-Larriet, S., Labra-Gayo, J.-E., & Fujisawa, T. (2026). TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol. *bioRxiv*. https://doi.org/10.64898/2026.03.19.713030
+
+Link the DOI. Include the authors, year, and journal as shown.
 
 ## Style
 - Use https://togomcp.rdfportal.org/ as a template.
@@ -68,7 +76,7 @@ For Gemini CLI, the settings.json should be
 ```
 
 ## List available databases
-Create a list of available databases with a summary of each.
+Create a list of available databases with a summary of each. Exclude SuperCon from the list.
 
 ## List available tools.
 Create a list of available tools, each with a brief description of its functionality.
@@ -111,6 +119,7 @@ The footer should include the following
 - The menu tab should be sticky so the user can always see it when scrolling.
 - The menu tab should include the pointers to all the sections.
   * Summary
+  * Preprint
   * Examples
   * Setup
   * Databases

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -668,6 +668,7 @@
 <nav class="main-nav" aria-label="Main navigation">
   <ul>
     <li><a href="#summary">Summary</a></li>
+    <li><a href="#preprint">Preprint</a></li>
     <li><a href="#examples">Examples</a></li>
     <li><a href="#setup">Setup</a></li>
     <li><a href="#databases">Databases</a></li>
@@ -728,6 +729,26 @@
         <h3>🤖 AI-Ready</h3>
         <p>Designed for integration with LLM-based assistants. Compatible with Claude Desktop, ChatGPT, and Gemini CLI. No bioinformatics expertise required — use natural language to explore data.</p>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ==============================
+     PREPRINT
+================================ -->
+<section id="preprint">
+  <div class="container">
+    <div class="section-header">
+      <h2 class="section-title">Preprint</h2>
+      <p class="section-lead">TogoMCP is described in the following preprint. Please cite it if you use TogoMCP in your research.</p>
+    </div>
+    <div class="summary-card">
+      <p style="font-size:14px;color:#444;line-height:1.8;">
+        Kinjo, A. R., Yamamoto, Y., Bustamante-Larriet, S., Labra-Gayo, J.-E., &amp; Fujisawa, T. (2026).
+        <strong>TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol</strong>.
+        <em>bioRxiv</em>.
+        <a href="https://doi.org/10.64898/2026.03.19.713030" target="_blank" rel="noopener">https://doi.org/10.64898/2026.03.19.713030</a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Update the intro-page spec (`togo_mcp/data/docs/make_intro.md`) to require a Preprint section citing the bioRxiv preprint (authors, year, title, journal, DOI) from the top-level `README.md`, and to exclude SuperCon from the database list.
- Apply the Preprint section to the generated `togo_mcp/data/docs/togomcp-intro.html`, along with a matching entry in the sticky navigation.

## Test plan
- [ ] Open `togo_mcp/data/docs/togomcp-intro.html` in a browser and confirm the new Preprint section renders between Summary and Examples with the DOI link working
- [ ] Confirm the sticky nav "Preprint" link scrolls to the new section
- [ ] Confirm SuperCon is not present in the Databases grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)