### PR TITLE
Token-efficient database discovery: find_databases + keyword/category metadata

### DIFF
--- a/.claude/skills/mie-generator/references/mie-structure.md
+++ b/.claude/skills/mie-generator/references/mie-structure.md
@@ -8,6 +8,8 @@ Descriptive header. Required fields:
 
 - `title`: canonical database name
 - `description`: 2–3 sentences — what the database contains, its main entity types, primary use cases
+- `keywords`: 8–15 lowercase terms for `find_databases()` discovery. Include synonyms a user might type instead of the canonical term (e.g. `mutation`, `polymorphism` alongside `variant`). See spec §3.1.5.
+- `categories`: 1–3 entries drawn from the controlled taxonomy in spec §3.1.5. Pick categories that genuinely characterize the database — don't tag every category whose vocabulary appears once in the description.
 - `endpoint`: SPARQL endpoint URL
 - `base_uri`: root URI namespace
 - `graphs`: list of named graphs in the endpoint

--- a/.claude/skills/mie-generator/references/template.yaml
+++ b/.claude/skills/mie-generator/references/template.yaml
@@ -10,6 +10,17 @@ schema_info:
   title: [DATABASE_NAME]
   description: |
     [2-3 sentences: contents, entity types, primary use cases]
+  # 8-15 lowercase keywords for token-efficient discovery via find_databases().
+  # Include synonyms a user might type instead of the canonical term
+  # (e.g. mutation/polymorphism alongside variant). See spec §3.1.5.
+  keywords:
+    - [keyword1]
+    - [keyword2]
+  # 1-3 categories from the controlled taxonomy. See spec §3.1.5 for the full list.
+  # Pick the categories that genuinely characterize this database, not every category
+  # whose vocabulary appears once in the description.
+  categories:
+    - [category1]
   endpoint: https://rdfportal.org/example/sparql
   base_uri: http://example.org/
   graphs:

--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ evaluation/scripts/evaluation_results_intermediate.csv
 .claude/settings.local.json
 .claude/worktrees/
 mie-generator.skill
+
+# Transient review artifact from scripts/bootstrap_mie_keywords.py
+scripts/mie_keyword_suggestions.yaml

