### PR TITLE
Add query alias for run_sparql and tolerate unknown search_* kwargs

### DIFF
--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -70,7 +70,9 @@ async def get_sparql_endpoints() -> dict[str, Any]:
     ),
 )
 async def run_sparql(
-    sparql_query: Annotated[str, Field(description="The SPARQL query to execute")],
+    sparql_query: Annotated[
+        str, Field(description="The SPARQL query to execute. Alias: `query`.", default="")
+    ] = "",
     database: Annotated[
         str, Field(description=DATABASE_DESCRIPTION, default="")
     ] = "",
@@ -91,6 +93,7 @@ async def run_sparql(
     ] = "",
     dbname: str = "",
     db: str = "",
+    query: str = "",
 ) -> str:
     """
     Run a SPARQL query on an RDF database.
@@ -98,13 +101,14 @@ async def run_sparql(
     Use `get_MIE_file()` to understand the RDF graph structure of each database.
 
     Args:
-        sparql_query (str): The SPARQL query to execute.
+        sparql_query (str): The SPARQL query to execute. Accepts alias `query`.
         database (str, optional): Database name for single-database queries.
             Accepts aliases `dbname` and `db`.
         endpoint_name (str, optional): Endpoint name for cross-database queries (e.g., 'ebi' for ChEMBL+ChEBI).
         endpoint_url (str, optional): Direct SPARQL endpoint URL.
         dbname (str, optional): Alias for `database`.
         db (str, optional): Alias for `database`.
+        query (str, optional): Alias for `sparql_query`.
 
     Note:
         Provide at least one of: database (or dbname/db), endpoint_name, or endpoint_url.
@@ -115,6 +119,11 @@ async def run_sparql(
     """
     toolcall_log("run_sparql")
     database = database or dbname or db
+    sparql_query = sparql_query or query
+    if not sparql_query:
+        raise ValueError(
+            "Missing SPARQL query. Pass it as `sparql_query` (canonical) or `query`."
+        )
     return await execute_sparql(sparql_query, database, endpoint_name, endpoint_url)
 
 

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -179,6 +179,51 @@ async def execute_sparql(
 mcp = FastMCP("TogoMCP: RDF Portal MCP Server")
 
 
+from fastmcp.server.middleware import Middleware as _Middleware
+import inspect as _inspect
+
+
+class _IgnoreUnknownSearchKwargs(_Middleware):
+    """Strip unknown kwargs from `search_*` tool calls before validation.
+
+    LLMs often pass made-up filters (taxon, organism, reviewed, …) to our
+    search_* tools. Pydantic's TypeAdapter rejects these with a validation
+    error, which is unhelpful. This middleware looks up the target tool's
+    function signature and drops any arguments that aren't declared on it.
+    """
+
+    _valid_kwargs_cache: dict[str, set[str]] = {}
+
+    async def _valid_kwargs(self, ctx, tool_name: str) -> set[str] | None:
+        if not tool_name.startswith("search_"):
+            return None
+        cached = self._valid_kwargs_cache.get(tool_name)
+        if cached is not None:
+            return cached
+        server = ctx.fastmcp_context.fastmcp if ctx.fastmcp_context else None
+        if server is None:
+            return None
+        try:
+            tool = await server.get_tool(tool_name)
+        except Exception:
+            return None
+        valid = set(_inspect.signature(tool.fn).parameters)
+        self._valid_kwargs_cache[tool_name] = valid
+        return valid
+
+    async def on_call_tool(self, context, call_next):
+        name = context.message.name
+        valid = await self._valid_kwargs(context, name)
+        if valid is not None and context.message.arguments:
+            filtered = {k: v for k, v in context.message.arguments.items() if k in valid}
+            if filtered.keys() != context.message.arguments.keys():
+                context.message.arguments = filtered
+        return await call_next(context)
+
+
+mcp.add_middleware(_IgnoreUnknownSearchKwargs())
+
+
 @mcp.custom_route("/health", methods=["GET"])
 async def health_check(request: Request) -> PlainTextResponse:
     return PlainTextResponse("OK")


### PR DESCRIPTION
## Summary
- `run_sparql` now accepts `query` as an alias for `sparql_query`, matching the existing `database`/`dbname`/`db` alias pattern.
- New `_IgnoreUnknownSearchKwargs` middleware strips unknown kwargs from `search_*` tool calls before Pydantic validation, so LLM-invented filters (taxon, organism, reviewed, …) no longer trigger validation errors.

## Test plan
- [ ] `uv run pytest`
- [ ] Smoke-test `run_sparql` with `query=` argument via an MCP client
- [ ] Smoke-test a `search_*` tool with a made-up extra kwarg and confirm it runs instead of failing validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)