### PR TITLE
search_pdb_entity: fix PRD name, bound limit, note multi-field search

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -500,7 +500,7 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
 async def search_pdb_entity(
     db: Literal["pdb", "cc", "prd"],
     query: str = "",
-    limit: int = 20,
+    limit: Annotated[int, Field(ge=0, le=500)] = 20,
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -520,6 +520,14 @@ async def search_pdb_entity(
             Accepts aliases: `search`, `term`, `keyword`, `keywords`,
             `search_term`, `name`.
         limit (int): The maximum number of results to return. Default is 20.
+            Must be in [0, 500].
+
+    Note:
+        The PDBj search hits multiple fields (title, authors, keywords,
+        citation metadata), not just the title. An entry can appear
+        even if its title does not contain the query. Always verify
+        relevance against the returned name/title before relying on
+        a hit.
 
     Returns:
         str: A JSON-formatted string containing the search results.
@@ -539,15 +547,20 @@ async def search_pdb_entity(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
+    # PDBj returns result rows as ordered arrays; the "name" column
+    # lives at a different index per DB. For PRD, index 1 is always
+    # empty — the human-readable name is at index 4.
+    name_idx = {"pdb": 1, "cc": 1, "prd": 4}[db]
     try:
         response = await _pdbj_client.get(
             f"/rest/newweb/search/{db}", params={"query": query}
         )
         response.raise_for_status()
-        # Parse the response as JSON
-        total_results = response.json().get("total", 0)
+        payload = response.json()
+        total_results = payload.get("total", 0)
         result_list = [
-            {entry[0]: entry[1]} for entry in response.json().get("results", [])[:limit]
+            {entry[0]: entry[name_idx] if len(entry) > name_idx else ""}
+            for entry in payload.get("results", [])[:limit]
         ]
         response_dict = {"total": total_results, "results": result_list}
         return json.dumps(response_dict)


### PR DESCRIPTION
## Summary

Three fixes for `search_pdb_entity` from an empirical bug report:

### 1. PRD results now return the human-readable name (was always empty)
PDBj's `/rest/newweb/search/prd` endpoint returns rows where index 1 is empty and the actual molecule name is at index 4 — unlike `/pdb` and `/cc` where the name is at index 1. The tool previously always picked index 1, so every PRD hit came back as `{"PRD_XXXXXX": ""}`, making the `prd` mode effectively unusable.

Now:
```
{"PRD_000480": "DECAPEPTIDE HIRUDIN ANALOGUE"}
{"PRD_000758": "THIOPEPTIDE THIOSTREPTON REDUCED AT N-CA BOND OF RESIDUE 14"}
```

### 2. `limit` bounded to [0, 500]
Negative values used to fall through to Python's `results[:-n]` slicing and return hundreds of hits — a real context-budget trap for LLM agents. Now rejected with a clear Pydantic validation error. Upper bound 500 prevents runaway responses.

### 3. Docstring note on multi-field search
PDBj search matches multiple fields (title, authors, keywords, citation), so a hit does not imply the title contains the query. Added a `Note:` in the docstring so callers know to verify the name before trusting a match.

Addresses issues 1, 2, and 4 of the PDB bug report. Issue 3 (CC ranking — ATP not in top hits) is upstream; deferred to a separate PR.

## Test plan
- [ ] `search_pdb_entity(db="prd", query="peptide", limit=3)` — names populated
- [ ] `search_pdb_entity(db="pdb", query="kinase", limit=-5)` — `ValidationError`
- [ ] `search_pdb_entity(db="pdb", query="kinase", limit=501)` — `ValidationError`
- [ ] `search_pdb_entity(db="pdb", query="kinase", limit=2)` — unchanged
- [ ] `search_pdb_entity(db="cc", query="HEM", limit=3)` — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)