--- a/scripts/bootstrap_mie_keywords.py
+++ b/scripts/bootstrap_mie_keywords.py
@@ -43,6 +43,8 @@ CATEGORY_RULES: dict[str, list[str]] = {
     "antimicrobial": ["amr", "antibiotic resistance", "antimicrobial"],
     "sequence": ["ddbj", "sequence database", "nucleotide"],
     "disease": ["disease", "phenotype", "clinical"],
+    "materials": ["materials science", "crystal structure", "lattice parameter", "alloy", "oxide", "superconductor", "supercon"],
+    "physics": ["superconductor", "supercon", "critical temperature", " tc ", "magnetic field", "conductivity", "physical property"],
 }
 
 STOPWORDS = {
@@ -94,9 +96,11 @@ def main() -> int:
         except yaml.YAMLError as e:
             print(f"Skipping {db_name}: {e}", file=sys.stderr)
             continue
-        si = (data or {}).get("schema_info", {}) or {}
-        title = (si.get("title") or "").strip()
-        desc = (si.get("description") or "").strip()
+        si = data.get("schema_info") if isinstance(data, dict) else None
+        if not isinstance(si, dict):
+            si = {}
+        title = str(si.get("title") or "").strip()
+        desc = str(si.get("description") or "").strip()
         suggestions[db_name] = {
             "title": title,
             "description_excerpt": (desc[:240] + "...") if len(desc) > 240 else desc,

--- a/scripts/bootstrap_mie_keywords.py
+++ b/scripts/bootstrap_mie_keywords.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Suggest `keywords` and `categories` fields for each MIE file's schema_info.
+
+Reads togo_mcp/data/mie/*.yaml, extracts title + description, runs simple
+heuristics, and emits a YAML file of suggestions for human review at
+scripts/mie_keyword_suggestions.yaml. Does NOT modify any MIE file.
+
+Workflow:
+    uv run python scripts/bootstrap_mie_keywords.py
+    # review scripts/mie_keyword_suggestions.yaml
+    # hand-edit each MIE's schema_info to add the approved fields
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIE_DIR = REPO_ROOT / "togo_mcp" / "data" / "mie"
+OUTPUT = REPO_ROOT / "scripts" / "mie_keyword_suggestions.yaml"
+
+# Hand-curated category taxonomy. Add new categories here as the corpus grows.
+# Each value is a list of substring rules; presence of any rule in title+description
+# (case-insensitive) tags the database with the category.
+CATEGORY_RULES: dict[str, list[str]] = {
+    "protein": ["protein", "swiss-prot", "swissprot", "trembl", "uniprot", "amino acid"],
+    "gene": ["gene ", " gene", "transcript", "ensembl", "ncbi gene"],
+    "variant": ["variant", "mutation", "polymorphism", "snp ", "clinvar"],
+    "compound": ["compound", "small molecule", "ligand", "chemical", "chebi", "pubchem"],
+    "drug_target": ["drug target", "chembl", "bioactivity", "ic50", "binding affinity"],
+    "pathway": ["pathway", "reactome", "metabolic"],
+    "reaction": ["reaction", "rhea", "enzyme reaction"],
+    "ontology": ["ontology", "go term", "mesh", "mondo", "nando", "obo"],
+    "structure": ["structure", "pdb", "3d ", "crystal", "cryo-em"],
+    "literature": ["pubmed", "publication", "article", "literature", "citation"],
+    "taxonomy": ["taxonomy", "taxon", "organism", "species"],
+    "microbe": ["bacdive", "mediadive", "bacterial", "culture media", "growth condition"],
+    "glycan": ["glycan", "glycosylation", "glycomics", "sugar"],
+    "antimicrobial": ["amr", "antibiotic resistance", "antimicrobial"],
+    "sequence": ["ddbj", "sequence database", "nucleotide"],
+    "disease": ["disease", "phenotype", "clinical"],
+}
+
+STOPWORDS = {
+    "the", "and", "for", "with", "from", "that", "this", "these", "those", "are",
+    "was", "were", "have", "has", "had", "will", "would", "could", "should", "may",
+    "must", "can", "all", "any", "some", "not", "only", "also", "more", "most",
+    "other", "such", "than", "too", "very", "just", "into", "through", "between",
+    "across", "over", "under", "rdf", "data", "database", "contains", "includes",
+    "used", "using", "entries", "etc", "see", "many", "well", "above", "below",
+    "after", "before", "during", "via", "ie", "eg", "csv", "yaml", "based", "each",
+    "which", "where", "when", "what", "while", "their", "them", "they", "your",
+    "available", "provides", "providing", "include", "including", "covers",
+}
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase tokens length >= 4, stopwords/digits dropped."""
+    tokens = re.findall(r"[a-z0-9_-]+", text.lower())
+    return [t for t in tokens if len(t) >= 4 and t not in STOPWORDS and not t.isdigit()]
+
+
+def suggest_keywords(title: str, description: str, top_n: int = 12) -> list[str]:
+    """Frequency rank with title boost. Stable on ties (alphabetical)."""
+    counts: dict[str, int] = {}
+    for tok in tokenize(title):
+        counts[tok] = counts.get(tok, 0) + 3
+    for tok in tokenize(description):
+        counts[tok] = counts.get(tok, 0) + 1
+    ranked = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    return [t for t, _ in ranked[:top_n]]
+
+
+def suggest_categories(title: str, description: str) -> list[str]:
+    haystack = (title + " " + description).lower()
+    return [cat for cat, rules in CATEGORY_RULES.items() if any(r in haystack for r in rules)]
+
+
+def main() -> int:
+    if not MIE_DIR.is_dir():
+        print(f"Error: {MIE_DIR} not found", file=sys.stderr)
+        return 1
+
+    suggestions: dict[str, dict[str, object]] = {}
+    for path in sorted(MIE_DIR.glob("*.yaml")):
+        db_name = path.stem
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Skipping {db_name}: {e}", file=sys.stderr)
+            continue
+        si = (data or {}).get("schema_info", {}) or {}
+        title = (si.get("title") or "").strip()
+        desc = (si.get("description") or "").strip()
+        suggestions[db_name] = {
+            "title": title,
+            "description_excerpt": (desc[:240] + "...") if len(desc) > 240 else desc,
+            "current_keywords": si.get("keywords"),
+            "current_categories": si.get("categories"),
+            "suggested_keywords": suggest_keywords(title, desc),
+            "suggested_categories": suggest_categories(title, desc),
+        }
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT, "w", encoding="utf-8") as f:
+        yaml.safe_dump(suggestions, f, sort_keys=False, allow_unicode=True, width=120)
+
+    uncategorized = [db for db, s in suggestions.items() if not s["suggested_categories"]]
+    print(f"Wrote {len(suggestions)} suggestions to {OUTPUT.relative_to(REPO_ROOT)}")
+    if uncategorized:
+        print(f"  ({len(uncategorized)} DBs got no category match — review manually): {', '.join(uncategorized)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/togo_mcp/data/docs/MIE_file_specs.md
+++ b/togo_mcp/data/docs/MIE_file_specs.md
@@ -72,6 +72,8 @@ schema_info:
                                    # - main entity types
                                    # - primary use cases
     ...
+  keywords: array<string>          # REQUIRED: 8-15 lowercase discovery terms (see §3.1.5)
+  categories: array<string>        # REQUIRED: 1-3 entries from controlled taxonomy (see §3.1.5)
   endpoint: uri                    # REQUIRED: SPARQL endpoint URL
   base_uri: uri                    # REQUIRED: base namespace URI
   graphs: array<uri>               # REQUIRED: named graph URIs
@@ -107,6 +109,46 @@ The `kw_search_tools` field enumerates keyword-search methods available for this
 - All URIs are valid and accessible.
 - `mie_created` uses ISO 8601 (`YYYY-MM-DD`).
 - `access.backend` is required; it determines whether `bif:contains` is available and therefore drives query-strategy decisions downstream.
+- `keywords` are lowercase, single tokens or short phrases; 8–15 entries.
+- `categories` come from the controlled taxonomy in §3.1.5; 1–3 entries per database.
+
+#### 3.1.5 Keywords and Categories
+
+Both fields drive the `find_databases()` discovery tool — a token-efficient alternative to `list_databases()` that lets a downstream LLM filter the catalog by topic instead of reading every description.
+
+**`keywords`** — 8–15 lowercase terms. Curate to maximize recall:
+
+- Include the canonical entity types and concepts that characterize the database.
+- Include common synonyms a user might type instead of the canonical term:
+  - variant ↔ mutation ↔ polymorphism
+  - drug ↔ compound ↔ chemical
+  - transcript ↔ mRNA
+  - protein ↔ amino acid sequence
+- Skip stopwords and generic filler ("data", "database", "contains", "available").
+- Skip terms that appear only incidentally in the description.
+
+**`categories`** — pick 1–3 from the controlled taxonomy below. Tag only categories that genuinely characterize the database, not every category whose vocabulary appears once.
+
+| Category | Use for |
+|---|---|
+| `protein` | Protein sequence, function, domains, isoforms |
+| `gene` | Gene records, transcripts, gene-level annotations |
+| `variant` | SNPs, mutations, polymorphisms, clinical variants |
+| `compound` | Small molecules, ligands, chemical entities |
+| `drug_target` | Drug–target bioactivity, IC50, binding affinity |
+| `pathway` | Biological pathways, signaling cascades |
+| `reaction` | Enzyme reactions, biochemical reactions |
+| `ontology` | Controlled vocabularies, ontologies (GO, MeSH, MONDO, etc.) |
+| `structure` | 3D structures, crystallography, cryo-EM |
+| `literature` | Publications, citations, full-text articles |
+| `taxonomy` | Organism / species / taxon hierarchies |
+| `microbe` | Bacterial / archaeal strains, growth conditions, culture media |
+| `glycan` | Glycans, glycosylation, glycomics |
+| `antimicrobial` | AMR, antibiotic resistance |
+| `sequence` | Nucleotide sequence repositories |
+| `disease` | Disease, phenotype, clinical associations |
+
+When adding a new category, update both this taxonomy and the `find_databases` tool documentation.
 
 ### 3.2 critical_warnings
 
@@ -689,7 +731,7 @@ When updating an existing MIE, evaluate against the following checklist and pick
 #### Structure & Format
 - [ ] Valid YAML
 - [ ] All 11 required sections present in order
-- [ ] `schema_info` includes `backend` and `kw_search_tools`
+- [ ] `schema_info` includes `backend`, `kw_search_tools`, `keywords`, `categories`
 - [ ] Multiline strings use pipe syntax
 
 #### Content Counts
@@ -731,7 +773,7 @@ When updating an existing MIE, evaluate against the following checklist and pick
 
 #### Structure
 - [ ] Valid YAML, 11 sections in order
-- [ ] `schema_info` complete with backend and kw_search_tools
+- [ ] `schema_info` complete with backend, kw_search_tools, keywords (8-15), categories (1-3)
 - [ ] `critical_warnings` documents silent-failure traps (or verified `[]`)
 - [ ] ShEx covers all major entity types with inline counts
 - [ ] Exactly 3 RDF entries, shared prefix block
@@ -889,6 +931,11 @@ schema_info:
   title: [DATABASE_NAME]
   description: |
     [2-3 sentences: contents, main entity types, primary use cases]
+  keywords:                        # 8-15 lowercase, include synonyms (see §3.1.5)
+    - [keyword1]
+    - [keyword2]
+  categories:                      # 1-3 from controlled taxonomy (see §3.1.5)
+    - [category1]
   endpoint: https://rdfportal.org/example/sparql
   base_uri: http://example.org/
   graphs:

--- a/togo_mcp/data/docs/MIE_file_specs.md
+++ b/togo_mcp/data/docs/MIE_file_specs.md
@@ -147,6 +147,8 @@ Both fields drive the `find_databases()` discovery tool — a token-efficient al
 | `antimicrobial` | AMR, antibiotic resistance |
 | `sequence` | Nucleotide sequence repositories |
 | `disease` | Disease, phenotype, clinical associations |
+| `materials` | Materials science — crystal structure, lattice parameters, alloys, oxides, polymers |
+| `physics` | Physical properties and measurements — Tc, magnetic fields, conductivity, thermal coefficients |
 
 When adding a new category, update both this taxonomy and the `find_databases` tool documentation.
 

--- a/togo_mcp/data/mie/amrportal.yaml
+++ b/togo_mcp/data/mie/amrportal.yaml
@@ -8,6 +8,25 @@ schema_info:
     GenotypeFeature (AMR genes and mutations with genomic coordinates).
     Applications: resistance pattern analysis, genotype-phenotype correlation, geographic
     surveillance, temporal trends, multi-drug resistance profiling.
+  keywords:
+    - antimicrobial resistance
+    - amr
+    - antibiotic
+    - mic
+    - minimum inhibitory concentration
+    - phenotype
+    - genotype
+    - resistance gene
+    - bacteria
+    - pathogen
+    - susceptibility
+    - surveillance
+    - disk diffusion
+    - multi-drug resistance
+    - breakpoint
+  categories:
+    - antimicrobial
+    - microbe
   endpoint: https://rdfportal.org/ebi/sparql
   base_uri: http://example.org/ebiamr#
   graphs:

--- a/togo_mcp/data/mie/bacdive.yaml
+++ b/togo_mcp/data/mie/bacdive.yaml
@@ -11,6 +11,24 @@ schema_info:
     LocationOfOrigin, Reference, StrainDesignation). Cross-referenced to NCBI Taxonomy, culture
     collections (DSMZ, JCM, KCTC), sequence databases (ENA, GenBank), and MediaDive for media
     recipes.
+  keywords:
+    - bacteria
+    - archaea
+    - strain
+    - culture
+    - growth condition
+    - medium
+    - morphology
+    - physiology
+    - 16s rrna
+    - genome
+    - isolation
+    - habitat
+    - temperature
+    - oxygen
+    - gram stain
+  categories:
+    - microbe
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: https://purl.dsmz.de/
   graphs:

--- a/togo_mcp/data/mie/chebi.yaml
+++ b/togo_mcp/data/mie/chebi.yaml
@@ -7,6 +7,25 @@ schema_info:
     via the chemrof namespace, biological roles via RO_0000087 OWL restrictions, chemical
     relationships (conjugate acids/bases, tautomers, enantiomers) via RO_ namespace properties,
     and cross-references to 50+ databases including KEGG, DrugBank, PubChem, and HMDB.
+  keywords:
+    - chemical entity
+    - small molecule
+    - metabolite
+    - lipid
+    - amino acid
+    - nucleotide
+    - ion
+    - radical
+    - functional group
+    - biological role
+    - drug
+    - ontology
+    - hierarchy
+    - chebi
+    - compound
+  categories:
+    - compound
+    - ontology
   endpoint: https://rdfportal.org/ebi/sparql
   base_uri: http://purl.obolibrary.org/obo/CHEBI_
   graphs:

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -7,6 +7,25 @@ schema_info:
     activities, documents, drug mechanisms, and drug indications.
     Enables queries for compound-target-activity relationships, mechanism of action,
     drug repositioning, and pharmaceutical research.
+  keywords:
+    - compound
+    - bioactive molecule
+    - drug
+    - target
+    - bioactivity
+    - ic50
+    - assay
+    - inhibitor
+    - mechanism of action
+    - indication
+    - atc
+    - clinical trial
+    - smiles
+    - binding affinity
+    - uniprot
+  categories:
+    - compound
+    - drug_target
   endpoint: https://rdfportal.org/ebi/sparql
   base_uri: http://rdf.ebi.ac.uk/resource/chembl/
   graphs:

--- a/togo_mcp/data/mie/clinvar.yaml
+++ b/togo_mcp/data/mie/clinvar.yaml
@@ -5,6 +5,25 @@ schema_info:
     Contains 3.59M+ variant records with clinical significance assertions, disease associations, and gene relationships.
     Main entities: VariationArchiveType (variants), Gene (genes), ClinAsserTraitType (diseases/phenotypes),
     ClassifiedRecord (clinical assertions). Variants link to MedGen, OMIM, Orphanet, MeSH, HPO, and NCBI Gene.
+  keywords:
+    - variant
+    - mutation
+    - clinical significance
+    - pathogenic
+    - benign
+    - uncertain significance
+    - snp
+    - indel
+    - gene
+    - disease
+    - phenotype
+    - allele
+    - hgvs
+    - germline
+    - vus
+  categories:
+    - variant
+    - disease
   endpoint: https://rdfportal.org/ncbi/sparql
   base_uri: http://ncbi.nlm.nih.gov/clinvar/
   graphs:

--- a/togo_mcp/data/mie/ddbj.yaml
+++ b/togo_mcp/data/mie/ddbj.yaml
@@ -8,6 +8,24 @@ schema_info:
     Sequence Ontology typing, and BFO/RO relationships. Cross-references to BioProject, BioSample,
     NCBI Protein, and NCBI Taxonomy are pervasive; every sequence object carries INSDC tri-partner
     FASTA links (DDBJ / ENA / NCBI).
+  keywords:
+    - nucleotide sequence
+    - dna
+    - rna
+    - gene
+    - genome
+    - accession
+    - organism
+    - feature annotation
+    - est
+    - pat
+    - insdc
+    - wgs
+    - division
+    - genbank
+    - embl
+  categories:
+    - sequence
   endpoint: https://rdfportal.org/ddbj/sparql
   base_uri: http://identifiers.org/insdc/
   graphs:

--- a/togo_mcp/data/mie/ensembl.yaml
+++ b/togo_mcp/data/mie/ensembl.yaml
@@ -7,6 +7,25 @@ schema_info:
     quality flags (MANE Select, APPRIS, TSL, canonical), proteins, and exons with
     FALDO genomic coordinates. Cross-referenced to UniProt, HGNC, Reactome, OMIM,
     NCBI Gene, and PDB.
+  keywords:
+    - gene
+    - transcript
+    - mrna
+    - protein
+    - genome
+    - annotation
+    - chromosome
+    - exon
+    - biotype
+    - protein-coding
+    - lncrna
+    - mirna
+    - vertebrate
+    - stable id
+    - species
+  categories:
+    - gene
+    - sequence
   endpoint: https://rdfportal.org/ebi/sparql
   base_uri: http://rdf.ebi.ac.uk/resource/ensembl/
   graphs:

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -5,6 +5,24 @@ schema_info:
     glycoproteins, glycosylation sites, glycogenes, glycoepitopes, lectin-glycan
     interactions (SugarBind/UniLectin), and glycolipids. Primary uses include
     glycobiology research, biomarker discovery, and drug target identification.
+  keywords:
+    - glycan
+    - glycosylation
+    - glycoprotein
+    - saccharide
+    - wurcs
+    - glycotoucan
+    - sugar
+    - n-glycan
+    - o-glycan
+    - epitope
+    - lectin
+    - glycogene
+    - glycomics
+    - monosaccharide
+    - glycosylation site
+  categories:
+    - glycan
   endpoint: https://ts.glycosmos.org/sparql
   base_uri: http://rdf.glycoinfo.org/
   graphs:

--- a/togo_mcp/data/mie/go.yaml
+++ b/togo_mcp/data/mie/go.yaml
@@ -7,6 +7,21 @@ schema_info:
     cellular_component (4,586 terms). GO enables consistent functional annotation with
     hierarchical relationships, definitions, synonyms, slim subsets, and extensive
     cross-references to external databases including Reactome, EC, RHEA, and MetaCyc.
+  keywords:
+    - gene ontology
+    - biological process
+    - molecular function
+    - cellular component
+    - protein annotation
+    - go term
+    - hierarchy
+    - obo
+    - controlled vocabulary
+    - evidence code
+    - gene product
+    - annotation
+  categories:
+    - ontology
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://purl.obolibrary.org/obo/
   graphs:

--- a/togo_mcp/data/mie/medgen.yaml
+++ b/togo_mcp/data/mie/medgen.yaml
@@ -7,6 +7,25 @@ schema_info:
     ConceptIDs carry direct relationship properties (mo:manifestation_of, mo:isa, etc.);
     MGREL records store provenance for each relationship. Attributes are in MGSAT (typed
     blank nodes); cross-references via mo:mgconso blank nodes (rdfs:seeAlso).
+  keywords:
+    - medical genetics
+    - disease
+    - phenotype
+    - clinical concept
+    - omim
+    - orphanet
+    - hpo
+    - snomed
+    - icd
+    - inheritance
+    - rare disease
+    - syndrome
+    - disorder
+    - finding
+    - genetic condition
+  categories:
+    - disease
+    - gene
   endpoint: https://rdfportal.org/ncbi/sparql
   base_uri: http://www.ncbi.nlm.nih.gov/medgen/
   graphs:

--- a/togo_mcp/data/mie/mediadive.yaml
+++ b/togo_mcp/data/mie/mediadive.yaml
@@ -6,6 +6,24 @@ schema_info:
     cross-references (GMO 58%, CAS 59%, ChEBI 46%), 45,685 strain records (73% with BacDive links),
     and growth conditions (pH, temperature, oxygen). Hierarchical recipe structure:
     medium → solution → solution_recipe → ingredient with detailed preparation protocols.
+  keywords:
+    - culture medium
+    - growth medium
+    - recipe
+    - ingredient
+    - bacteria
+    - archaea
+    - fungi
+    - yeast
+    - microalgae
+    - phage
+    - dsmz
+    - bacdive
+    - media
+    - chebi
+    - component
+  categories:
+    - microbe
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: https://purl.dsmz.de/mediadive/
   graphs:

--- a/togo_mcp/data/mie/mesh.yaml
+++ b/togo_mcp/data/mie/mesh.yaml
@@ -8,6 +8,24 @@ schema_info:
     records, and 679K AllowedDescriptorQualifierPairs.
     Primary use cases: PubMed article indexing, biomedical database curation, clinical research queries,
     cross-ontology disease mapping.
+  keywords:
+    - medical subject headings
+    - controlled vocabulary
+    - thesaurus
+    - descriptor
+    - tree number
+    - qualifier
+    - disease
+    - anatomy
+    - pharmacology
+    - organism
+    - supplementary record
+    - concept
+    - annotation
+    - pubmed indexing
+  categories:
+    - ontology
+    - disease
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://id.nlm.nih.gov/mesh/
   graphs:

--- a/togo_mcp/data/mie/mondo.yaml
+++ b/togo_mcp/data/mie/mondo.yaml
@@ -5,6 +5,25 @@ schema_info:
     classification system. Contains 30,612 disease classes (26,660 active) covering genetic disorders,
     infectious diseases, cancers, psychiatric disorders, and rare diseases. Primary use cases include
     translational research, precision medicine, literature mining, and cross-database disease queries.
+  keywords:
+    - disease
+    - ontology
+    - disorder
+    - syndrome
+    - rare disease
+    - genetic disease
+    - infectious disease
+    - omim
+    - orphanet
+    - mesh
+    - icd
+    - doid
+    - cross-reference
+    - phenotype
+    - monarch
+  categories:
+    - disease
+    - ontology
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://purl.obolibrary.org/obo/
   graphs:

--- a/togo_mcp/data/mie/nando.yaml
+++ b/togo_mcp/data/mie/nando.yaml
@@ -6,6 +6,24 @@ schema_info:
     Features trilingual labels (English, Japanese kanji, hiragana phonetic), notification numbers for
     designated diseases, cross-references to MONDO for international harmonization, and links to KEGG,
     government documents, and patient resources. Maintained by DBCLS (Database Center for Life Science).
+  keywords:
+    - intractable disease
+    - rare disease
+    - japanese
+    - nanbyou
+    - nando
+    - orphanet
+    - icd10
+    - mondo
+    - designated disease
+    - hierarchy
+    - phenotype
+    - disorder
+    - government support
+    - classification
+  categories:
+    - disease
+    - ontology
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://nanbyodata.jp/ontology/
   graphs:

--- a/togo_mcp/data/mie/ncbigene.yaml
+++ b/togo_mcp/data/mie/ncbigene.yaml
@@ -7,6 +7,24 @@ schema_info:
     extensive cross-references to Ensembl, HGNC, OMIM, and miRBase.
     Supports comparative genomics through bidirectional orthology relationships.
     Best coverage for model organisms (human, mouse, rat).
+  keywords:
+    - gene
+    - ncbi
+    - annotation
+    - transcript
+    - gene symbol
+    - synonym
+    - chromosome
+    - organism
+    - function
+    - go term
+    - pathway
+    - refseq
+    - locus
+    - protein-coding
+    - ncrna
+  categories:
+    - gene
   endpoint: https://rdfportal.org/ncbi/sparql
   base_uri: http://identifiers.org/ncbigene/
   graphs:

--- a/togo_mcp/data/mie/pdb.yaml
+++ b/togo_mcp/data/mie/pdb.yaml
@@ -6,6 +6,24 @@ schema_info:
     and cryo-EM. Contains 248,874 entries with experimental methods, structural
     coordinates, resolution data, sequences, biological assemblies, and cross-references
     to UniProt, taxonomy, EMDB, and publications. Updated weekly.
+  keywords:
+    - protein structure
+    - 3d structure
+    - crystal
+    - x-ray crystallography
+    - cryo-em
+    - nmr
+    - macromolecule
+    - ligand
+    - binding site
+    - resolution
+    - polymer chain
+    - assembly
+    - entry
+    - method
+  categories:
+    - structure
+    - protein
   endpoint: https://rdfportal.org/pdb/sparql
   base_uri: http://rdf.wwpdb.org/pdb/
   graphs:

--- a/togo_mcp/data/mie/pubchem.yaml
+++ b/togo_mcp/data/mie/pubchem.yaml
@@ -6,6 +6,24 @@ schema_info:
     80K pathways, and 53M patents. Integrates molecular descriptors (SMILES, InChI, MW), ontology
     classifications (ChEBI, SNOMED CT, NCI Thesaurus), stereoisomer relationships, drug roles, and
     bioactivity measurements via SIO and OBO ontologies.
+  keywords:
+    - compound
+    - chemical
+    - molecule
+    - drug
+    - cid
+    - smiles
+    - inchi
+    - cas
+    - bioassay
+    - bioactivity
+    - pharmacology
+    - toxicology
+    - descriptor
+    - substance
+    - target
+  categories:
+    - compound
   endpoint: https://rdfportal.org/pubchem/sparql
   base_uri: http://rdf.ncbi.nlm.nih.gov/pubchem/
   graphs:

--- a/togo_mcp/data/mie/pubmed.yaml
+++ b/togo_mcp/data/mie/pubmed.yaml
@@ -4,6 +4,23 @@ schema_info:
     Biomedical literature database with 37+ million citations from MEDLINE, life science journals, and online books.
     Primary entity types: research articles, reviews, authors, journals. Rich MeSH term annotations enable precise
     topic-based queries using controlled vocabulary IRIs. Updated daily with new publications.
+  keywords:
+    - publication
+    - article
+    - citation
+    - abstract
+    - author
+    - journal
+    - mesh term
+    - pmid
+    - doi
+    - review
+    - biomedical literature
+    - research paper
+    - clinical trial
+    - full text
+  categories:
+    - literature
   endpoint: https://rdfportal.org/ncbi/sparql
   base_uri: http://rdf.ncbi.nlm.nih.gov/pubmed/
   graphs:

--- a/togo_mcp/data/mie/pubtator.yaml
+++ b/togo_mcp/data/mie/pubtator.yaml
@@ -6,6 +6,23 @@ schema_info:
     linked to PubMed articles using MeSH disease identifiers, NCBI Gene IDs, and dbSNP rsIDs.
     Each Disease/Gene annotation records mention frequency within articles; variant annotations
     come from ClinVar/dbSNP and use blank nodes without dcterms:subject.
+  keywords:
+    - annotation
+    - entity
+    - article
+    - gene
+    - disease
+    - chemical
+    - mutation
+    - species
+    - text mining
+    - named entity recognition
+    - bioconcept
+    - pmid
+    - pubmed
+    - curation
+  categories:
+    - literature
   endpoint: https://rdfportal.org/ncbi/sparql
   base_uri: http://purl.jp/bio/10/pubtator-central/
   graphs:

--- a/togo_mcp/data/mie/reactome.yaml
+++ b/togo_mcp/data/mie/reactome.yaml
@@ -5,6 +5,23 @@ schema_info:
     Contains 23K+ pathways, 94K+ biochemical reactions, 232K+ proteins, 109K complexes, and 51K
     small molecules across 30+ species. Hierarchical pathway organization with cross-references
     to UniProt, ChEBI, PubMed, GO (primarily via RelationshipXref), ChEMBL, and MOD ontology.
+  keywords:
+    - pathway
+    - biological pathway
+    - reaction
+    - signaling cascade
+    - protein
+    - gene
+    - complex
+    - catalyst
+    - disease pathway
+    - regulation
+    - go term
+    - biopax
+    - event
+    - species
+  categories:
+    - pathway
   endpoint: https://rdfportal.org/ebi/sparql
   base_uri: http://www.biopax.org/release/biopax-level3.owl#
   graphs:

--- a/togo_mcp/data/mie/rhea.yaml
+++ b/togo_mcp/data/mie/rhea.yaml
@@ -6,6 +6,24 @@ schema_info:
     (L→R, R→L) and bidirectional representations, covering 12,496 small molecules and 261
     polymers with ChEBI links. Primary reaction resource for UniProtKB enzyme annotation;
     transport reactions (1,522) include cellular location annotations.
+  keywords:
+    - biochemical reaction
+    - enzyme
+    - substrate
+    - product
+    - cofactor
+    - ec number
+    - stoichiometry
+    - mass balance
+    - chebi
+    - uniprot
+    - catalysis
+    - metabolite
+    - directional
+    - bidirectional
+    - transport
+  categories:
+    - reaction
   endpoint: https://rdfportal.org/sib/sparql
   base_uri: http://rdf.rhea-db.org/
   graphs:

--- a/togo_mcp/data/mie/supercon.yaml
+++ b/togo_mcp/data/mie/supercon.yaml
@@ -10,6 +10,22 @@ schema_info:
     coherence and penetration lengths, and sample preparation conditions. Primary use
     cases: materials informatics, ML model training for superconductor discovery,
     and comparative Tc studies across compound families.
+  keywords:
+    - superconductor
+    - superconducting material
+    - critical temperature
+    - tc
+    - nims
+    - chemical formula
+    - material science
+    - inorganic compound
+    - oxide
+    - cuprate
+    - experimental measurement
+    - physical property
+  categories:
+    - materials
+    - physics
   endpoint: https://rdfportal.org/nims/sparql
   base_uri: http://dice.nims.go.jp/ontology/SuperCon-ont/
   graphs:

--- a/togo_mcp/data/mie/taxonomy.yaml
+++ b/togo_mcp/data/mie/taxonomy.yaml
@@ -5,6 +5,24 @@ schema_info:
     from bacteria to mammals. Hierarchical structure via rdfs:subClassOf enables
     lineage traversal from species to kingdom. Rich metadata includes scientific
     names, common names, synonyms, and genetic code assignments.
+  keywords:
+    - taxonomy
+    - organism
+    - species
+    - taxon
+    - phylogeny
+    - lineage
+    - rank
+    - bacteria
+    - vertebrate
+    - plant
+    - insect
+    - fungus
+    - ncbi taxonomy
+    - scientific name
+    - classification
+  categories:
+    - taxonomy
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://identifiers.org/taxonomy/
   graphs:

--- a/togo_mcp/data/mie/uniprot.yaml
+++ b/togo_mcp/data/mie/uniprot.yaml
@@ -6,6 +6,24 @@ schema_info:
     Contains sequences, functions, domains, structures, variants, disease associations,
     and cross-references to 200+ databases. CRITICAL: Always filter by up:reviewed 1
     for quality queries — omitting it queries ~244M instead of 589K (99.8% overhead).
+  keywords:
+    - protein
+    - sequence
+    - swiss-prot
+    - trembl
+    - reviewed
+    - annotation
+    - function
+    - domain
+    - isoform
+    - enzyme
+    - variant
+    - disease association
+    - gene ontology
+    - pathway
+    - cross-reference
+  categories:
+    - protein
   endpoint: https://rdfportal.org/sib/sparql
   base_uri: http://purl.uniprot.org/
   graphs:

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -234,7 +234,7 @@ schema_info:
     - [keyword2]
   # 1-3 entries from the controlled taxonomy: protein, gene, variant, compound,
   # drug_target, pathway, reaction, ontology, structure, literature, taxonomy,
-  # microbe, glycan, antimicrobial, sequence, disease.
+  # microbe, glycan, antimicrobial, sequence, disease, materials, physics.
   # Tag only categories that genuinely characterize the database.
   categories:
     - [category1]

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -193,7 +193,7 @@ if "error" in result.lower():
 
 ### Required Sections (in order)
 
-1. **schema_info** — Endpoint, graphs, search tools, backend, versioning
+1. **schema_info** — Endpoint, graphs, search tools, backend, versioning, plus `keywords` (8–15 lowercase discovery terms incl. synonyms) and `categories` (1–3 from controlled taxonomy) for `find_databases()` discovery
 2. **critical_warnings** — Schema pathologies that cause silent failures (typos in IRIs, non-obvious namespace traps, critical performance filters). Use `[]` if none.
 3. **shape_expressions** — ShEx for ALL entity types with inline counts and caveats
 4. **sample_rdf_entries** — Exactly 3 diverse, illustrative examples (shared prefix block)
@@ -226,6 +226,18 @@ schema_info:
   title: [DATABASE_NAME]
   description: |
     [2–3 sentences: contents, entity types, primary use cases]
+  # 8-15 lowercase keywords for find_databases() discovery. Include synonyms a user
+  # might type instead of the canonical term (variant ↔ mutation ↔ polymorphism;
+  # drug ↔ compound ↔ chemical). Skip stopwords and incidental vocabulary.
+  keywords:
+    - [keyword1]
+    - [keyword2]
+  # 1-3 entries from the controlled taxonomy: protein, gene, variant, compound,
+  # drug_target, pathway, reaction, ontology, structure, literature, taxonomy,
+  # microbe, glycan, antimicrobial, sequence, disease.
+  # Tag only categories that genuinely characterize the database.
+  categories:
+    - [category1]
   endpoint: https://rdfportal.org/example/sparql
   base_uri: http://example.org/
   graphs:
@@ -552,7 +564,8 @@ common_errors:
 
 **Structure:**
 - ☐ Valid YAML (load with `get_MIE_file` and check for errors)
-- ☐ All 10 required sections present in order
+- ☐ All 11 required sections present in order
+- ☐ `schema_info` includes `keywords` (8–15) and `categories` (1–3 from taxonomy)
 - ☐ 3–4 anti-patterns (including "schema check before text search")
 - ☐ 2–3 common errors
 

--- a/togo_mcp/data/resources/togomcp_usage_guide_v3.md
+++ b/togo_mcp/data/resources/togomcp_usage_guide_v3.md
@@ -49,7 +49,7 @@ Answer four questions before any tool call:
 
 ```
 STEP -1: Analyze (no tools)
-STEP  0: list_databases()                  ← ALWAYS first tool call
+STEP  0: find_databases(keywords=[...])    ← ALWAYS first; falls back to list_databases() if too vague
 STEP  1: Specialized search OR ncbi_esearch
 STEP  2: get_MIE_file(database)            ← ALWAYS before run_sparql
 STEP  3: run_sparql() — LIMIT 10 first; max 2 consecutive
@@ -78,9 +78,15 @@ From 150 evaluated questions. Treat numbers as directional; the patterns are rob
 
 ---
 
-## 🔍 STEP 0: `list_databases()` — ALWAYS FIRST
+## 🔍 STEP 0: DATABASE DISCOVERY — ALWAYS FIRST
 
-Match query keywords to database descriptions: "MANE" → Ensembl, "drug targets" → ChEMBL, "clinical variants" → ClinVar, "pathways" → Reactome, "culture media" → BacDive/MediaDive, "glycobiology" → GlyCosmos (specialist; see Known-Hard Queries).
+Three tools, pick by intent:
+
+- **`find_databases(keywords=[...])`** — default. Token-efficient: returns only DBs whose title, description, or curated keywords match (case-insensitive substring). Use when you have specific search terms (gene, pathway, drug target, variant, superconductor, etc.). Synonyms work — each MIE's keywords field includes terms users type instead of canonical ("mutation" alongside "variant", "drug" alongside "compound"). Pass `match="all"` to require every keyword.
+- **`find_databases(category=...)`** — when you want everything in a topic area. Categories: `protein`, `gene`, `variant`, `compound`, `drug_target`, `pathway`, `reaction`, `ontology`, `structure`, `literature`, `taxonomy`, `microbe`, `glycan`, `antimicrobial`, `sequence`, `disease`, `materials`, `physics`. Call `list_categories()` first if unsure.
+- **`list_databases()`** — full catalog browse. Use only when the question is too vague to keyword-match. Higher token cost, scales linearly with corpus.
+
+Quick keyword hints: "MANE" → Ensembl, "drug targets" → ChEMBL, "clinical variants" → ClinVar, "pathways" → Reactome, "culture media" → BacDive/MediaDive, "superconductor" → SuperCon, "glycobiology" → GlyCosmos (specialist; see Known-Hard Queries).
 
 ---
 
@@ -130,18 +136,18 @@ Skip TogoID when: both DBs share an endpoint, or `ncbi_esearch` already cross-re
 ## 📋 WORKFLOWS
 
 ### VERIFICATION ("Does X exist?") — 5–8 tools, 1–2 SPARQL
-`-1` analyze → `0` list_databases → `1` search/esearch (often answers it) → `2` MIE if needed → `3` run_sparql LIMIT 10 if needed → `4` answer.
+`-1` analyze → `0` find_databases → `1` search/esearch (often answers it) → `2` MIE if needed → `3` run_sparql LIMIT 10 if needed → `4` answer.
 
 ### ENUMERATION ("How many?", "List all") — 8–12 tools, 2–3 SPARQL
-**Single DB:** `-1` analyze → `0` list_databases → `1` search → `2` MIE → `3` exploratory SPARQL (LIMIT 10) → `4` comprehensive COUNT/list → answer.
+**Single DB:** `-1` analyze → `0` find_databases → `1` search → `2` MIE → `3` exploratory SPARQL (LIMIT 10) → `4` comprehensive COUNT/list → answer.
 **Cross DB:** + `togoid_getAllRelation()` early → `togoid_convertId` → MIE for target → SPARQL on target.
 
 ### COMPARATIVE ("Which has most?") — 10–15 tools, 3–4 SPARQL
 **Critical:** enumerate ALL categories, count EACH, `ORDER BY DESC(?count)`. Don't search one category and declare it the winner.
-`-1` identify all categories → `0` list_databases → `1` search/esearch confirms data exists → `2` MIE → `3` single SPARQL with `GROUP BY` across all categories → verify counts make sense → answer. **Prefer one broad GROUP BY over many narrow queries.**
+`-1` identify all categories → `0` find_databases → `1` search/esearch confirms data exists → `2` MIE → `3` single SPARQL with `GROUP BY` across all categories → verify counts make sense → answer. **Prefer one broad GROUP BY over many narrow queries.**
 
 ### SYNTHESIS ("Summarize", "Describe") — 8–15 tools, 2–3 SPARQL
-`-1` analyze → `0` list_databases → `1` entity searches → `2` MIE (1–2 DBs) → `3` SPARQL (2–3 calls) → `4` togoid_convertId if cross-DB → `5` ncbi_esummary/PubMed for detail → `6` concise paragraph.
+`-1` analyze → `0` find_databases → `1` entity searches → `2` MIE (1–2 DBs) → `3` SPARQL (2–3 calls) → `4` togoid_convertId if cross-DB → `5` ncbi_esummary/PubMed for detail → `6` concise paragraph.
 > **Repetition warning:** synthesis answers degrade most on repetition (3.78 → 3.46/5 across runs). Each fact once.
 
 ### EXPLORATION ("Tell me more", "深掘りして") — open-ended deep dives

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 import yaml
@@ -201,73 +201,35 @@ async def get_MIE_file(
     return f"Content-type: application/yaml; charset=utf-8\n{content}"
 
 
-# Module-level cache for list_databases results
-_cached_databases: list[dict[str, Any]] | None = None
+# Module-level cache for database records loaded from MIE schema_info sections.
+# Each record: {database, title, description, keywords, categories}.
+_databases_cache: list[dict[str, Any]] | None = None
 
 
-@mcp.tool(name="list_databases")
-def list_databases() -> list[dict[str, Any]]:
-    """
-    CRITICAL FIRST STEP: Database Discovery & Selection
-
-    **ALWAYS CALL THIS FIRST when you need to:**
-    - Determine which database(s) contain relevant data for a query
-    - Discover available databases before starting research
-    - Verify database capabilities and coverage
-    - Identify cross-database integration opportunities
-
-    **What it returns:**
-    A list of all 22 RDF databases with:
-    - Database name (for use in other tool calls)
-    - Title (human-readable name)
-    - Description (detailed content, entities, cross-references, use cases)
-
-    **Why this matters:**
-    Database descriptions contain CRITICAL KEYWORDS that reveal content:
-    - "MANE" appears in Ensembl description -> transcript quality flags
-    - "drug targets" appears in ChEMBL -> pharmaceutical research
-    - "clinical variants" appears in ClinVar -> disease associations
-    - "pathways" appears in Reactome -> biological processes
-
-    **Workflow:**
-    1. Call list_databases() BEFORE calling get_MIE_file() or run_sparql()
-    2. Read descriptions to identify 1-3 relevant databases
-    3. Proceed with get_MIE_file() on identified databases
-    4. Query comprehensively with discovered structured properties
-
-    **Common mistake to avoid:**
-    Do not assume a database based on name alone (e.g., "gene query -> only NCBI Gene").
-    Discover databases by reading descriptions (e.g., "gene query -> both NCBI Gene AND
-    Ensembl have complementary data").
-
-    **Example pattern:**
-    Query: "MANE Select transcripts for drug targets"
-    -> Call list_databases()
-    -> See "MANE" in Ensembl description
-    -> See "drug targets" in ChEMBL description
-    -> Query both databases on shared 'ebi' endpoint
-
-    **This is reconnaissance, not optional.**
-    Skipping this step = guessing which database to use = missing 50-80% of relevant data.
-
-    Returns:
-        A list of dictionaries, each containing schema info for a file.
-    """
-    toolcall_log("list_databases")
-
-    global _cached_databases
-    if _cached_databases is not None:
-        return _cached_databases
+def _load_databases_cache() -> list[dict[str, Any]]:
+    """Load and cache schema_info from every MIE file. Returns full records including
+    optional `keywords` and `categories` fields when present."""
+    global _databases_cache
+    if _databases_cache is not None:
+        return _databases_cache
 
     resources_dir = Path(MIE_DIR)
     if not resources_dir.is_dir():
         print(f"Error: Directory '{resources_dir}' not found.", file=sys.stderr)
-        return []
+        _databases_cache = []
+        return _databases_cache
 
-    all_schemas_info = []
+    records: list[dict[str, Any]] = []
     for db_name in sorted(SPARQL_ENDPOINT.keys()):
         filename = db_name + ".yaml"
         file_path = resources_dir.joinpath(filename)
+        record: dict[str, Any] = {
+            "database": db_name,
+            "title": "No title found.",
+            "description": "No description found.",
+            "keywords": [],
+            "categories": [],
+        }
         try:
             with open(file_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
@@ -280,41 +242,191 @@ def list_databases() -> list[dict[str, Any]]:
                     "'schema_info' section not found or not a dictionary."
                 )
 
-            title = schema_info.get("title")
-            description = schema_info.get("description")
-
-            all_schemas_info.append(
-                {
-                    "database": db_name,
-                    "title": title or "No title found.",
-                    "description": description or "No description found.",
-                }
-            )
-
+            record["title"] = schema_info.get("title") or "No title found."
+            record["description"] = schema_info.get("description") or "No description found."
+            kws = schema_info.get("keywords") or []
+            cats = schema_info.get("categories") or []
+            if isinstance(kws, list):
+                record["keywords"] = [str(k).lower() for k in kws if str(k).strip()]
+            if isinstance(cats, list):
+                record["categories"] = [str(c).lower() for c in cats if str(c).strip()]
         except yaml.YAMLError as e:
-            all_schemas_info.append(
-                {
-                    "database": db_name,
-                    "title": "No title found.",
-                    "description": f"Error processing YAML file: {e}",
-                }
-            )
+            record["description"] = f"Error processing YAML file: {e}"
         except FileNotFoundError:
-            all_schemas_info.append(
-                {
-                    "database": db_name,
-                    "title": "No title found.",
-                    "description": f"MIE file not found: {filename}",
-                }
-            )
+            record["description"] = f"MIE file not found: {filename}"
         except OSError as e:
-            all_schemas_info.append(
-                {
-                    "database": db_name,
-                    "title": "No title found.",
-                    "description": f"Error reading {filename}: {e.strerror or 'unknown error'}",
-                }
-            )
+            record["description"] = f"Error reading {filename}: {e.strerror or 'unknown error'}"
 
-    _cached_databases = all_schemas_info
-    return _cached_databases
+        records.append(record)
+
+    _databases_cache = records
+    return _databases_cache
+
+
+@mcp.tool(name="list_databases")
+def list_databases() -> list[dict[str, Any]]:
+    """
+    Database Discovery & Selection — full catalog browse.
+
+    Returns every available RDF database with `{database, title, description}`. Use this
+    when you want to see the entire catalog. For token-efficient lookup when you already
+    have search terms in mind, prefer `find_databases(keywords=...)`.
+
+    Common keywords-in-descriptions to watch for: "MANE" (Ensembl), "drug targets" (ChEMBL),
+    "clinical variants" (ClinVar), "pathways" (Reactome).
+
+    Workflow:
+    1. (Optional) call list_databases() or find_databases() to identify 1–3 relevant DBs.
+    2. get_MIE_file(database) for each.
+    3. run_sparql() with discovered structured properties.
+
+    Returns:
+        A list of dicts with keys `database`, `title`, `description`.
+    """
+    toolcall_log("list_databases")
+    return [
+        {"database": r["database"], "title": r["title"], "description": r["description"]}
+        for r in _load_databases_cache()
+    ]
+
+
+def _normalize_terms(value: str | list[str] | None) -> list[str]:
+    """Lowercase, strip, drop empties. Accepts str | list[str] | None."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        v = value.strip().lower()
+        return [v] if v else []
+    return [s.strip().lower() for s in value if isinstance(s, str) and s.strip()]
+
+
+def _make_snippet(text: str, keyword: str, context: int = 80) -> str:
+    """Return ~context chars surrounding the first occurrence of keyword (case-insensitive).
+    Falls back to the leading slice when no match is found."""
+    if not text:
+        return ""
+    if not keyword:
+        return text[: context * 2].strip().replace("\n", " ") + ("..." if len(text) > context * 2 else "")
+    idx = text.lower().find(keyword.lower())
+    if idx < 0:
+        return _make_snippet(text, "", context)
+    start = max(0, idx - context // 2)
+    end = min(len(text), idx + len(keyword) + context // 2)
+    snippet = text[start:end].strip().replace("\n", " ")
+    return f"{'...' if start > 0 else ''}{snippet}{'...' if end < len(text) else ''}"
+
+
+@mcp.tool(name="find_databases")
+def find_databases(
+    keywords: Annotated[
+        str | list[str] | None,
+        Field(
+            description=(
+                "Keyword or list of keywords (case-insensitive substring match against "
+                "title, description, and the database's curated keywords field)."
+            )
+        ),
+    ] = None,
+    category: Annotated[
+        str | list[str] | None,
+        Field(
+            description=(
+                "Category filter (substring, case-insensitive). Call list_categories() "
+                "to see the available set."
+            )
+        ),
+    ] = None,
+    match: Annotated[
+        Literal["any", "all"],
+        Field(
+            description=(
+                "'any' returns DBs matching at least one keyword (OR); 'all' requires "
+                "every keyword to match (AND)."
+            )
+        ),
+    ] = "any",
+    verbose: Annotated[
+        bool,
+        Field(
+            description=(
+                "If True, return the full description; if False (default), return a "
+                "short snippet around the first match."
+            )
+        ),
+    ] = False,
+) -> list[dict[str, Any]]:
+    """
+    Token-efficient database discovery — alternative to list_databases().
+
+    Filters the RDF database catalog by keywords and/or category, returning only matching
+    entries. Use this when you already have specific search terms (gene, pathway, drug
+    target, variant, etc.) and want a focused candidate list before calling get_MIE_file().
+
+    Use list_databases() instead when you want to browse the full catalog.
+
+    Returns:
+        List of dicts: `{database, title, matched_keywords, categories, snippet}` (or
+        `description` when `verbose=True`). Sorted by number of matched keywords
+        descending, then alphabetically by database name.
+    """
+    toolcall_log("find_databases")
+    kw_list = _normalize_terms(keywords)
+    cat_list = _normalize_terms(category)
+
+    if not kw_list and not cat_list:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for r in _load_databases_cache():
+        if cat_list:
+            db_cats = " ".join(r["categories"])
+            if not any(c in db_cats for c in cat_list):
+                continue
+
+        haystack = " ".join([
+            r["title"].lower(),
+            r["description"].lower(),
+            " ".join(r["keywords"]),
+        ])
+        matched = [k for k in kw_list if k in haystack]
+
+        if kw_list:
+            if match == "all" and len(matched) < len(kw_list):
+                continue
+            if match == "any" and not matched:
+                continue
+
+        anchor = matched[0] if matched else (cat_list[0] if cat_list else "")
+        body_key = "description" if verbose else "snippet"
+        body_val = r["description"] if verbose else _make_snippet(r["description"], anchor)
+
+        results.append({
+            "database": r["database"],
+            "title": r["title"],
+            "matched_keywords": matched,
+            "categories": r["categories"],
+            body_key: body_val,
+        })
+
+    results.sort(key=lambda x: (-len(x["matched_keywords"]), x["database"]))
+    return results
+
+
+@mcp.tool(name="list_categories")
+def list_categories() -> dict[str, list[str]]:
+    """
+    Coarse-grained index of database categories with member database names.
+
+    Use this when you don't yet have specific keywords — drill down with
+    `find_databases(category=...)` once you've identified relevant categories.
+
+    Returns:
+        Dict mapping category name -> sorted list of database names. Returns an empty
+        dict if no databases have been annotated with categories yet.
+    """
+    toolcall_log("list_categories")
+    cats: dict[str, list[str]] = {}
+    for r in _load_databases_cache():
+        for c in r["categories"]:
+            cats.setdefault(c, []).append(r["database"])
+    return {k: sorted(v) for k, v in sorted(cats.items())}


### PR DESCRIPTION
## Summary

Replaces unconditional `list_databases()` (~5–10k tokens, scaling worse as the corpus grows toward 70 databases) with a token-efficient discovery path keyed off curated metadata.

- New **`find_databases(keywords, category, match, verbose)`** tool — substring-matches each MIE's title, description, and curated keywords field; returns only matched entries with snippets, sorted by match count.
- New **`list_categories()`** tool — returns the controlled-vocabulary index `{category: [db_names]}` as a coarse navigable map.
- Adds required **`keywords`** (8–15 lowercase, including synonyms users type instead of canonical terms) and **`categories`** (1–3 from a controlled 18-entry taxonomy) fields to MIE `schema_info`. All 24 existing MIE files annotated.
- Extends taxonomy with `materials` and `physics` for SuperCon (NIMS superconductor database) — `compound` was misleading since SuperCon's compounds are inorganic/metallic materials, not drug-target small molecules.
- `list_databases()` retained as the vague-question fallback; the v3 Usage Guide now points clients at `find_databases` as the default and lists all 18 categories inline.
- Bootstrap script (`scripts/bootstrap_mie_keywords.py`) emits keyword/category suggestions per MIE for human review when adding new databases.

## Files

- **Code:** `togo_mcp/rdf_portal.py` (refactor cache, add 2 tools), `scripts/bootstrap_mie_keywords.py` (new)
- **Spec:** `togo_mcp/data/docs/MIE_file_specs.md` (§3.1.2 / §3.1.4 / new §3.1.5 with controlled taxonomy table)
- **Prompt:** `togo_mcp/data/resources/MIE_prompt.md` (template + checklist)
- **Skill:** `.claude/skills/mie-generator/{template.yaml, references/mie-structure.md}`
- **Guide:** `togo_mcp/data/resources/togomcp_usage_guide_v3.md` (STEP 0 + workflow checklists)
- **Data:** all 24 `togo_mcp/data/mie/*.yaml` annotated

## Test plan

- [ ] `find_databases(keywords="superconductor")` returns `supercon`.
- [ ] `find_databases(category="materials")` returns `supercon`.
- [ ] `find_databases(keywords=["drug", "target"], match="all")` returns the expected DBs.
- [ ] `list_categories()` returns the full annotated map (no empty buckets).
- [ ] `list_databases()` still loads the catalog with the original 3-field shape.
- [ ] `TogoMCP_Usage_Guide()` returns the updated v3 guide with the new STEP 0 section.
