### PR TITLE
Clarify search_reactome_entity species docstring: scientific name required

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -624,8 +624,10 @@ async def search_reactome_entity(
         query: The search query string (e.g., "apoptosis", "TP53", "cell cycle").
             Accepts aliases: `search`, `term`, `keyword`, `keywords`,
             `search_term`, `name`.
-        species: Filter by species. Accepts a single string (e.g.,
-            "Homo sapiens", "9606") or a list (e.g., ["Homo sapiens"]).
+        species: Filter by species. Must be the scientific name
+            (e.g., "Homo sapiens", "Mus musculus") — numeric taxon IDs
+            like "9606" are silently ignored by the Reactome API.
+            Accepts a single string or a list of strings.
         types: Filter by entity types. Accepts a single string (e.g.,
             "Pathway") or a list (e.g., ["Pathway", "Reaction", "Complex"]).
         rows: Number of results to return. Defaults to 30.


### PR DESCRIPTION
## Summary
- Updates the `species` docstring in `search_reactome_entity` to clarify that the Reactome search API requires scientific names (e.g. "Homo sapiens"), not numeric taxon IDs.
- Empirically confirmed: passing `"9606"` does not filter — results include `R-HSA-*`, `R-MMU-*`, `R-GGA-*`, `R-XTR-*`, `R-DRE-*`, `R-RNO-*`, `R-DME-*` entries. Passing `"Homo sapiens"` filters correctly to `R-HSA-*` only.
- Follow-up to #43 based on tester feedback.

## Test plan
- [ ] `search_reactome_entity(query="TP53", species="Homo sapiens")` → only `R-HSA-*` results
- [ ] Rendered docstring no longer suggests `"9606"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)