### PR TITLE
Add docker compose setup; add nbrp.shex placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and fill in. .env is loaded automatically by `docker compose`
+# and is gitignored.
+
+# Required: NCBI API key, used by both services
+NCBI_API_KEY=
+
+# Optional: image tags per service (defaults shown)
+MAIN_IMAGE=localhost/togo-mcp:latest
+TEST_IMAGE=localhost/togo-mcp:dev
+
+# Optional: host ports (defaults shown; container always listens on 8000)
+MAIN_PORT=8000
+TEST_PORT=8001

--- a/README.md
+++ b/README.md
@@ -80,7 +80,32 @@ Replace `togo-mcp-local` with `togo-mcp-admin` to also enable tools for generati
 
 ## Docker
 
-A `Dockerfile` is provided for containerized deployment:
+A `Dockerfile` is provided for containerized deployment.
+
+### Recommended: `docker compose`
+
+`compose.yaml` defines two services — `togomcp-main` (port 8000) and `togomcp-test` (port 8001) — so you can run production and staging endpoints side by side from the same image.
+
+```bash
+cp .env.example .env                                # then fill in NCBI_API_KEY
+docker build -t localhost/togo-mcp:latest .         # build main image (tag in .env)
+docker compose up -d togomcp-main                   # start main endpoint
+```
+
+Common operations:
+
+```bash
+docker compose logs -f togomcp-main                 # tail logs
+docker compose down                                 # stop and remove all services
+docker compose down togomcp-test                    # stop and remove just one
+docker compose up -d togomcp-test                   # after rebuilding, recreates with new image
+```
+
+Override image tags and host ports via `.env` — see `.env.example` for the full list. Use `docker compose up -d --force-recreate <svc>` if compose doesn't pick up a rebuilt image, and `docker image prune -f` to clean up dangling layers.
+
+### Simple: `docker run`
+
+For a single container without compose:
 
 ```bash
 docker build -t togo-mcp .

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  togomcp-main:
+    image: ${MAIN_IMAGE:-localhost/togo-mcp:latest}
+    container_name: togomcp-main
+    ports:
+      - "${MAIN_PORT:-8000}:8000"
+    environment:
+      NCBI_API_KEY: ${NCBI_API_KEY}
+    restart: unless-stopped
+
+  togomcp-test:
+    image: ${TEST_IMAGE:-localhost/togo-mcp:dev}
+    container_name: togomcp-test
+    ports:
+      - "${TEST_PORT:-8001}:8000"
+    environment:
+      NCBI_API_KEY: ${NCBI_API_KEY}
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `compose.yaml` and `.env.example` defining two services (`togomcp-main` on :8000, `togomcp-test` on :8001) sharing the same image with `.env`-driven `NCBI_API_KEY`, image tags, and ports. Update the README Docker section to lead with the compose workflow and keep `docker run` as a fallback.
- Add zero-byte `shex/nbrp.shex` placeholder, matching the existing pattern for databases whose ShEx schema has not yet been authored.

## Test plan
- [ ] `cp .env.example .env`, fill in `NCBI_API_KEY`
- [ ] `docker build -t localhost/togo-mcp:latest . && docker compose up -d togomcp-main` — confirm container starts and port 8000 is reachable
- [ ] `docker compose up -d togomcp-test` with a `:dev` image — confirm both containers coexist on their respective ports
- [ ] `docker compose down togomcp-test` — confirm only the test container is removed
- [ ] Rebuild image, run `docker compose up -d togomcp-main` — confirm the new image is picked up without manual `--force-recreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)