### PR TITLE
Update search_uniprot_entity docstring for new kwarg-stripping behavior

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -52,10 +52,10 @@ async def search_uniprot_entity(
     """
     Search for a UniProt entity ID by query.
 
-    ⚠️ Only the search string and `limit` are accepted. Do NOT pass `taxon`,
-       `organism`, `reviewed`, `species`, etc. as separate parameters — they
-       will raise a validation error. Express such filters inside the Solr
-       query string (e.g., `organism_id:9606 AND reviewed:true`).
+    ⚠️ Only the search string and `limit` are accepted. Extra parameters
+       like `taxon`, `organism`, `reviewed`, `species`, etc. are silently
+       dropped and have no effect — express such filters inside the Solr
+       query string instead (e.g., `organism_id:9606 AND reviewed:true`).
 
     The search string can be passed as any of: `query` (canonical),
     `search`, `term`, `keyword`, `keywords`, `search_term`, or `name`.


### PR DESCRIPTION
## Summary
- Updates the `search_uniprot_entity` docstring warning to match the middleware's actual behavior: unknown kwargs (e.g. `taxon`, `organism`, `reviewed`) are now silently dropped rather than raising a validation error.
- Keeps the original guidance that such filters should be expressed inside the Solr query string.

## Test plan
- [ ] Verify docstring renders correctly via `get_MIE_file` / tool schema inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)