### PR TITLE
search_reactome_entity: reject numeric taxon IDs, clarify rows semantics

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -625,12 +625,17 @@ async def search_reactome_entity(
             Accepts aliases: `search`, `term`, `keyword`, `keywords`,
             `search_term`, `name`.
         species: Filter by species. Must be the scientific name
-            (e.g., "Homo sapiens", "Mus musculus") — numeric taxon IDs
-            like "9606" are silently ignored by the Reactome API.
-            Accepts a single string or a list of strings.
+            (e.g., "Homo sapiens", "Mus musculus"). Numeric NCBI taxon
+            IDs like "9606" are rejected here (this tool raises ValueError)
+            because the Reactome API silently ignores them AND can
+            degrade co-occurring filters (e.g. `types`). Accepts a
+            single string or a list of strings.
         types: Filter by entity types. Accepts a single string (e.g.,
             "Pathway") or a list (e.g., ["Pathway", "Reaction", "Complex"]).
-        rows: Number of results to return. Defaults to 30.
+        rows: Per-category result cap. Reactome clusters results by
+            entity type (`cluster=true`), so `rows=30` returns up to 30
+            hits *per type*, not 30 hits total. To bound the total,
+            constrain `types` to a single value.
 
     Returns:
         List of results with 'id', 'name', and 'type' fields.
@@ -669,7 +674,15 @@ async def search_reactome_entity(
     params = {"query": query, "cluster": "true", "start": 0, "rows": rows}
 
     if species:
-        params["species"] = species if isinstance(species, str) else ",".join(species)
+        species_list = [species] if isinstance(species, str) else list(species)
+        bad = [s for s in species_list if s.strip().isdigit()]
+        if bad:
+            raise ValueError(
+                f"species must be a scientific name (e.g. 'Homo sapiens'); "
+                f"got numeric taxon ID(s): {bad}. The Reactome search API "
+                "silently ignores numeric IDs and can also drop other filters."
+            )
+        params["species"] = ",".join(species_list)
     if types:
         params["types"] = types if isinstance(types, str) else ",".join(types)
 


### PR DESCRIPTION
## Summary
Two follow-ups from empirical testing against the live Reactome search endpoint:

1. **Reject numeric `species` values** (e.g. `"9606"`) with a clear `ValueError` before hitting the API. Reactome silently ignores numeric taxon IDs AND can degrade co-occurring filters — a request with `species="9606"` and `types="Pathway"` came back with mixed species AND mixed entity types. Pre-validating fails fast with an actionable message.
2. **Clarify `rows` semantics in the docstring.** With `cluster=true` (our default), `rows` is a per-category cap, not a global total. `rows=30` can return up to ~300 hits across ~10 categories. Callers should constrain `types` to a single value to bound the total.

Follow-up to #43 / #44.

## Test plan
- [ ] `search_reactome_entity(query="TP53", species="9606")` → `ValueError`
- [ ] `search_reactome_entity(query="TP53", species=["Homo sapiens", "9606"])` → `ValueError`
- [ ] `search_reactome_entity(query="TP53", species="Homo sapiens")` → works, all `R-HSA-*`
- [ ] `search_reactome_entity(query="apoptosis", rows=3)` with no `types` → returns >3 hits across categories (confirms per-category behavior matches docstring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)