### PR TITLE
Onboard Bgee/BRENDA/HGNC; SuperCon ontology integration; +2 categories

### DIFF
--- a/scripts/bootstrap_mie_keywords.py
+++ b/scripts/bootstrap_mie_keywords.py
@@ -45,6 +45,8 @@ CATEGORY_RULES: dict[str, list[str]] = {
     "disease": ["disease", "phenotype", "clinical"],
     "materials": ["materials science", "crystal structure", "lattice parameter", "alloy", "oxide", "superconductor", "supercon"],
     "physics": ["superconductor", "supercon", "critical temperature", " tc ", "magnetic field", "conductivity", "physical property"],
+    "enzymology": ["enzyme", "ec number", "kinetic", "brenda", "kcat", "km value", "turnover", "substrate"],
+    "genomics": ["genome", "genomic", "hgnc", "gene nomenclature", "official symbol", "ensembl"],
 }
 
 STOPWORDS = {

--- a/togo_mcp/data/docs/MIE_file_specs.md
+++ b/togo_mcp/data/docs/MIE_file_specs.md
@@ -149,6 +149,8 @@ Both fields drive the `find_databases()` discovery tool — a token-efficient al
 | `disease` | Disease, phenotype, clinical associations |
 | `materials` | Materials science — crystal structure, lattice parameters, alloys, oxides, polymers |
 | `physics` | Physical properties and measurements — Tc, magnetic fields, conductivity, thermal coefficients |
+| `enzymology` | Enzyme function, kinetics, EC numbers, substrates / inhibitors / activators |
+| `genomics` | Genome-scale resources, gene nomenclature, cross-genome catalogs |
 
 When adding a new category, update both this taxonomy and the `find_databases` tool documentation.
 

--- a/togo_mcp/data/mie/bgee.yaml
+++ b/togo_mcp/data/mie/bgee.yaml
@@ -1,0 +1,653 @@
+schema_info:
+  title: Bgee
+  description: |
+    Bgee is a curated database of gene expression patterns across animal species,
+    integrating RNA-Seq, Affymetrix, EST, and in situ hybridization data into uniform
+    expression "calls" (present / absent) tagged with anatomy (UBERON / CL / WBbt
+    etc.), developmental stage, sex, and strain. Core entity types: Gene (orth:Gene
+    via OMA gene IRIs), Expression / AbsenceExpression (gene-condition calls),
+    ExpressionCondition (anatomy + dev stage + sex + strain bundles), AnatomicalEntity,
+    DevelopmentalStage, Taxon. Primary use cases: cross-species expression comparison,
+    finding tissues where a gene is/isn't expressed, anatomy-restricted gene sets.
+  keywords:
+    - gene expression
+    - bgee
+    - anatomical entity
+    - tissue
+    - developmental stage
+    - rna-seq
+    - in situ hybridization
+    - cross-species
+    - uberon
+    - genex
+    - homology
+    - tpm
+    - expression call
+  categories:
+    - gene
+    - taxonomy
+  endpoint: https://rdfportal.org/sib/sparql
+  base_uri: http://bgee.org/#
+  graphs:
+    - http://bgee.org
+  kw_search_tools: []
+  version:
+    mie_version: "2.0"
+    mie_created: "2026-04-28"
+    data_version: "Bgee 15.2"
+    update_frequency: "Annual"
+  access:
+    backend: "Virtuoso (supports bif:contains)"
+
+# Critical traps documented from live discovery on 2026-04-28. Each item below
+# causes silent failures (zero rows, wrong counts, or timeouts).
+critical_warnings: |
+  - DUAL TAXON IRI NAMESPACES: Bgee uses two parallel taxonomy IRI schemes for the
+    same NCBI taxon ID. orth:Gene → orth:organism points to <https://bgee.org/species/NNN>
+    (typed orth:Organism). genex:ExpressionCondition → obo:RO_0002162 points to
+    <http://purl.uniprot.org/taxonomy/NNN> (typed up:Taxon). Bridge:
+    <https://bgee.org/species/NNN> obo:RO_0002162 <http://purl.uniprot.org/taxonomy/NNN>.
+    Picking the wrong namespace silently returns 0 rows.
+  - GENE IRI USES OMA NAMESPACE: Genes are minted as
+    <http://omabrowser.org/ontology/oma#GENE_<EXTERNAL_ID>> where EXTERNAL_ID is the
+    upstream species-specific accession (Ensembl ENSG.../ENSDARG..., WBGene..., FB...,
+    MGI:..., etc.), NOT a UniProt or NCBI Gene ID. To find a gene from UniProt,
+    bridge through lscr:xrefUniprot. From Ensembl, use lscr:xrefEnsemblGene or
+    construct the IRI directly.
+  - genex:isExpressedIn IS DENORMALIZED AND POLYMORPHIC: Values include BOTH
+    anatomy IRIs (UBERON_*, CL_*, WBbt_*, GO_0005575) AND ExpressionCondition IRIs
+    (<http://bgee.org/#EXPRESSION_CONDITION_*>). Filter the object explicitly if you
+    only want one kind. For "where is this gene expressed", joining via Expression →
+    hasExpressionCondition → hasAnatomicalEntity is more controlled.
+  - EXPRESSION TABLE IS HUGE: genex:Expression has 709M instances; genex:AbsenceExpression
+    adds 4.6M. Never run an unfiltered COUNT or LIMIT-less query against it.
+    Always filter by gene, anatomy, or species first; add LIMIT during exploration.
+  - GENES HAVE MULTIPLE rdf:type ENTRIES: orth:Gene, orth:GeneTreeNode,
+    orth:SequenceUnit, obo:SO_0000704, obo:CDAO_0000140, obo:BFO_0000001/2.
+    Filter on orth:Gene as the canonical class.
+  - ABSENCE CALLS ARE A SEPARATE CLASS: Genes that are NOT expressed in a condition
+    are typed genex:AbsenceExpression, not genex:Expression. To get "all calls",
+    union both classes; to get "expressed", filter to genex:Expression only.
+  - NO DEDICATED SEARCH API: kw_search_tools is empty. Find anchor IRIs via SPARQL
+    (rdfs:label match on a gene symbol restricted to a species) before doing
+    comprehensive queries.
+  - CONFIDENCE LEVEL IS A CIO IRI, NOT A NUMBER: genex:hasConfidenceLevel takes
+    obo:CIO_0000029 (high confidence; 617M calls) or obo:CIO_0000030 (medium
+    confidence; 97M calls). Filter by IRI, not by string.
+
+shape_expressions: |
+  PREFIX genex: <http://purl.org/genex#>
+  PREFIX orth: <http://purl.org/net/orth#>
+  PREFIX lscr: <http://purl.org/lscr#>
+  PREFIX dcterms: <http://purl.org/dc/terms/>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX obo: <http://purl.obolibrary.org/obo/>
+  PREFIX up: <http://purl.uniprot.org/core/>
+  PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
+  PREFIX bgee: <http://bgee.org/#>
+  PREFIX bgeespecies: <https://bgee.org/species/>
+  PREFIX oma: <http://omabrowser.org/ontology/oma#>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+  # ~709M expressed-call instances + 4.6M absence calls.
+  # ALWAYS filter by gene, condition, or species before counting.
+  <ExpressionShape> {
+    a [ genex:Expression genex:AbsenceExpression ] ;       # AbsenceExpression = gene NOT expressed
+    genex:hasSequenceUnit @<GeneShape> ;                   # → oma:GENE_<ID>
+    genex:hasExpressionCondition @<ExpressionConditionShape> ;
+    genex:hasConfidenceLevel [ obo:CIO_0000029 obo:CIO_0000030 ] ;  # high | medium
+    genex:hasFDRpvalue xsd:float ;
+    genex:hasExpressionLevel xsd:float                     # rank score (lower = higher confidence)
+  }
+
+  # ~1.56M genes across 52 species.
+  # rdfs:label = gene symbol (e.g. "TP53"); dcterms:identifier = species-native ID.
+  <GeneShape> {
+    a [ orth:Gene ] ;                                       # also typed orth:GeneTreeNode, orth:SequenceUnit
+    rdfs:label xsd:string ;                                 # gene symbol
+    dcterms:identifier xsd:string ;                         # native ID (Ensembl, WBGene, MGI, FB, …)
+    dcterms:description xsd:string ? ;                      # incl. UniProt cross-ref note
+    orth:organism @<OrganismShape> ;                        # → bgeespecies:NNN (NOT UniProt taxonomy)
+    lscr:xrefUniprot IRI * ;                                # → up:<accession> AND up:<MNEMONIC>
+    lscr:xrefEnsemblGene IRI * ;                            # → http://rdf.ebi.ac.uk/resource/ensembl/<id>
+    lscr:xrefNCBIGene IRI * ;                               # → https://www.ncbi.nlm.nih.gov/gene/<id> (sparse)
+    genex:isExpressedIn IRI *                               # DENORMALIZED: anatomy IRIs AND condition IRIs
+  }
+
+  # ~123K distinct condition bundles (anatomy × stage × sex × strain × species).
+  <ExpressionConditionShape> {
+    a [ genex:ExpressionCondition ] ;
+    genex:hasAnatomicalEntity @<AnatomicalEntityShape> + ;  # UBERON / CL / WBbt / GO_0005575
+    genex:hasDevelopmentalStage @<DevelopmentalStageShape> ;
+    genex:hasSex xsd:string ;                               # "any" | "male" | "female" | "hermaphrodite"
+    genex:hasStrain @<StrainShape> ? ;
+    obo:RO_0002162 @<TaxonShape>                            # in taxon → taxonomy:NNN (UniProt namespace)
+  }
+
+  # ~40K anatomical entities — UBERON, CL, WBbt, GO_0005575 (cellular_component fallback).
+  <AnatomicalEntityShape> {
+    a [ genex:AnatomicalEntity ] ;
+    rdfs:label xsd:string ;
+    dcterms:description xsd:string ?
+  }
+
+  # ~1.2K developmental stages — typed efo:EFO_0000399.
+  <DevelopmentalStageShape> {
+    a [ <http://www.ebi.ac.uk/efo/EFO_0000399> ] ;
+    rdfs:label xsd:string ;
+    dcterms:description xsd:string ?
+  }
+
+  # Strain instances (~38K typed obo:OBI_0000181); EFO_0005135 is the population class itself (1 instance).
+  <StrainShape> {
+    a [ obo:OBI_0000181 ] ;                                 # also <http://www.ebi.ac.uk/efo/EFO_0005135>
+    rdfs:label xsd:string                                   # often "wild-type"
+  }
+
+  # 52 species; UniProt-namespaced taxon entities.
+  <TaxonShape> {
+    a [ up:Taxon ] ;
+    dcterms:identifier xsd:integer ;                        # NCBI taxon ID, e.g. 9606
+    up:scientificName xsd:string ;                          # "Homo sapiens"
+    up:commonName xsd:string ? ;                            # "human"
+    up:rank IRI                                              # → up:Species, up:Genus, …
+  }
+
+  # 52 organism instances; bgee species namespace; bridge to UniProt taxonomy.
+  <OrganismShape> {
+    a [ orth:Organism ] ;                                   # also obo:NCIT_C14250
+    obo:RO_0002162 @<TaxonShape>                            # bgeespecies:NNN obo:RO_0002162 taxonomy:NNN
+  }
+
+# Three diverse, validated entries. Shared prefix block; do not repeat @prefix per entry.
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix genex: <http://purl.org/genex#> .
+    @prefix orth: <http://purl.org/net/orth#> .
+    @prefix lscr: <http://purl.org/lscr#> .
+    @prefix dcterms: <http://purl.org/dc/terms/> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix obo: <http://purl.obolibrary.org/obo/> .
+    @prefix up: <http://purl.uniprot.org/core/> .
+    @prefix taxonomy: <http://purl.uniprot.org/taxonomy/> .
+    @prefix bgee: <http://bgee.org/#> .
+    @prefix bgeespecies: <https://bgee.org/species/> .
+    @prefix oma: <http://omabrowser.org/ontology/oma#> .
+  entries:
+    - title: "Gene: human TP53 (orth:Gene with multi-namespace cross-refs)"
+      description: |
+        Illustrates the OMA gene-IRI minting (uses Ensembl ID), the gene-symbol-as-label
+        convention, and the multi-valued lscr:xrefUniprot pattern (canonical accession
+        AND MNEMONIC_ORGCODE form coexist). orth:organism uses the Bgee-species namespace,
+        not UniProt taxonomy.
+      rdf: |
+        oma:GENE_ENSG00000141510 a orth:Gene ;
+            rdfs:label "TP53" ;
+            dcterms:identifier "ENSG00000141510" ;
+            dcterms:description "tumor protein p53 [Source:HGNC Symbol;Acc:HGNC:11998]" ;
+            orth:organism bgeespecies:9606 ;
+            lscr:xrefUniprot <http://purl.uniprot.org/uniprot/A0A087WT22> ,
+                             <http://purl.uniprot.org/uniprot/A0A087WT22_HUMAN> .
+
+    - title: "ExpressionCondition: C. elegans wild-type fully-formed-stage condition"
+      description: |
+        Illustrates the four-axis condition (anatomy + dev stage + sex + strain) and the
+        in-taxon link via obo:RO_0002162 to a UniProt-namespace taxon IRI. Multiple
+        hasAnatomicalEntity values are common (specific tissue + cellular component fallback).
+      rdf: |
+        bgee:EXPRESSION_CONDITION_91484 a genex:ExpressionCondition ;
+            genex:hasSex "any" ;
+            obo:RO_0002162 taxonomy:6239 ;
+            genex:hasStrain bgee:STRAIN_3d4eba69908860b0d838be983fd7f9c8 ;
+            genex:hasAnatomicalEntity obo:CL_0000000 , obo:GO_0005575 ;
+            genex:hasDevelopmentalStage obo:UBERON_0000066 .
+
+    - title: "Expression call: WBGene00006961 (xnp-1) in C. elegans"
+      description: |
+        Shows a complete expression call with all six predicates including the CIO
+        confidence IRI (CIO_0000029 = high confidence) and the rank-score expression
+        level. Links a gene to an ExpressionCondition with an FDR p-value.
+      rdf: |
+        bgee:EXPRESSION_533853243 a genex:Expression ;
+            genex:hasSequenceUnit oma:GENE_WBGene00006961 ;
+            genex:hasExpressionCondition bgee:EXPRESSION_CONDITION_91484 ;
+            genex:hasConfidenceLevel obo:CIO_0000029 ;
+            genex:hasFDRpvalue 0.00278813 ;
+            genex:hasExpressionLevel 76.8077 .
+
+# Exactly 7 queries: 2 basic / 3 intermediate / 2 advanced.
+# All tested against https://rdfportal.org/sib/sparql on 2026-04-28.
+sparql_query_examples:
+  - title: "Find a gene by symbol and species"
+    description: |
+      Anchor lookup. Resolves a gene symbol to an OMA gene IRI for use in subsequent
+      expression queries. Always restrict by species; gene symbols are not unique
+      across species.
+    question: "What is the Bgee gene IRI for human TP53?"
+    complexity: basic
+    sparql: |
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?gene ?ensembl_id WHERE {
+        GRAPH <http://bgee.org> {
+          ?gene a orth:Gene ;
+                rdfs:label "TP53" ;
+                orth:organism <https://bgee.org/species/9606> ;
+                <http://purl.org/dc/terms/identifier> ?ensembl_id .
+        }
+      }
+      LIMIT 5
+
+  - title: "Get one expression call with all attributes"
+    description: |
+      Inspects an Expression entity end-to-end. Useful as a template for the call shape.
+    question: "Show one expression call with its gene, condition, confidence, and level."
+    complexity: basic
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+
+      SELECT ?call ?gene ?condition ?confidence ?fdr ?level WHERE {
+        GRAPH <http://bgee.org> {
+          ?call a genex:Expression ;
+                genex:hasSequenceUnit ?gene ;
+                genex:hasExpressionCondition ?condition ;
+                genex:hasConfidenceLevel ?confidence ;
+                genex:hasFDRpvalue ?fdr ;
+                genex:hasExpressionLevel ?level .
+        }
+      }
+      LIMIT 1
+
+  - title: "Anatomical entities where a UniProt protein's gene is expressed"
+    description: |
+      Bridges from a UniProt accession into Bgee via lscr:xrefUniprot, then walks
+      Expression → ExpressionCondition → hasAnatomicalEntity. Uses structured IRIs
+      throughout — no text search.
+    question: "In which anatomical entities is human TP53 (UniProt P04637) expressed?"
+    complexity: intermediate
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX lscr: <http://purl.org/lscr#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?anatomy ?label WHERE {
+        GRAPH <http://bgee.org> {
+          ?gene a orth:Gene ;
+                lscr:xrefUniprot <http://purl.uniprot.org/uniprot/P04637> .
+          ?call a genex:Expression ;
+                genex:hasSequenceUnit ?gene ;
+                genex:hasExpressionCondition ?cond .
+          ?cond genex:hasAnatomicalEntity ?anatomy .
+          ?anatomy rdfs:label ?label .
+        }
+      }
+      LIMIT 20
+
+  - title: "Count distinct genes expressed in a specific anatomy across species"
+    description: |
+      Uses GROUP BY on the species axis. Demonstrates the bgeespecies:NNN ↔ taxonomy:NNN
+      bridge via obo:RO_0002162 — needed because Gene→organism uses the Bgee namespace
+      while we want the human-readable scientificName from the UniProt-namespace taxon.
+    question: "How many distinct genes are reported as expressed in 'brain' (UBERON_0000955) per species?"
+    complexity: intermediate
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?species_name (COUNT(DISTINCT ?gene) AS ?n_genes) WHERE {
+        GRAPH <http://bgee.org> {
+          ?call a genex:Expression ;
+                genex:hasSequenceUnit ?gene ;
+                genex:hasExpressionCondition ?cond .
+          ?cond genex:hasAnatomicalEntity obo:UBERON_0000955 ;
+                obo:RO_0002162 ?taxon .
+          ?taxon up:scientificName ?species_name .
+          ?gene a orth:Gene .
+        }
+      }
+      GROUP BY ?species_name
+      ORDER BY DESC(?n_genes)
+      LIMIT 20
+
+  - title: "List high-confidence expression sites for a gene"
+    description: |
+      Combines confidence filter (CIO_0000029) with anatomy/dev-stage projection.
+      Demonstrates filtering by IRI on hasConfidenceLevel and joining the condition
+      bundle to anatomy and stage labels in one shot.
+    question: "Where (anatomy + dev stage) is mouse Sox2 expressed at high confidence?"
+    complexity: intermediate
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT DISTINCT ?anatomy_label ?stage_label WHERE {
+        GRAPH <http://bgee.org> {
+          ?gene a orth:Gene ;
+                rdfs:label "Sox2" ;
+                orth:organism <https://bgee.org/species/10090> .
+          ?call a genex:Expression ;
+                genex:hasSequenceUnit ?gene ;
+                genex:hasConfidenceLevel obo:CIO_0000029 ;
+                genex:hasExpressionCondition ?cond .
+          ?cond genex:hasAnatomicalEntity ?anatomy ;
+                genex:hasDevelopmentalStage ?stage .
+          ?anatomy rdfs:label ?anatomy_label .
+          ?stage rdfs:label ?stage_label .
+        }
+      }
+      LIMIT 50
+
+  - title: "Top anatomies by call count for a specific gene"
+    description: |
+      Comparative aggregation anchored to a single gene. Demonstrates the canonical
+      pattern (GROUP BY + ORDER BY DESC + confidence-IRI filter + GO_0005575 exclusion
+      to drop the cellular_component fallback). Anchoring to a gene first keeps the
+      working set tractable; an unanchored "all human anatomies" variant times out on
+      the public endpoint.
+    question: "Which 10 human anatomies have the most high-confidence expression calls for TP53?"
+    complexity: advanced
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?anatomy_label (COUNT(*) AS ?n_calls) WHERE {
+        GRAPH <http://bgee.org> {
+          ?gene a orth:Gene ;
+                rdfs:label "TP53" ;
+                orth:organism <https://bgee.org/species/9606> .
+          ?call a genex:Expression ;
+                genex:hasSequenceUnit ?gene ;
+                genex:hasConfidenceLevel obo:CIO_0000029 ;
+                genex:hasExpressionCondition ?cond .
+          ?cond genex:hasAnatomicalEntity ?anatomy .
+          ?anatomy rdfs:label ?anatomy_label .
+          FILTER(?anatomy != obo:GO_0005575)
+        }
+      }
+      GROUP BY ?anatomy_label
+      ORDER BY DESC(?n_calls)
+      LIMIT 10
+
+  - title: "Cross-graph: Bgee genes ↔ UniProt reviewed proteins (same SIB endpoint)"
+    description: |
+      The SIB endpoint hosts both Bgee and UniProt. lscr:xrefUniprot crosses the graph
+      boundary to UniProt's <http://sparql.uniprot.org/uniprot> graph. Filter by
+      up:reviewed 1 (Swiss-Prot) on the UniProt side — the Critical Warnings of the
+      uniprot MIE apply.
+    question: "For human SOX2, which reviewed UniProt entries does its Bgee gene cross-reference?"
+    complexity: advanced
+    sparql: |
+      PREFIX genex: <http://purl.org/genex#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX lscr: <http://purl.org/lscr#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX up: <http://purl.uniprot.org/core/>
+
+      SELECT DISTINCT ?protein ?recName WHERE {
+        GRAPH <http://bgee.org> {
+          ?gene a orth:Gene ;
+                rdfs:label "SOX2" ;
+                orth:organism <https://bgee.org/species/9606> ;
+                lscr:xrefUniprot ?protein .
+        }
+        GRAPH <http://sparql.uniprot.org/uniprot> {
+          ?protein a up:Protein ;
+                   up:reviewed 1 ;
+                   up:recommendedName/up:fullName ?recName .
+        }
+      }
+      LIMIT 10
+
+# Bgee on SIB shares the endpoint with UniProt and Rhea — cross-graph queries are possible.
+cross_database_queries:
+  shared_endpoint: sib
+  co_located_databases: [uniprot, rhea, bgee]
+  examples:
+    - title: "Bgee + UniProt: tissue expression sites for all reviewed Swiss-Prot proteins of a species"
+      description: |
+        Use case: starting from UniProt's curated proteome, where is each protein's
+        gene reported as expressed in Bgee? Bridges via lscr:xrefUniprot. The taxon
+        identity is enforced on both sides — bgeespecies on the Bgee gene, UniProt
+        taxonomy IRI on the protein — to avoid orphan matches.
+
+        Linking strategy:
+        - Both graphs on the same SIB endpoint → single SPARQL with two GRAPH blocks
+        - Bridge IRI: UniProt accession (lscr:xrefUniprot equates to up:Protein)
+        - Filter by species on both sides for symmetry
+      databases_used: [bgee, uniprot]
+      complexity: advanced
+      sparql: |
+        PREFIX genex: <http://purl.org/genex#>
+        PREFIX orth: <http://purl.org/net/orth#>
+        PREFIX lscr: <http://purl.org/lscr#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX up: <http://purl.uniprot.org/core/>
+        PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
+
+        SELECT ?protein ?gene_label ?anatomy_label WHERE {
+          GRAPH <http://sparql.uniprot.org/uniprot> {
+            ?protein a up:Protein ;
+                     up:reviewed 1 ;
+                     up:organism taxonomy:9606 .
+          }
+          GRAPH <http://bgee.org> {
+            ?gene a orth:Gene ;
+                  rdfs:label ?gene_label ;
+                  orth:organism <https://bgee.org/species/9606> ;
+                  lscr:xrefUniprot ?protein .
+            ?call a genex:Expression ;
+                  genex:hasSequenceUnit ?gene ;
+                  genex:hasExpressionCondition ?cond .
+            ?cond genex:hasAnatomicalEntity ?anatomy .
+            ?anatomy rdfs:label ?anatomy_label .
+          }
+        }
+        LIMIT 25
+      notes: |
+        - Linking via: UniProt accession IRI (lscr:xrefUniprot ↔ up:Protein subject)
+        - Performance: fast for narrow gene queries; a comprehensive scan over reviewed
+          human proteome (~20K) without LIMIT will time out — always anchor to a gene,
+          anatomy, or LIMIT.
+        - MIE files checked: bgee (this file), uniprot
+
+cross_references:
+  - pattern: lscr:xrefUniprot
+    description: |
+      Gene → UniProt protein. Multi-valued; both bare accession (up:<accession>) and
+      MNEMONIC form (up:<NAME_ORGCODE>) are present for every linked protein. Use
+      either; UniProt's owl:sameAs unifies them.
+    databases:
+      protein:
+        - "UniProt: ~95% coverage for vertebrate genes; sparser for invertebrate species"
+
+  - pattern: lscr:xrefEnsemblGene
+    description: |
+      Gene → Ensembl gene IRI (http://rdf.ebi.ac.uk/resource/ensembl/<id>). Primary
+      for vertebrate species; for invertebrates Ensembl Genomes IDs may not appear.
+    databases:
+      gene:
+        - "Ensembl: high coverage for vertebrates"
+
+  - pattern: lscr:xrefNCBIGene
+    description: |
+      Gene → NCBI Gene (https://www.ncbi.nlm.nih.gov/gene/<id>). Sparse — many
+      species-specific IDs (WBGene, FB) have no NCBI Gene mapping.
+    databases:
+      gene:
+        - "NCBI Gene: partial coverage; relies on cross-DB"
+
+  - pattern: orth:organism / obo:RO_0002162
+    description: |
+      Gene → bgeespecies:NNN organism → obo:RO_0002162 → taxonomy:NNN (UniProt taxon).
+      Two-hop bridge required because Gene's organism IRI is in the Bgee namespace,
+      not UniProt's. Only 52 distinct species are present.
+    databases:
+      taxonomy:
+        - "UniProt taxonomy: 52/52 species linked via RO_0002162"
+
+architectural_notes:
+  query_strategy:
+    - "MANDATORY FIRST STEP: filter by gene, anatomy, or species before COUNT or non-LIMIT queries — the Expression class has 709M instances."
+    - "Anchor first via gene symbol (rdfs:label + orth:organism) or external xref (lscr:xrefUniprot, lscr:xrefEnsemblGene). Never start with bif:contains."
+    - "Comprehensive: prefer GRAPH <http://bgee.org> wrapping the entire pattern — Virtuoso optimises better with explicit graph clauses on SIB."
+    - "Cross-graph (Bgee + UniProt): both live on SIB; use one SELECT with two GRAPH blocks. Filter inside each GRAPH before joining."
+    - "Priority: rdfs:label gene-symbol lookup > lscr:xref* bridge > genex:isExpressedIn (denormalized; less precise)."
+
+  schema_design:
+    - "Central pattern: Gene ↔ Expression ↔ ExpressionCondition. Joining is always through Expression as the hub."
+    - "Conditions bundle 4 axes: anatomy (multi-valued), dev stage, sex, strain. Most analyses pivot on anatomy + species."
+    - "Two parallel taxonomy IRI namespaces: bgeespecies:NNN (orth:Organism, used by Gene) vs taxonomy:NNN (up:Taxon, used by ExpressionCondition). Bridge via obo:RO_0002162."
+    - "Anatomy IRIs are heterogeneous: UBERON_*, CL_*, GO_0005575, WBbt_* (worm), FBbt_* (fly). All carry rdfs:label and dcterms:description in this graph."
+    - "Confidence is a CIO IRI (CIO_0000029 high, CIO_0000030 medium). No third level; absence of a level means absence call."
+
+  performance:
+    - "ALWAYS wrap query patterns in GRAPH <http://bgee.org>. Without it, queries scan the entire SIB store including UniProt's 244M triples."
+    - "LIMIT every exploratory query. The expression table is 709M rows."
+    - "For comparative anatomy/species ranks, restrict to confidence level CIO_0000029 to drop ~14% lower-quality calls and shrink the working set."
+
+  data_integration:
+    - "lscr:xref* predicates: Gene → UniProt | Ensembl | NCBI Gene. UniProt coverage is densest."
+    - "obo:RO_0002162 (in taxon): bridges Bgee organism namespace ↔ UniProt taxonomy namespace."
+    - "Cross-graph SPARQL works for Bgee + UniProt + Rhea (all on SIB). Cross-endpoint (e.g., Bgee → ChEMBL) requires TogoID."
+
+  data_quality:
+    - "AbsenceExpression covers only ~0.65% of calls (4.6M of 714M total) — most calls are positive. Negative findings are sparser than positive."
+    - "Strain field is mostly the wild-type archetype (one canonical instance, hash-based IRIs link to it). Strain-stratified analyses are limited."
+    - "Sex distribution skews toward 'any' (pooled analyses)."
+    - "Gene cross-references: vertebrates well-served; invertebrates may have only Ensembl Genomes / WBGene / FB IDs without NCBI Gene mapping."
+
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0"
+    - "All anchor lookups go through rdfs:label gene-symbol matches (effectively an indexed string equality, not a substring scan) or specific IRIs."
+    - "bif:contains was considered for description fields but was rejected — every relevant entity carries either an IRI (anatomy, taxon, dev stage, confidence) or a structured label (gene symbol, sex, strain name)."
+
+data_statistics:
+  total_expression_calls: 709482280
+  total_absence_calls: 4642933
+  total_genes: 1559014
+  total_expression_conditions: 123467
+  total_anatomical_entities: 40646
+  total_developmental_stages: 1239
+  total_species: 52
+  verified_date: "2026-04-28"
+  verification_method: "Direct COUNT queries against http://bgee.org graph on SIB endpoint"
+
+  confidence_distribution:
+    high_confidence_CIO_0000029: 617437101
+    medium_confidence_CIO_0000030: 96688112
+    verified_date: "2026-04-28"
+
+  top_species_by_gene_count:
+    human_9606: 67139
+    mouse_10090: 56305
+    salmon_8030: 55819
+    c_elegans_6239: 46904
+    zebrafish_7955: 37241
+    verified_date: "2026-04-28"
+
+anti_patterns:
+  - title: "Schema check before text search"
+    problem: |
+      Using bif:contains or FILTER(CONTAINS()) to find a gene, anatomy, or species
+      when structured predicates exist.
+    wrong_sparql: |
+      # No schema checked — text search over rdfs:label
+      ?gene rdfs:label ?label .
+      FILTER(CONTAINS(LCASE(?label), "tp53"))
+    correct_sparql: |
+      # 1. shape_expressions documents rdfs:label as gene symbol (exact string).
+      # 2. Use exact match anchored to species:
+      ?gene a orth:Gene ;
+            rdfs:label "TP53" ;
+            orth:organism <https://bgee.org/species/9606> .
+    explanation: "Bgee's rdfs:label on Gene is the canonical gene symbol — already controlled and case-correct. Text search would also match transcripts with TP53 in the description and is 100× slower."
+
+  - title: "Wrong taxonomy IRI namespace"
+    problem: |
+      Querying gene→organism with a UniProt taxonomy IRI, or condition→in-taxon with
+      a Bgee species IRI. Both silently return zero rows.
+    wrong_sparql: |
+      ?gene orth:organism <http://purl.uniprot.org/taxonomy/9606> .
+      # ↑ 0 rows — Gene's organism uses bgeespecies: namespace
+    correct_sparql: |
+      ?gene orth:organism <https://bgee.org/species/9606> .
+      # On ExpressionCondition use the OTHER namespace:
+      ?cond <http://purl.obolibrary.org/obo/RO_0002162> <http://purl.uniprot.org/taxonomy/9606> .
+    explanation: "Bgee uses two parallel taxon IRI namespaces. Gene → bgeespecies:NNN; ExpressionCondition → taxonomy:NNN (UniProt). Bridge with obo:RO_0002162."
+
+  - title: "Unfiltered scan of the Expression class"
+    problem: |
+      Counting or listing genex:Expression without anchoring to a gene, anatomy, or
+      species. The class has 709M instances; queries time out.
+    wrong_sparql: |
+      SELECT (COUNT(*) AS ?n) WHERE {
+        GRAPH <http://bgee.org> { ?c a genex:Expression }
+      }
+      # Times out at the endpoint
+    correct_sparql: |
+      # Anchor first, then COUNT:
+      SELECT (COUNT(*) AS ?n) WHERE {
+        GRAPH <http://bgee.org> {
+          ?c a genex:Expression ;
+             genex:hasSequenceUnit ?gene ;
+             genex:hasExpressionCondition ?cond .
+          ?cond <http://purl.obolibrary.org/obo/RO_0002162> taxonomy:9606 .
+        }
+      }
+    explanation: "The expression call table is the largest in the SIB store. Filter by species, gene, or anatomy via the condition before any aggregation."
+
+  - title: "Treating genex:isExpressedIn as a clean anatomy link"
+    problem: |
+      Assuming genex:isExpressedIn always returns anatomy IRIs. It is denormalized —
+      values include both anatomy IRIs (UBERON, CL) AND ExpressionCondition IRIs.
+    wrong_sparql: |
+      ?gene genex:isExpressedIn ?anatomy .
+      ?anatomy rdfs:label ?label .
+      # Some ?anatomy bindings are EXPRESSION_CONDITION_* IRIs without rdfs:label
+    correct_sparql: |
+      # Go through the call/condition path explicitly:
+      ?call a genex:Expression ;
+            genex:hasSequenceUnit ?gene ;
+            genex:hasExpressionCondition ?cond .
+      ?cond genex:hasAnatomicalEntity ?anatomy .
+      ?anatomy a genex:AnatomicalEntity ;
+               rdfs:label ?label .
+    explanation: "Expression → ExpressionCondition → hasAnatomicalEntity is the precise path. genex:isExpressedIn is a convenience shortcut and mixes anatomy with condition IRIs."
+
+common_errors:
+  - error: "Empty result for gene-symbol query"
+    causes:
+      - "Wrong taxonomy IRI namespace (used UniProt taxonomy where bgeespecies is required)"
+      - "Case mismatch on rdfs:label (gene symbols are case-sensitive in Bgee — TP53 not tp53)"
+      - "Missing GRAPH <http://bgee.org> wrapper — query hit a different graph"
+    solutions:
+      - "Confirm orth:organism uses bgeespecies:NNN (not taxonomy:NNN)"
+      - "Use exact case as it appears in upstream species nomenclature (HGNC for human, MGI for mouse)"
+      - "Always wrap patterns in GRAPH <http://bgee.org>"
+
+  - error: "SPARQL timeout on Expression aggregation"
+    causes:
+      - "Unfiltered COUNT or scan over genex:Expression (709M rows)"
+      - "Missing LIMIT during exploration"
+    solutions:
+      - "Anchor by gene, anatomy, or species (via condition's RO_0002162) before aggregating"
+      - "Add LIMIT 100 during query development; remove only after schema/filter is confirmed"
+      - "For comparative work, restrict to genex:hasConfidenceLevel obo:CIO_0000029 to drop ~14% of calls"
+
+  - error: "Cross-graph query (Bgee + UniProt) returns no rows"
+    causes:
+      - "lscr:xrefUniprot binding is the IRI of the up:Protein subject (no further bridge needed)"
+      - "Forgot up:reviewed 1 on the UniProt side; matched a TrEMBL entry that exists but is unreviewed"
+      - "Used GRAPH <http://sparql.uniprot.org/core> — that is the ontology graph; data is in <http://sparql.uniprot.org/uniprot>"
+    solutions:
+      - "Use lscr:xrefUniprot ?protein with ?protein appearing as subject in the UniProt graph block"
+      - "Add up:reviewed 1 inside the UniProt GRAPH if you only want Swiss-Prot"
+      - "Use the data graph http://sparql.uniprot.org/uniprot for protein records"

--- a/togo_mcp/data/mie/brenda.yaml
+++ b/togo_mcp/data/mie/brenda.yaml
@@ -1,0 +1,628 @@
+schema_info:
+  title: BRENDA (Braunschweig Enzyme Database)
+  description: |
+    BRENDA is the world's most comprehensive manually curated enzyme database, covering
+    functional, kinetic, and taxonomic data for enzymes classified by EC number. Each
+    enzyme entry represents a specific protein in a specific organism, classified under
+    one or more EC numbers. The database contains enzyme instances, EC number definitions,
+    inhibitors, activators, cofactors, substrates, products, reactions, tissue expression
+    data, chemical compounds with InChI/InChIKey, and supporting literature references.
+  keywords:
+    - enzyme
+    - ec number
+    - brenda
+    - enzymatic reaction
+    - substrate
+    - inhibitor
+    - activator
+    - cofactor
+    - kinetics
+    - biochemistry
+    - catalysis
+    - inchi
+    - inchikey
+    - tissue expression
+    - organism enzyme
+  categories:
+    - reaction
+    - protein
+    - enzymology
+  endpoint: https://rdfportal.org/primary/sparql
+  base_uri: https://purl.dsmz.de/brenda/
+  graphs:
+    - http://rdfportal.org/dataset/brenda
+  kw_search_tools: []
+  version:
+    mie_version: "2.0"
+    mie_created: "2026-04-28"
+    data_version: "Release 2026"
+    update_frequency: "Irregular"
+  access:
+    backend: "Virtuoso"
+
+critical_warnings: |
+  - QUERY SCOPE: Always include FROM <http://rdfportal.org/dataset/brenda> or a GRAPH
+    clause. Without it, queries span all primary-endpoint datasets and will time out or
+    return mixed results.
+  - ENZYME IDs ARE INTERNAL, NOT EC NUMBERS: Enzyme IRIs use internal BRENDA numeric IDs
+    (e.g. https://purl.dsmz.de/brenda/enzyme/2485), NOT EC numbers. Multiple enzyme
+    instances exist per EC class (one per organism). Always navigate from EC number to
+    enzyme via `d3o:isClassifiedAs`, not by IRI guessing.
+  - EC NUMBER IRI PATTERN: EC number IRIs encode the dotted EC number directly:
+    `https://purl.dsmz.de/brenda/ec/4.1.1.17`. Use these IRIs directly in queries
+    (e.g. `d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/4.1.1.17>`).
+  - EFFECTOR ROLES ARE CONTEXT-SPECIFIC: Inhibitor and Activator IRIs represent the
+    *role* of a compound in context, not the compound itself. Each inhibitor/activator
+    node has `d3o:refersToCompound` → the actual ChemicalCompound node (which holds
+    the label, InChI, and InChIKey). Do not expect structural data on the inhibitor IRI.
+  - REACTION IRI PREFIXES: Reactions have two subtypes in their IRI: `reaction/I_N`
+    (IUBMB reactions, canonical) and `reaction/S_N` (substrate-specific variants).
+    The predicate `d3o:isIubmbReaction` is present on IUBMB reactions. Both types have
+    `d3o:catalyzedByClass` linking to the ECNumber.
+  - TAXON ID TYPE: `d3o:hasTaxID` is an xsd:integer (e.g. `d3o:hasTaxID 9606`), not a
+    string. Use `FILTER(?taxid = 9606)` or the integer literal directly in triple patterns.
+  - TISSUE AND LOCALIZATION USE `d3o:expresses`: Tissue nodes link to enzymes via
+    `d3o:expresses` (not `d3o:foundIn`). The predicate direction is: tissue → enzyme,
+    not enzyme → tissue.
+
+shape_expressions: |
+  PREFIX d3o:  <https://purl.dsmz.de/schema/>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX dct:  <http://purl.org/dc/terms/>
+
+  # IRI pattern: https://purl.dsmz.de/brenda/enzyme/{N}  (internal BRENDA ID, not EC number)
+  # ~54,720 instances; multiple per EC class (one per organism)
+  <EnzymeShape> {
+    a [ d3o:Enzyme d3o:Protein d3o:GeneProduct ] ;  # all three types always present
+    d3o:isClassifiedAs @<ECNumberShape> + ;           # EC class(es) this enzyme belongs to
+    d3o:foundIn @<OrganismShape> ;                    # the organism containing this enzyme
+    d3o:hasReference @<ReferenceShape> *              # supporting literature
+    # NOTE: enzyme IRIs are internal — do NOT use them as EC numbers
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/ec/{X.X.X.X}  e.g. ec/4.1.1.17
+  # ~7,453 EC class entries
+  <ECNumberShape> {
+    a [ d3o:ECNumber d3o:EnzymeIdentifier d3o:MoleculeIdentifier d3o:Identifier ] ;
+    rdfs:label xsd:string ;          # enzyme common name, e.g. "ornithine decarboxylase"
+    dct:description xsd:string ;     # IUBMB description, e.g. "A pyridoxal-phosphate protein."
+    d3o:hasSynonyms xsd:string + ;   # gene names, isoform names, synonyms
+    d3o:hasSystematicName xsd:string # IUBMB systematic name
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/organism/{N}
+  # ~30,338 organism instances; each is a distinct organism+strain combination
+  <OrganismShape> {
+    a [ d3o:BiologicalMaterial ] ;
+    rdfs:label xsd:string ;          # organism name/strain
+    d3o:hasSynonym xsd:string * ;    # synonyms including taxonomic lineage strings
+    d3o:hasTaxID xsd:integer ? ;     # NCBI Taxonomy ID as integer; ~50% coverage
+    d3o:hasIdentifier IRI ?          # link to external taxonomy resource
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/inhibitor/{N}
+  # ~110,187 inhibitor role instances (context-specific: one per enzyme+compound+organism)
+  # IMPORTANT: inhibitor represents the ROLE, not the compound — use d3o:refersToCompound
+  <InhibitorShape> {
+    a [ d3o:Inhibitor d3o:Effector d3o:ChemicalRole d3o:ConceptualEntity ] ;
+    d3o:inhibits @<EnzymeShape> + ;           # specific enzyme instances inhibited
+    d3o:affectsClass @<ECNumberShape> + ;     # EC class(es) affected
+    d3o:foundIn @<OrganismShape> + ;          # organism context
+    d3o:refersToCompound @<CompoundShape> ;   # the chemical compound with structure
+    d3o:hasReference @<ReferenceShape> +
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/activator/{N}
+  # ~6,479 activator instances
+  <ActivatorShape> {
+    a [ d3o:Activator d3o:Effector d3o:ChemicalRole d3o:ConceptualEntity ] ;
+    d3o:activates @<EnzymeShape> + ;
+    d3o:affectsClass @<ECNumberShape> + ;
+    d3o:foundIn @<OrganismShape> + ;
+    d3o:refersToCompound @<CompoundShape> ;
+    d3o:hasReference @<ReferenceShape> +
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/cofactor/{N}
+  # ~549 cofactor instances
+  <CofactorShape> {
+    a [ d3o:Cofactor d3o:ChemicalRole d3o:ConceptualEntity ] ;
+    d3o:isCofactorOf @<EnzymeShape> + ;
+    d3o:refersToCompound @<CompoundShape> ;
+    d3o:hasReference @<ReferenceShape> +
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/compound/{N}
+  # ~214,688 chemical compound instances; shared across inhibitor/activator/cofactor/substrate/product roles
+  <CompoundShape> {
+    a [ d3o:ChemicalCompound d3o:ChemicalMaterial ] ;
+    rdfs:label xsd:string ;          # compound name, e.g. "spermidine"
+    d3o:hasIdentifier xsd:integer ;  # internal BRENDA compound ID integer
+    d3o:hasSynonym xsd:string * ;    # alternative names
+    d3o:hasStructure @<StructureShape> +  # one or more molecular structure entries
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/structure/{N}
+  # ~171,721 structure entries
+  <StructureShape> {
+    a [ d3o:MolecularStructure ] ;
+    d3o:hasInChI xsd:string ;        # InChI string for structure lookup
+    d3o:hasInChIKey xsd:string       # InChIKey for exact-match searches
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/reaction/{I_N or S_N}
+  # ~139,860 reactions; I_N = IUBMB, S_N = substrate-specific variant
+  <ReactionShape> {
+    a [ d3o:Reaction ] ;
+    rdfs:label xsd:string ;              # reaction equation string, e.g. "L-ornithine = putrescine + CO2"
+    d3o:catalyzedBy @<EnzymeShape> * ;   # specific enzyme instances
+    d3o:catalyzedByClass @<ECNumberShape> + ;  # EC class(es) that catalyze this
+    d3o:isIubmbReaction xsd:boolean ? ; # present on IUBMB canonical reactions (I_ prefix)
+    d3o:partOf @<PathwayShape> * ;
+    d3o:hasReference @<ReferenceShape> *
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/tissue/{N}
+  # ~4,815 tissue types; expression links go FROM tissue TO enzyme
+  <TissueShape> {
+    a [ d3o:Tissue d3o:AnatomicStructure ] ;
+    rdfs:label xsd:string ;
+    d3o:expresses @<EnzymeShape> * ;   # tissue EXPRESSES the enzyme (not enzyme→tissue)
+    d3o:partOf @<OrganismShape> * ;
+    d3o:hasReference @<ReferenceShape> *
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/pathway/{N}
+  # ~194 pathway entries
+  <PathwayShape> {
+    a [ d3o:Pathway ] ;
+    rdfs:label xsd:string ;
+    d3o:hasReaction @<ReactionShape> +
+  }
+
+  # IRI pattern: https://purl.dsmz.de/brenda/reference/{N}
+  # ~173,164 reference entries
+  <ReferenceShape> {
+    a [ d3o:Reference ] ;
+    dct:title xsd:string ;
+    dct:creator xsd:string ;
+    d3o:hasPubMedID xsd:string ;         # PubMed ID as string
+    d3o:hasPMCID xsd:string ? ;          # PMC ID (~30% coverage)
+    dct:issued xsd:string ;
+    d3o:hasJournalAbbreviation xsd:string ;
+    d3o:hasVolume xsd:string ;
+    d3o:hasPageRange xsd:string ;
+    d3o:hasBibliographicInformation xsd:string
+  }
+
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix d3o:  <https://purl.dsmz.de/schema/> .
+    @prefix ec:   <https://purl.dsmz.de/brenda/ec/> .
+    @prefix enz:  <https://purl.dsmz.de/brenda/enzyme/> .
+    @prefix org:  <https://purl.dsmz.de/brenda/organism/> .
+    @prefix inh:  <https://purl.dsmz.de/brenda/inhibitor/> .
+    @prefix cmpd: <https://purl.dsmz.de/brenda/compound/> .
+    @prefix str:  <https://purl.dsmz.de/brenda/structure/> .
+    @prefix ref:  <https://purl.dsmz.de/brenda/reference/> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dct:  <http://purl.org/dc/terms/> .
+  entries:
+    - title: "EC 4.1.1.17 — ornithine decarboxylase EC class entry"
+      description: EC number node with enzyme name, IUBMB description, systematic name, and gene name synonyms.
+      rdf: |
+        ec:4.1.1.17 a d3o:ECNumber, d3o:EnzymeIdentifier, d3o:MoleculeIdentifier, d3o:Identifier ;
+                    rdfs:label "ornithine decarboxylase" ;
+                    dct:description "A pyridoxal-phosphate protein." ;
+                    d3o:hasSystematicName "L-ornithine carboxy-lyase (putrescine-forming)" ;
+                    d3o:hasSynonyms "ODC1" , "ODC" , "SpeC" , "SpeA" , "AZIN2" .
+
+    - title: "Enzyme instance — ornithine decarboxylase in Pelophylax nigromaculatus"
+      description: Enzyme node linking to its EC class, host organism, and supporting reference.
+      rdf: |
+        enz:2485 a d3o:Enzyme, d3o:Protein, d3o:GeneProduct ;
+                 d3o:isClassifiedAs ec:4.1.1.17 ;
+                 d3o:foundIn org:19526 ;
+                 d3o:hasReference ref:4043 .
+
+        org:19526 a d3o:BiologicalMaterial ;
+                  rdfs:label "Pelophylax nigromaculatus" .
+
+    - title: "Inhibitor role node — spermidine inhibiting EC 4.1.1.17, with compound structure"
+      description: Inhibitor node (context-specific role) linking to the actual compound with InChIKey.
+      rdf: |
+        inh:139 a d3o:Inhibitor, d3o:Effector, d3o:ChemicalRole, d3o:ConceptualEntity ;
+                d3o:affectsClass ec:4.1.1.17 ;
+                d3o:refersToCompound cmpd:139 .
+
+        cmpd:139 a d3o:ChemicalCompound, d3o:ChemicalMaterial ;
+                 rdfs:label "spermidine" ;
+                 d3o:hasIdentifier 139 ;
+                 d3o:hasStructure str:148 .
+
+        str:148 a d3o:MolecularStructure ;
+                d3o:hasInChI "InChI=1S/C7H19N3/c8-4-1-2-6-10-7-3-5-9/h10H,1-9H2" ;
+                d3o:hasInChIKey "InChIKey=ATHGHQPFGPMSJY-UHFFFAOYSA-N" .
+
+sparql_query_examples:
+  - title: "Get all enzyme instances for a specific EC class"
+    description: Retrieve every enzyme instance of a given EC class with their host organisms.
+    question: "Which organisms have ornithine decarboxylase (EC 4.1.1.17) in BRENDA?"
+    complexity: basic
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?enzyme ?orgLabel
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?enzyme a d3o:Enzyme ;
+                # EC IRI encodes the number directly — use it as a filter
+                d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/4.1.1.17> ;
+                d3o:foundIn ?organism .
+        ?organism rdfs:label ?orgLabel .
+      }
+      LIMIT 20
+
+  - title: "Get EC number details — name, description, systematic name, synonyms"
+    description: Retrieve the IUBMB definition and gene-name synonyms for a specific EC class.
+    question: "What is the IUBMB name, description, and systematic name for EC 4.1.1.17?"
+    complexity: basic
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+
+      SELECT ?ecLabel ?description ?systematicName ?synonym
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        <https://purl.dsmz.de/brenda/ec/4.1.1.17> rdfs:label ?ecLabel ;
+            dct:description ?description .
+        OPTIONAL { <https://purl.dsmz.de/brenda/ec/4.1.1.17> d3o:hasSystematicName ?systematicName }
+        OPTIONAL { <https://purl.dsmz.de/brenda/ec/4.1.1.17> d3o:hasSynonyms ?synonym }
+      }
+      LIMIT 20
+
+  - title: "Find inhibitors of an EC class with compound structures"
+    description: Retrieve inhibitors affecting a specific enzyme class, navigating through the role
+      node to the actual compound and its InChIKey for structure lookup.
+    question: "What compounds inhibit ornithine decarboxylase (EC 4.1.1.17), and what are their InChIKeys?"
+    complexity: intermediate
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?inhibitor ?compLabel ?inchiKey
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?inhibitor a d3o:Inhibitor ;
+                   d3o:affectsClass <https://purl.dsmz.de/brenda/ec/4.1.1.17> ;
+                   # Navigate from role node to compound — structural data is on the compound
+                   d3o:refersToCompound ?compound .
+        ?compound rdfs:label ?compLabel ;
+                  d3o:hasStructure ?structure .
+        ?structure d3o:hasInChIKey ?inchiKey .
+      }
+      LIMIT 20
+
+  - title: "Get reactions catalyzed by an EC class"
+    description: Retrieve all reaction equations (both IUBMB and substrate-specific) for a given EC.
+    question: "What are the reactions catalyzed by ornithine decarboxylase (EC 4.1.1.17)?"
+    complexity: intermediate
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?reaction ?equation
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?reaction a d3o:Reaction ;
+                  # d3o:catalyzedByClass links reaction to EC class (not enzyme instance)
+                  d3o:catalyzedByClass <https://purl.dsmz.de/brenda/ec/4.1.1.17> ;
+                  rdfs:label ?equation .
+      }
+      LIMIT 20
+
+  - title: "Find enzyme classes expressed in a specific organism by NCBI Taxonomy ID"
+    description: Use d3o:hasTaxID (integer) to look up organism nodes, then navigate to their
+      enzymes and EC classes.
+    question: "Which enzyme classes does BRENDA have data for in Homo sapiens (NCBI Taxonomy 9606)?"
+    complexity: intermediate
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?ec ?ecLabel
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        # d3o:hasTaxID is an integer — use integer literal, not string
+        ?organism a d3o:BiologicalMaterial ;
+                  d3o:hasTaxID 9606 .
+        ?enzyme a d3o:Enzyme ;
+                d3o:foundIn ?organism ;
+                d3o:isClassifiedAs ?ec .
+        ?ec rdfs:label ?ecLabel .
+      }
+      LIMIT 20
+
+  - title: "Compare enzyme breadth across multiple EC classes"
+    description: Count enzyme instances and organism coverage for a set of EC classes in one query.
+    question: "How many enzyme instances and organisms does BRENDA have for alcohol dehydrogenase,
+      receptor tyrosine kinase, and caspase-1?"
+    complexity: advanced
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?ec ?ecLabel (COUNT(DISTINCT ?enzyme) AS ?enzymeCount) (COUNT(DISTINCT ?organism) AS ?orgCount)
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        VALUES ?ec {
+          <https://purl.dsmz.de/brenda/ec/1.1.1.1>    # alcohol dehydrogenase
+          <https://purl.dsmz.de/brenda/ec/2.7.10.1>   # receptor protein-tyrosine kinase
+          <https://purl.dsmz.de/brenda/ec/3.4.22.36>  # caspase-1
+        }
+        ?ec rdfs:label ?ecLabel .
+        ?enzyme d3o:isClassifiedAs ?ec ;
+                d3o:foundIn ?organism .
+      }
+      GROUP BY ?ec ?ecLabel
+
+  - title: "Tissue-specific enzyme expression across organisms"
+    description: Find tissues that express a specific enzyme class and the organisms they belong to.
+      Demonstrates the tissue→enzyme direction (d3o:expresses).
+    question: "In which tissues and organisms is ornithine decarboxylase expressed according to BRENDA?"
+    complexity: advanced
+    sparql: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?tissueLabel ?orgLabel
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        # Tissue EXPRESSES enzyme (direction: tissue → enzyme, not enzyme → tissue)
+        ?tissue a d3o:Tissue ;
+                rdfs:label ?tissueLabel ;
+                d3o:expresses ?enzyme ;
+                d3o:partOf ?organism .
+        ?organism rdfs:label ?orgLabel .
+        # Navigate from enzyme to its EC class to filter by class
+        ?enzyme d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/4.1.1.17> .
+      }
+      LIMIT 20
+
+cross_database_queries:
+  shared_endpoint: primary
+  co_located_databases: [hgnc, bacdive, nando, mondo, mesh, go, taxonomy, mediadive]
+  examples:
+    - title: "Link BRENDA EC classes to HGNC enzyme-coding genes"
+      description: |
+        Linking strategy:
+        - BRENDA: ECNumber IRI encodes the EC number in its path
+          (https://purl.dsmz.de/brenda/ec/4.1.1.17 → "4.1.1.17")
+        - HGNC: genes have rdfs:seeAlso → idt:ec-code nodes with dct:identifier "4.1.1.17"
+        - Join via BIND + FILTER(STR=STR) to normalise the typed-string vs plain-string mismatch
+        - No text search required
+      databases_used: [brenda, hgnc]
+      complexity: intermediate
+      sparql: |
+        PREFIX d3o:  <https://purl.dsmz.de/schema/>
+        PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX dct:  <http://purl.org/dc/terms/>
+        PREFIX idt:  <http://identifiers.org/>
+
+        SELECT ?geneSymbol ?ecNum ?ecLabel
+        WHERE {
+          GRAPH <http://rdfportal.org/dataset/hgnc> {
+            ?gene a m2r:Gene ;
+                  rdfs:label ?geneSymbol ;
+                  rdfs:seeAlso ?ecCode .
+            ?ecCode a idt:ec-code ;
+                    dct:identifier ?ecNum .
+          }
+          GRAPH <http://rdfportal.org/dataset/brenda> {
+            ?ec a d3o:ECNumber ;
+                rdfs:label ?ecLabel .
+            # Extract EC number from IRI and compare with HGNC identifier string
+            BIND(STRAFTER(STR(?ec), "https://purl.dsmz.de/brenda/ec/") AS ?ecNum2)
+            FILTER(STR(?ecNum2) = STR(?ecNum))
+          }
+        }
+        LIMIT 20
+      notes: |
+        - Linking via: EC number string (BRENDA IRI path vs HGNC dct:identifier)
+        - MIE files checked: brenda, hgnc
+        - BRENDA EC IRI namespace: https://purl.dsmz.de/brenda/ec/ (NOT the same as idt:ec-code)
+        - FILTER(STRAFTER(STR(?ec), prefix) = ?ecNum) alone may fail in Virtuoso due to
+          xsd:string type mismatch — always use BIND + FILTER(STR()=STR()) pattern
+
+cross_references:
+  - pattern: d3o:isClassifiedAs
+    description: |
+      Links enzyme instances to their EC number class nodes. Multiple enzymes can share
+      one EC class (one per organism). The EC IRI encodes the number directly.
+    databases:
+      internal:
+        - "EC Number: 100% of enzyme instances"
+  - pattern: d3o:refersToCompound
+    description: |
+      Links inhibitor, activator, cofactor, substrate, and product role nodes to the
+      actual ChemicalCompound node, which carries rdfs:label, d3o:hasIdentifier, and
+      d3o:hasStructure → InChI/InChIKey.
+    databases:
+      internal:
+        - "ChemicalCompound: 100% of effector/role nodes"
+  - pattern: d3o:hasPubMedID
+    description: |
+      String PubMed ID on Reference nodes. Use this to bridge to the pubmed database on
+      the ncbi endpoint (separate endpoint — cannot join directly in SPARQL).
+    databases:
+      literature:
+        - "PubMed: ~100% of Reference nodes have hasPubMedID"
+
+architectural_notes:
+  query_strategy:
+    - "FIRST: read the MIE file; examine shape_expressions for entity hierarchy"
+    - "EC lookup: use the EC IRI directly (https://purl.dsmz.de/brenda/ec/{X.X.X.X})"
+    - "Enzyme instances: query via d3o:isClassifiedAs from the EC IRI"
+    - "Compound structure: navigate inhibitor/activator → d3o:refersToCompound → d3o:hasStructure"
+    - "Organism filter: use d3o:hasTaxID integer for NCBI Taxonomy ID lookups"
+    - "Tissue expression: query FROM tissue (tissue d3o:expresses enzyme), not from enzyme"
+    - "Priority: EC IRI > Taxonomy ID > Compound name (rdfs:label) > Text search"
+
+  schema_design:
+    - "Central entities: EC number (class) and Enzyme (instance = class × organism)"
+    - "Inhibitor/Activator/Cofactor are ROLE nodes, not compound nodes — bridge via refersToCompound"
+    - "Reactions link to EC classes (catalyzedByClass) and enzyme instances (catalyzedBy)"
+    - "Tissue expression flows FROM tissue TO enzyme (d3o:expresses)"
+    - "Organism nodes are strain-level; d3o:hasTaxID (integer) links to NCBI Taxonomy"
+    - "Compound nodes are shared across all role types; structure is via hasStructure → InChI"
+
+  performance:
+    - "Always include FROM <http://rdfportal.org/dataset/brenda> or GRAPH clause"
+    - "EC-class-filtered queries (d3o:isClassifiedAs <ec/X.X.X.X>) are fast — indexed predicate"
+    - "Organism-by-taxID (d3o:hasTaxID 9606): use integer literal, not string"
+    - "Inhibitor queries can be large (110K nodes) — always add d3o:affectsClass filter"
+    - "Split property paths before bif:contains on Virtuoso — avoid /d3o:hasSynonyms chained"
+
+  data_integration:
+    - "Bridge to HGNC: BRENDA ec/{X.X.X.X} IRI → STR extraction → HGNC idt:ec-code dct:identifier"
+    - "Bridge to PubMed: Reference d3o:hasPubMedID → PMID string (ncbi endpoint, separate)"
+    - "Bridge to InChI databases: compound d3o:hasStructure → d3o:hasInChIKey"
+
+  data_quality:
+    - "Organism nodes are strain-specific (e.g. 'Saccharomyces cerevisiae X 2180') — multiple per species"
+    - "hasTaxID is present on ~50% of organism nodes; absent entries need label-based lookup"
+    - "Compounds have multiple structure nodes (different stereoisomers, salts, isotopes)"
+    - "Inhibitor/139 (spermidine) affects 100+ EC classes — very broad inhibitor nodes exist"
+
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0"
+    - "EC numbers are IRIs — use directly"
+    - "Organism lookup uses d3o:hasTaxID integer or exact rdfs:label match"
+    - "Compound names (rdfs:label) are controllable — use exact match for known compounds"
+    - "Free text only justified for dct:description (IUBMB annotation text) or reference titles"
+
+data_statistics:
+  total_entities: 54720
+  verified_date: "2026-04-28"
+  verification_method: "Direct COUNT on d3o:Enzyme instances from earlier class-count query"
+
+  coverage:
+    enzyme_instances:
+      value: "54,720 enzyme instances"
+      calculation: "COUNT of d3o:Enzyme class"
+      verified_date: "2026-04-28"
+    ec_numbers:
+      value: "7,453 EC classes"
+      calculation: "COUNT of d3o:ECNumber class"
+      verified_date: "2026-04-28"
+    compounds:
+      value: "214,688 chemical compounds"
+      calculation: "COUNT of d3o:ChemicalCompound class"
+      verified_date: "2026-04-28"
+    reactions:
+      value: "139,860 reactions"
+      calculation: "COUNT of d3o:Reaction class"
+      verified_date: "2026-04-28"
+    inhibitors:
+      value: "110,187 inhibitor role nodes"
+      calculation: "COUNT of d3o:Inhibitor class"
+      verified_date: "2026-04-28"
+    organisms:
+      value: "30,338 organism entries"
+      calculation: "COUNT of d3o:BiologicalMaterial class"
+      verified_date: "2026-04-28"
+    references:
+      value: "173,164 literature references"
+      calculation: "COUNT of d3o:Reference class"
+      verified_date: "2026-04-28"
+    tissues:
+      value: "4,815 tissue types"
+      calculation: "COUNT of d3o:Tissue class"
+      verified_date: "2026-04-28"
+    activators:
+      value: "6,479 activator role nodes"
+      calculation: "COUNT of d3o:Activator class"
+      verified_date: "2026-04-28"
+    pathways:
+      value: "194 pathway entries"
+      calculation: "COUNT of d3o:Pathway class"
+      verified_date: "2026-04-28"
+
+anti_patterns:
+  - title: "Confusing Enzyme IRI with EC Number IRI"
+    problem: "Using enzyme internal IDs where EC number IRIs are needed, or vice versa."
+    wrong_sparql: |
+      # Wrong — enzyme/2485 is an enzyme instance, not an EC number
+      ?inhibitor d3o:affectsClass <https://purl.dsmz.de/brenda/enzyme/2485> .
+    correct_sparql: |
+      # EC number IRI uses the dotted number directly
+      ?inhibitor d3o:affectsClass <https://purl.dsmz.de/brenda/ec/4.1.1.17> .
+    explanation: "Enzyme IRIs are internal BRENDA instance IDs. EC number IRIs encode the class number in the path. They are completely different namespaces."
+
+  - title: "Querying Structural Data from Inhibitor/Activator Nodes"
+    problem: "Expecting rdfs:label or InChI on an inhibitor node — structure data is on the compound."
+    wrong_sparql: |
+      ?inhibitor a d3o:Inhibitor ;
+                 rdfs:label ?label ;           # wrong — inhibitor has no label
+                 d3o:hasInChIKey ?inchiKey .   # wrong — InChIKey is on the compound/structure
+    correct_sparql: |
+      ?inhibitor a d3o:Inhibitor ;
+                 d3o:refersToCompound ?compound .
+      ?compound rdfs:label ?label ;
+                d3o:hasStructure ?structure .
+      ?structure d3o:hasInChIKey ?inchiKey .
+    explanation: "Inhibitor/Activator nodes represent context-specific roles, not chemical entities. Navigate via d3o:refersToCompound to reach the compound and its structure."
+
+  - title: "Wrong Direction for Tissue Expression"
+    problem: "Looking for d3o:expresses on enzyme nodes — the predicate goes FROM tissue TO enzyme."
+    wrong_sparql: |
+      ?enzyme d3o:expresses ?tissue .   # wrong direction
+    correct_sparql: |
+      ?tissue a d3o:Tissue ;
+              d3o:expresses ?enzyme ;   # tissue expresses enzyme
+              d3o:partOf ?organism .
+      ?enzyme d3o:isClassifiedAs ?ec .
+    explanation: "The d3o:expresses predicate is on tissue nodes pointing to enzyme nodes, not the reverse. Check shape_expressions for the correct predicate direction."
+
+  - title: "Skipping Schema Check Before Text Search"
+    problem: "Using bif:contains to find enzymes by name when the EC IRI can be used directly."
+    wrong_sparql: |
+      ?ec rdfs:label ?label .
+      ?label bif:contains "'ornithine decarboxylase'"
+    correct_sparql: |
+      # Workflow: Look up the EC number in the IUBMB classification, then use the IRI
+      # EC 4.1.1.17 = ornithine decarboxylase
+      ?enzyme d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/4.1.1.17> .
+      # If EC number is unknown, use exact label match (controlled vocabulary):
+      ?ec rdfs:label "ornithine decarboxylase" .
+    explanation: "EC number names are controlled vocabulary. Use exact rdfs:label match or the EC IRI directly. bif:contains is only warranted for free-text fields like dct:description."
+
+common_errors:
+  - error: "Empty results when querying inhibitors or activators"
+    causes:
+      - "Missing d3o:affectsClass filter — querying all 110K inhibitors without EC class restriction"
+      - "Expected rdfs:label on inhibitor node — labels are on the compound, not the role node"
+      - "Confused inhibitor IRI with compound IRI — they share the same internal number but different namespaces (brenda:inhibitor/ vs brenda:compound/)"
+    solutions:
+      - "Always filter inhibitors by d3o:affectsClass <ec/X.X.X.X>"
+      - "Navigate to compound via d3o:refersToCompound for name and structure"
+      - "Use a idt:Inhibitor type check to confirm the node type"
+
+  - error: "Organism lookup returns no results with d3o:hasTaxID"
+    causes:
+      - "Used string literal '9606' instead of integer 9606 for the taxon ID"
+      - "hasTaxID is absent on ~50% of organism nodes — organism has no NCBI taxon link"
+    solutions:
+      - "Use integer literal: d3o:hasTaxID 9606 (not '9606' or \"9606\"^^xsd:string)"
+      - "If taxID query returns nothing, fall back to rdfs:label exact match for organism name"
+
+  - error: "Cross-database SPARQL to HGNC returns empty results"
+    causes:
+      - "Used FROM + GRAPH mix instead of pure GRAPH clauses"
+      - "FILTER(STRAFTER(STR(?ec), prefix) = ?ecNum) fails due to xsd:string vs plain-string mismatch"
+    solutions:
+      - "Use only GRAPH clauses (no FROM) for cross-dataset queries at the primary endpoint"
+      - "Use BIND(STRAFTER(STR(?ec), prefix) AS ?ecNum2) then FILTER(STR(?ecNum2) = STR(?ecNum))"

--- a/togo_mcp/data/mie/hgnc.yaml
+++ b/togo_mcp/data/mie/hgnc.yaml
@@ -1,0 +1,559 @@
+schema_info:
+  title: HGNC (HUGO Gene Nomenclature Committee)
+  description: |
+    HGNC is the authoritative resource for approved human gene nomenclature, providing
+    unique symbols and names for every human gene. Each record represents an approved
+    gene entry with its official symbol, full name, chromosomal location, approval status,
+    and cross-references to dozens of external databases (NCBI Gene, Ensembl, UniProt,
+    RefSeq, OMIM, MGI, RGD, miRBase, EC codes, and more).
+  keywords:
+    - gene
+    - human gene
+    - gene nomenclature
+    - gene symbol
+    - hgnc
+    - hugo
+    - approved gene
+    - gene name
+    - chromosomal location
+    - gene alias
+    - gene cross-reference
+    - omim
+    - ncbi gene
+    - ensembl gene
+  categories:
+    - gene
+    - genomics
+  endpoint: https://rdfportal.org/primary/sparql
+  base_uri: http://identifiers.org/hgnc/
+  graphs:
+    - http://rdfportal.org/dataset/hgnc
+  kw_search_tools: []
+  version:
+    mie_version: "2.0"
+    mie_created: "2026-04-28"
+    data_version: "Release 2026"
+    update_frequency: "Monthly"
+  access:
+    backend: "Virtuoso"
+
+critical_warnings: |
+  - QUERY SCOPE: All gene records use FROM <http://rdfportal.org/dataset/hgnc>. Without
+    this graph clause, queries may return empty results or mix with other primary-endpoint
+    datasets (bacdive, brenda, nando, etc.).
+  - DUAL TYPE: Every HGNC gene has BOTH `a obo:SO_0000704` AND `a m2r:Gene`. Use either
+    one; do not require both with separate triples — it will still work but adds redundancy.
+  - APPROVAL STATUS: ALL 44,960 genes have `skos:historyNote "Approved"`. This predicate
+    cannot be used to filter subsets; it is a constant on every record.
+  - CROSS-REFERENCE PATTERN: External database links are NOT stored as literals on the
+    gene. They are typed IRI nodes via `rdfs:seeAlso`. Each linked node has `a idt:<type>`
+    and `dct:identifier`. Using `rdfs:seeAlso` alone gives IRIs, not identifier strings —
+    join through the typed node to get the string value.
+  - EC-CODE IRI NAMESPACE: HGNC ec-code links use `http://identifiers.org/ec-code/{num}`,
+    NOT the BRENDA namespace `https://purl.dsmz.de/brenda/ec/{num}`. Cross-database joins
+    require STR comparison (see cross_database_queries).
+  - LOCATION IS A STRING: `obo:so_part_of` stores the chromosomal band as a plain string
+    (e.g. "17p13.1"). There is no IRI for the location — use STRSTARTS/FILTER for
+    chromosome-level filtering.
+
+shape_expressions: |
+  PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+  PREFIX obo:  <http://purl.obolibrary.org/obo/>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX dct:  <http://purl.org/dc/terms/>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  PREFIX idt:  <http://identifiers.org/>
+
+  # IRI pattern: http://identifiers.org/hgnc/{HGNC_ID}  e.g. hgnc/11998 = TP53
+  <HGNCGeneShape> {
+    a [ obo:SO_0000704 m2r:Gene ] ;   # ~44,960 genes; both types always present
+    rdfs:label xsd:string ;            # official gene symbol, e.g. "TP53"
+    dct:identifier xsd:string ;        # HGNC numeric ID as string, e.g. "11998"
+    dct:description xsd:string ;       # full gene name, e.g. "tumor protein p53"
+    skos:historyNote xsd:string ;      # always "Approved" — constant on every record
+    obo:so_part_of xsd:string ? ;      # chromosomal location string, e.g. "17p13.1"; 99.9%
+    skos:altLabel xsd:string * ;       # aliases, previous symbols, associated diseases
+    dct:references @<PubMedRefShape> * ;  # supporting publications
+    rdfs:seeAlso @<ExternalRefShape> *    # cross-references to external databases
+  }
+
+  # Cross-reference nodes — accessed via rdfs:seeAlso from the gene
+  # Each node carries its database type and the identifier string
+  <ExternalRefShape> {
+    a [ idt:ncbigene      # NCBI Gene: 98.6% of genes (44,353)
+        idt:ensembl       # Ensembl gene: 94.0% (42,275)
+        idt:refseq        # RefSeq: 93.1% (41,865)
+        idt:ccds          # CCDS: 79.0% (35,506); multiple entries per gene
+        idt:uniprot       # UniProt: 45.0% (20,252)
+        idt:mgi           # MGI (mouse ortholog): 44.0% (19,798)
+        idt:rgd           # RGD (rat ortholog): 42.1% (18,946)
+        idt:mim           # OMIM: 39.1% (17,591); disease genes
+        idt:orphanet      # Orphanet: 9.8% (4,418); rare disease genes
+        idt:iuphar.receptor  # IUPHAR receptor: 8.0% (3,591)
+        idt:mirbase       # miRBase: 4.3% (1,912); microRNA genes
+        idt:lrg           # LRG: 2.9% (1,325)
+        idt:ec-code       # EC number: 2.6% (1,147); enzyme-coding genes
+        idt:ena.embl      # ENA/EMBL: ~46% (20,684)
+        idt:insdc ] ;     # INSDC: ~46% (20,684)
+    dct:identifier xsd:string   # the identifier as a string (e.g. "7157", "ENSG00000141510")
+  }
+
+  <PubMedRefShape> {
+    a [ idt:pubmed ] ;      # 23,448 PubMed reference nodes; ~35,720 dct:references triples
+    dct:identifier xsd:string
+  }
+
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix m2r:  <http://med2rdf.org/ontology/med2rdf#> .
+    @prefix obo:  <http://purl.obolibrary.org/obo/> .
+    @prefix hgnc: <http://identifiers.org/hgnc/> .
+    @prefix idt:  <http://identifiers.org/> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dct:  <http://purl.org/dc/terms/> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  entries:
+    - title: "TP53 gene — approved HGNC record with chromosomal location"
+      description: Core gene record showing symbol, name, HGNC ID, chromosomal location, and approval status.
+      rdf: |
+        hgnc:11998 a obo:SO_0000704, m2r:Gene ;
+                   rdfs:label "TP53" ;
+                   dct:identifier "11998" ;
+                   dct:description "tumor protein p53" ;
+                   obo:so_part_of "17p13.1" ;
+                   skos:historyNote "Approved" ;
+                   skos:altLabel "p53" , "LFS1" , "Li-Fraumeni syndrome" .
+
+    - title: "TP53 cross-references — typed external database links via rdfs:seeAlso"
+      description: Each external cross-reference is a typed IRI node; dct:identifier holds the string ID.
+      rdf: |
+        hgnc:11998 rdfs:seeAlso idt:ncbigene/7157 ,
+                                 idt:ensembl/ENSG00000141510 ,
+                                 idt:uniprot/P04637 ,
+                                 idt:refseq/NM_000546 ,
+                                 idt:mim/191170 ,
+                                 idt:mgi/MGI:98834 ,
+                                 idt:rgd/3889 ,
+                                 idt:lrg/LRG_321 ,
+                                 idt:orphanet/120204 .
+
+        idt:ncbigene/7157 a idt:ncbigene ; dct:identifier "7157" .
+        idt:ensembl/ENSG00000141510 a idt:ensembl ; dct:identifier "ENSG00000141510" .
+        idt:uniprot/P04637 a idt:uniprot ; dct:identifier "P04637" .
+
+    - title: "TP53 literature references — PubMed links via dct:references"
+      description: Supporting publications are typed pubmed nodes linked via dct:references.
+      rdf: |
+        hgnc:11998 dct:references idt:pubmed/2047879 ,
+                                   idt:pubmed/6396087 ,
+                                   idt:pubmed/3456488 .
+
+        idt:pubmed/2047879 a idt:pubmed ; dct:identifier "2047879" .
+
+sparql_query_examples:
+  - title: "Retrieve full gene record by gene symbol"
+    description: Look up all core metadata for a gene using its official HGNC symbol.
+    question: "What is the full HGNC record for TP53, including its chromosomal location and HGNC ID?"
+    complexity: basic
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX obo:  <http://purl.obolibrary.org/obo/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?gene ?hgnc_id ?description ?location ?alias
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?symbol { "TP53" }
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              dct:identifier ?hgnc_id ;
+              dct:description ?description .
+        OPTIONAL { ?gene obo:so_part_of ?location }
+        OPTIONAL { ?gene skos:altLabel ?alias }
+      }
+      LIMIT 20
+
+  - title: "Get all cross-references for a known HGNC gene"
+    description: Retrieve all external database identifiers linked from a specific HGNC IRI.
+    question: "What are the NCBI Gene, Ensembl, UniProt, and OMIM IDs for HGNC:11998 (TP53)?"
+    complexity: basic
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+
+      SELECT ?type ?identifier
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        # Use the HGNC IRI directly for fast lookup — no text search needed
+        <http://identifiers.org/hgnc/11998> rdfs:seeAlso ?ref .
+        ?ref a ?type ;
+             dct:identifier ?identifier .
+      }
+      LIMIT 30
+
+  - title: "Find genes on a specific chromosomal arm using STRSTARTS"
+    description: Retrieve genes mapped to a chromosomal arm by filtering the string location field.
+    question: "Which genes are located on chromosome arm 17p?"
+    complexity: intermediate
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX obo:  <http://purl.obolibrary.org/obo/>
+
+      SELECT ?gene ?symbol ?description ?location
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              dct:description ?description ;
+              obo:so_part_of ?location .
+        # so_part_of is a plain string — use STRSTARTS for chromosome-level filtering
+        FILTER(STRSTARTS(?location, "17p"))
+      }
+      LIMIT 20
+
+  - title: "Find disease-associated genes with OMIM cross-references"
+    description: Filter for genes that have an OMIM/MIM identifier, indicating disease association.
+    question: "Which human genes are linked to OMIM disease entries?"
+    complexity: intermediate
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT ?gene ?symbol ?description ?omim_id
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              dct:description ?description ;
+              rdfs:seeAlso ?mim .
+        # Navigate through the typed cross-reference node to get the OMIM ID
+        ?mim a idt:mim ;
+             dct:identifier ?omim_id .
+      }
+      LIMIT 20
+
+  - title: "Retrieve genes with Ensembl, UniProt, and NCBI Gene cross-references"
+    description: Join through multiple typed cross-reference nodes for protein-coding gene discovery.
+    question: "Which genes have Ensembl, UniProt, and NCBI Gene IDs all linked from HGNC?"
+    complexity: intermediate
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT ?gene ?symbol ?ncbigene_id ?ensembl_id ?uniprot_id
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol .
+        OPTIONAL {
+          ?gene rdfs:seeAlso ?ncbi .
+          ?ncbi a idt:ncbigene ;
+                dct:identifier ?ncbigene_id .
+        }
+        OPTIONAL {
+          ?gene rdfs:seeAlso ?ens .
+          ?ens a idt:ensembl ;
+               dct:identifier ?ensembl_id .
+        }
+        OPTIONAL {
+          ?gene rdfs:seeAlso ?uni .
+          ?uni a idt:uniprot ;
+               dct:identifier ?uniprot_id .
+        }
+      }
+      LIMIT 20
+
+  - title: "Genes with most supporting PubMed references"
+    description: Count supporting publications per gene to find highly curated or prominent entries.
+    question: "Which HGNC genes have the most linked PubMed references?"
+    complexity: advanced
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+
+      SELECT ?gene ?symbol (COUNT(DISTINCT ?ref) AS ?pub_count)
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              dct:references ?ref .
+      }
+      GROUP BY ?gene ?symbol
+      ORDER BY DESC(?pub_count)
+      LIMIT 20
+
+  - title: "Enzyme-coding genes with Orphanet links — EC code and rare disease co-annotation"
+    description: Find genes that are both enzyme-coding (have EC code cross-references) and linked to
+      Orphanet rare disease entries.
+    question: "Which human enzyme-coding genes are also associated with rare diseases in Orphanet?"
+    complexity: advanced
+    sparql: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT ?gene ?symbol ?description ?ec_num ?orphanet_id
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              dct:description ?description ;
+              rdfs:seeAlso ?ecRef ;
+              rdfs:seeAlso ?orphRef .
+        # EC code cross-reference (enzyme-coding genes, 2.6% of all)
+        ?ecRef a idt:ec-code ;
+               dct:identifier ?ec_num .
+        # Orphanet cross-reference (rare disease association, 9.8% of all)
+        ?orphRef a idt:orphanet ;
+                 dct:identifier ?orphanet_id .
+      }
+      LIMIT 20
+
+cross_database_queries:
+  shared_endpoint: primary
+  co_located_databases: [brenda, bacdive, nando, mondo, mesh, go, taxonomy, mediadive]
+  examples:
+    - title: "Link HGNC enzyme genes to BRENDA EC class entries"
+      description: |
+        Linking strategy:
+        - HGNC: genes with `rdfs:seeAlso idt:ec-code` → `dct:identifier` gives EC number string (e.g. "4.1.1.17")
+        - BRENDA: ECNumber IRIs encode the EC number in the path (https://purl.dsmz.de/brenda/ec/4.1.1.17)
+        - Join via STR comparison: BIND(STRAFTER(STR(?ec), "https://purl.dsmz.de/brenda/ec/") AS ?ecNum2),
+          then FILTER(STR(?ecNum2) = STR(?ecNum))
+        - No text search required; the join is purely IRI-string based
+      databases_used: [hgnc, brenda]
+      complexity: intermediate
+      sparql: |
+        PREFIX d3o:  <https://purl.dsmz.de/schema/>
+        PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX dct:  <http://purl.org/dc/terms/>
+        PREFIX idt:  <http://identifiers.org/>
+
+        SELECT ?geneSymbol ?ecNum ?ecLabel
+        WHERE {
+          GRAPH <http://rdfportal.org/dataset/hgnc> {
+            ?gene a m2r:Gene ;
+                  rdfs:label ?geneSymbol ;
+                  rdfs:seeAlso ?ecCode .
+            ?ecCode a idt:ec-code ;
+                    dct:identifier ?ecNum .
+          }
+          GRAPH <http://rdfportal.org/dataset/brenda> {
+            ?ec a d3o:ECNumber ;
+                rdfs:label ?ecLabel .
+            BIND(STRAFTER(STR(?ec), "https://purl.dsmz.de/brenda/ec/") AS ?ecNum2)
+            FILTER(STR(?ecNum2) = STR(?ecNum))
+          }
+        }
+        LIMIT 20
+      notes: |
+        - Linking via: EC number string extracted from BRENDA IRI vs HGNC dct:identifier
+        - MIE files checked: hgnc, brenda
+        - BRENDA EC IRI namespace: https://purl.dsmz.de/brenda/ec/
+        - HGNC EC identifier namespace: http://identifiers.org/ec-code/ (different!)
+        - BIND + FILTER(STR=STR) required because the EC numbers come as typed strings
+          from HGNC and as plain strings from STRAFTER — the STR() cast normalises them
+
+cross_references:
+  - pattern: rdfs:seeAlso
+    description: |
+      Links to typed external database nodes. Each node carries `a idt:<type>` and
+      `dct:identifier` with the database-specific ID string. Coverage varies widely
+      by database type.
+    databases:
+      genomics:
+        - "NCBI Gene: 98.6% (44,353 genes)"
+        - "Ensembl: 94.0% (42,275)"
+        - "RefSeq: 93.1% (41,865)"
+        - "CCDS: 79.0% (35,506; multiple entries per gene)"
+        - "ENA/EMBL: 46.0% (20,684)"
+        - "INSDC: 46.0% (20,684)"
+      proteins:
+        - "UniProt: 45.0% (20,252)"
+      model_organisms:
+        - "MGI (mouse): 44.0% (19,798)"
+        - "RGD (rat): 42.1% (18,946)"
+      disease:
+        - "OMIM/MIM: 39.1% (17,591)"
+        - "Orphanet: 9.8% (4,418)"
+      functional:
+        - "IUPHAR receptor: 8.0% (3,591)"
+        - "miRBase: 4.3% (1,912)"
+        - "LRG: 2.9% (1,325)"
+        - "EC code: 2.6% (1,147)"
+  - pattern: dct:references
+    description: |
+      Links to PubMed literature via typed pubmed nodes. Each node has
+      `a idt:pubmed` and `dct:identifier` with the PMID string.
+    databases:
+      literature:
+        - "PubMed: 23,448 reference nodes; 35,720 dct:references triples total"
+
+architectural_notes:
+  query_strategy:
+    - "FIRST: read the MIE file; examine shape_expressions for cross-reference node structure"
+    - "Specific IRI: use <http://identifiers.org/hgnc/{HGNC_ID}> directly for known genes"
+    - "Symbol lookup: rdfs:label exact match (gene symbols are controlled; no text search needed)"
+    - "Cross-reference: always navigate through the typed node (?gene rdfs:seeAlso ?ref . ?ref a idt:TYPE ; dct:identifier ?id)"
+    - "Chromosomal location: use STRSTARTS/FILTER on obo:so_part_of — it is a string, not an IRI"
+    - "Text search: only for skos:altLabel or dct:description free-text matching; use bif:contains"
+    - "Priority: Specific IRI > Symbol (exact label) > Typed cross-reference > Chromosomal FILTER"
+
+  schema_design:
+    - "Central entity: HGNC gene IRI (http://identifiers.org/hgnc/{ID}) with dual typing"
+    - "All external IDs are indirect: gene → rdfs:seeAlso → typed node → dct:identifier"
+    - "Gene symbol (rdfs:label) is unique and official; aliases are in skos:altLabel"
+    - "Chromosomal location (obo:so_part_of) is a band string, e.g. '17p13.1', '6q21'"
+    - "dct:references links to PubMed nodes (idt:pubmed) not directly to PMIDs"
+
+  performance:
+    - "Always include FROM <http://rdfportal.org/dataset/hgnc> or GRAPH clause"
+    - "Lookup by symbol: VALUES ?symbol { 'TP53' } is fast (indexed rdfs:label)"
+    - "Lookup by HGNC IRI: always fast — direct subject lookup"
+    - "Cross-database EC joins: use BIND+FILTER(STR=STR) not STRAFTER in FILTER alone"
+
+  data_integration:
+    - "Bridge to BRENDA: gene rdfs:seeAlso idt:ec-code → dct:identifier matches BRENDA ec/ IRI path"
+    - "Bridge to ncbigene: gene rdfs:seeAlso idt:ncbigene → dct:identifier = NCBI Gene ID"
+    - "Bridge to UniProt: gene rdfs:seeAlso idt:uniprot → dct:identifier = UniProt accession"
+    - "Bridge to OMIM: gene rdfs:seeAlso idt:mim → dct:identifier = OMIM ID string"
+
+  data_quality:
+    - "All 44,960 records have status 'Approved' — the historyNote field is not useful for filtering"
+    - "CCDS has multiple entries per gene (alternative transcripts); expect multi-row results"
+    - "UniProt coverage is ~45% — not all genes encode proteins (many are ncRNAs, pseudogenes)"
+    - "miRBase entries (4.3%) represent microRNA genes; EC code entries (2.6%) are enzyme genes"
+
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0"
+    - "Gene symbols (rdfs:label) are controlled vocabulary — exact VALUES match preferred"
+    - "Chromosomal locations are structured strings — STRSTARTS filter preferred"
+    - "Cross-reference IDs are controlled — navigate through typed nodes"
+    - "skos:altLabel is free text (aliases, disease associations) — bif:contains applicable if needed"
+
+data_statistics:
+  total_entities: 44960
+  verified_date: "2026-04-28"
+  verification_method: "Direct COUNT query on m2r:Gene instances"
+
+  coverage:
+    ncbi_gene_xref:
+      value: "98.6%"
+      calculation: "44353 / 44960 genes"
+      verified_date: "2026-04-28"
+    ensembl_xref:
+      value: "94.0%"
+      calculation: "42275 / 44960 genes"
+      verified_date: "2026-04-28"
+    refseq_xref:
+      value: "93.1%"
+      calculation: "41865 / 44960 genes"
+      verified_date: "2026-04-28"
+    uniprot_xref:
+      value: "45.0%"
+      calculation: "20252 / 44960 genes"
+      verified_date: "2026-04-28"
+    omim_xref:
+      value: "39.1%"
+      calculation: "17591 / 44960 genes"
+      verified_date: "2026-04-28"
+    chromosomal_location:
+      value: "99.9%"
+      calculation: "44941 / 44960 genes have obo:so_part_of"
+      verified_date: "2026-04-28"
+
+anti_patterns:
+  - title: "Text Search for Gene Symbols"
+    problem: "Using bif:contains or FILTER(CONTAINS()) to find genes when an exact symbol or HGNC IRI is known."
+    wrong_sparql: |
+      ?gene dct:description ?desc .
+      ?desc bif:contains "'TP53'"
+    correct_sparql: |
+      # Gene symbols are a controlled vocabulary — use exact label match
+      VALUES ?symbol { "TP53" }
+      ?gene a m2r:Gene ;
+            rdfs:label ?symbol .
+    explanation: "rdfs:label holds the official gene symbol as an exact string. VALUES + exact match is instant; text search scans descriptions and aliases unnecessarily."
+
+  - title: "Skipping Schema Check Before Text Search"
+    problem: "Using bif:contains on cross-reference identifiers instead of navigating the typed node structure."
+    wrong_sparql: |
+      ?gene rdfs:seeAlso ?ref .
+      ?ref bif:contains "'ENSG00000141510'"
+    correct_sparql: |
+      # Cross-references are IRIs with typed nodes, not text literals
+      PREFIX idt: <http://identifiers.org/>
+      ?gene rdfs:seeAlso ?ref .
+      ?ref a idt:ensembl ;
+           dct:identifier "ENSG00000141510" .
+    explanation: "rdfs:seeAlso objects are IRIs (not string literals), so bif:contains cannot match them. Navigate to the typed node and filter on dct:identifier."
+
+  - title: "Direct rdfs:seeAlso IRI Use Without Type Filter"
+    problem: "Assuming rdfs:seeAlso links directly to an identifier string, or that a single seeAlso gives the desired type."
+    wrong_sparql: |
+      # Wrong — rdfs:seeAlso gives IRIs, not strings; mixes all cross-reference types
+      ?gene rdfs:seeAlso ?ensemblId .
+      FILTER(STRSTARTS(STR(?ensemblId), "http://identifiers.org/ensembl/"))
+    correct_sparql: |
+      PREFIX idt: <http://identifiers.org/>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      ?gene rdfs:seeAlso ?ref .
+      ?ref a idt:ensembl ;
+           dct:identifier ?ensembl_id .
+    explanation: "Using the typed node pattern (?ref a idt:ensembl) is both cleaner and better indexed than IRI string filtering."
+
+  - title: "Circular Reasoning with altLabel Search"
+    problem: "Using bif:contains on aliases to count how many genes are 'tumor suppressors', when that is not a structured property."
+    wrong_sparql: |
+      ?gene skos:altLabel ?alias .
+      ?alias bif:contains "'tumor suppressor'"
+      SELECT (COUNT(?gene) AS ?count) WHERE { ... }
+    correct_sparql: |
+      # Gene functional classification is not stored in HGNC as a controlled vocabulary.
+      # Use OMIM or GO (separate databases) for functional classification.
+      # Text search on altLabel is legitimate for discovery, but cannot give complete counts.
+      ?gene skos:altLabel ?alias .
+      ?alias bif:contains "'tumor suppressor'"
+      # Note: This finds only genes where someone wrote "tumor suppressor" in an alias —
+      # it is not a comprehensive functional classification query.
+    explanation: "Gene function is not a structured property in HGNC. Text search on altLabel is exploratory, not comprehensive — document this limitation in the query comment."
+
+common_errors:
+  - error: "Empty results when querying by gene symbol"
+    causes:
+      - "Symbol is case-sensitive — HGNC symbols are uppercase (TP53, not tp53 or Tp53)"
+      - "Missing FROM <http://rdfportal.org/dataset/hgnc> graph clause"
+      - "Used FILTER(CONTAINS()) on rdfs:label instead of exact match or VALUES"
+    solutions:
+      - "Use VALUES ?symbol { 'TP53' } with exact uppercase symbol"
+      - "Always include FROM <http://rdfportal.org/dataset/hgnc> or GRAPH clause"
+      - "Check skos:altLabel if symbol lookup fails — gene may be known by a previous symbol"
+
+  - error: "Cross-reference identifier not retrievable"
+    causes:
+      - "Queried rdfs:seeAlso directly expecting a string — seeAlso returns IRIs"
+      - "Did not filter by cross-reference type (a idt:ensembl etc.)"
+      - "Multiple cross-reference types returned when only one was wanted"
+    solutions:
+      - "Always follow the typed node pattern: ?gene rdfs:seeAlso ?ref . ?ref a idt:TYPE ; dct:identifier ?id"
+      - "Filter by type (e.g. a idt:uniprot) to restrict to one database"
+      - "If multiple results per gene, use DISTINCT or GROUP BY"
+
+  - error: "Cross-database join to BRENDA returns empty results"
+    causes:
+      - "FILTER(STRAFTER(STR(?ec), prefix) = ?ecNum) fails due to xsd:string type mismatch"
+      - "Used FROM + GRAPH mixed syntax instead of pure GRAPH clauses"
+    solutions:
+      - "Use BIND(STRAFTER(STR(?ec), prefix) AS ?ecNum2) then FILTER(STR(?ecNum2) = STR(?ecNum))"
+      - "Use only GRAPH clauses (no FROM) for cross-dataset queries at the primary endpoint"

--- a/togo_mcp/data/mie/supercon.yaml
+++ b/togo_mcp/data/mie/supercon.yaml
@@ -7,9 +7,15 @@ schema_info:
     metallic superconductors. Documented properties include critical temperature (Tc and
     multiple variants), crystal structure, lattice parameters, critical magnetic fields,
     thermal properties (Debye temperature, gamma coefficient), energy gap, resistivity,
-    coherence and penetration lengths, and sample preparation conditions. Primary use
-    cases: materials informatics, ML model training for superconductor discovery,
-    and comparative Tc studies across compound families.
+    coherence and penetration lengths, and sample preparation conditions.
+    The SuperCon-ont OWL ontology (244 owl:Class entries with rdfs:label and rdfs:comment)
+    is co-loaded into the same data graph and defines the property class hierarchy
+    (SuperConductingProperty → tc, t1, t2, t3, tcsus, hc2zero, …; MagneticProperty;
+    MechanicalProperty; ThermalProperty; NormalStateProperty), enabling rdfs:subClassOf*
+    navigation to gather all transition-temperature variants or all magnetic-field
+    properties for a sample without enumerating each subclass IRI manually.
+    Primary use cases: materials informatics, ML model training for superconductor
+    discovery, and comparative Tc studies across compound families.
   keywords:
     - superconductor
     - superconducting material
@@ -32,8 +38,8 @@ schema_info:
     - http://rdfportal.org/dataset/supercon
   kw_search_tools: []
   version:
-    mie_version: "3.2"
-    mie_created: "2026-04-22"
+    mie_version: "4.0"
+    mie_created: "2026-04-28"
     data_version: "NIMS SuperCon RDF 2026 snapshot (archival; last substantive entries 2019-2020)"
     update_frequency: "Effectively frozen: 4 papers added 2021, 2 in 2022, 1 in 2023"
   license:
@@ -45,19 +51,57 @@ schema_info:
     backend: Virtuoso
 
 critical_warnings: |
-  - SCAFFOLD BUG (CRITICAL -- v3.1 queries ALL return 0 rows):
+  - SCAFFOLD BUG (CRITICAL -- queries that put IAO_0000221 on the Measurement node return 0 rows):
     IAO_0000221 is on the DATUM node, NOT the Measurement node.
-    WRONG (v3.1):  ?meas obo:IAO_0000221 ?propNode ; obo:OBI_0000299 ?datum .
-    CORRECT (v3.2): ?meas obo:OBI_0000299 ?datum .
-                    ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value .
-    SHORTCUT:       ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value .
+    WRONG:    ?meas obo:IAO_0000221 ?propNode ; obo:OBI_0000299 ?datum .
+    CORRECT:  ?meas obo:OBI_0000299 ?datum .
+              ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value .
+    SHORTCUT: ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value .
     Any query omitting this correction returns 0 rows with no error message.
 
-  - TYPO (required verbatim): dct:referecens (NOT dct:references).
+  - TYPO (required verbatim) -- INSTANCE DATA: dct:referecens (NOT dct:references).
     Using the corrected spelling returns zero results for all reference lookups.
 
-  - TYPO (required verbatim): Schema:IntermalStructure (NOT Schema:InternalStructure).
-    Instance IRIs use correctly-spelled "InternalStructure"; typo applies to class name only.
+  - TYPO ASYMMETRY (instance data vs ontology):
+    INSTANCE TYPE:  Schema:IntermalStructure (typo) -- 35,752 records.
+    ONTOLOGY CLASS: Schema:InternalStructure (correct) -- defined in the loaded ontology
+                    with rdfs:label "InternalStructure" and rdfs:comment.
+    Filter on Schema:IntermalStructure for instance queries; query Schema:InternalStructure
+    only for ontology metadata lookups (rdfs:label, rdfs:subClassOf). Mixing them
+    silently returns 0 rows.
+
+  - ONTOLOGY IS CO-LOADED INTO THE DATA GRAPH (since v4):
+    The SuperCon-ont OWL ontology lives in the SAME graph as the data
+    (<http://rdfportal.org/dataset/supercon>), not a separate ontology graph.
+    rdfs:label and rdfs:comment patterns work without any GRAPH switch.
+    244 owl:Class entries, organised under property categories:
+    SuperConductingProperty (37 subclasses), NormalStateProperty (18),
+    MechanicalProperty (12), MagneticProperty (5), ThermalProperty (9),
+    StructuralProperty (7), MaterialStructureDescriptor (5).
+
+  - VIRTUOSO PROPERTY-PATH JOIN BUG: rdfs:subClassOf* (and +) returns 0 rows when
+    the path's start variable is bound from another join (e.g. ?propNode a ?propClass
+    chained with ?propClass rdfs:subClassOf* :Class).
+    WORKS:    ?cls rdfs:subClassOf* :SCP                    (open-ended)
+    WORKS:    VALUES ?cls { :tc :t1 } . ?cls rdfs:subClassOf* :SCP   (bound by VALUES)
+    WORKS:    Schema:tc rdfs:subClassOf* :SCP               (bound by IRI)
+    BROKEN:   ?node a ?cls . ?cls rdfs:subClassOf* :SCP     (bound by triple-pattern join)
+    Workarounds: (a) use single-step rdfs:subClassOf if the hierarchy is shallow
+    (most SuperCon property categories are 1 level deep -- this works for SuperConductingProperty,
+    MagneticProperty, etc.); (b) materialise the subclass list via a separate query
+    and inline as VALUES.
+
+  - t1 / t2 / t3 / tcn SEMANTICS (now defined by ontology):
+    Schema:t1   = transition temperature (R = 0)             -- zero-resistance Tc
+    Schema:t2   = transition temperature (mid-point of R(T)) -- midpoint Tc
+    Schema:t3   = transition temperature (R = 100% normal)   -- onset Tc
+    Schema:tc   = recommended Tc                             -- the canonical value to use
+    Schema:tcn  = lowest temperature measured (NOT superconducting)
+                  -- a lower bound for Tc when nothing was observed
+    Schema:tcsus = Tc from magnetic susceptibility measurement
+    Empirical note: in the current snapshot t2 == tc for ALL records (0 mismatches)
+    despite ontologically distinct semantics; treat t2 as a derived duplicate of tc
+    for ML and omit it from feature matrices.
 
   - RETRACTED PAPERS (no flags in database):
     C-S-H at ~287.7 K: ref NAT586000373 -- retracted September 2022.
@@ -76,6 +120,8 @@ shape_expressions: |
   PREFIX dct:    <http://purl.org/dc/terms/>
   PREFIX bibo:   <http://purl.org/ontology/bibo/>
   PREFIX prism:  <http://prismstandard.org/namespaces/basic/2.0/>
+  PREFIX owl:    <http://www.w3.org/2002/07/owl#>
+  PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 
   # -- CENTRAL ENTITY: 165,969 instances ---------------------------------------
   # 80.8% (134,039) are skeleton nodes with no name/formula/Tc data.
@@ -94,20 +140,28 @@ shape_expressions: |
   <ElementShape> { a [ Schema:element ] ; sio:SIO_000300 xsd:string }
 
   # -- TEMPERATURE PROPERTIES (all attach to sample via sio:SIO_000008) --------
-  # Schema:tc      26,358  primary critical temperature; use this for Tc queries
-  # Schema:t2      17,117  EMPIRICALLY IDENTICAL to tc in ALL records -- data duplicate
-  #                        (0 records with t2 != tc; verified); omit from ML feature matrices
-  # Schema:t1       4,051  variant (semantics undocumented)
-  # Schema:t3       4,606  variant (semantics undocumented)
-  # Schema:tcn      4,641  Tc variant (semantics undocumented)
-  # Schema:tcsus    5,624  Tc from magnetic susceptibility
+  # Ontology defines all semantics; classes are subclasses of SuperConductingProperty
+  # (tc, t1, t2, t3, tcn, tcsus) or MagneticProperty (curiet, curiec, neelt).
+  # Schema:tc      26,358  recommended Tc (the canonical value for analysis)
+  # Schema:t2      17,117  Tc at midpoint of R(T) transition;
+  #                        EMPIRICALLY IDENTICAL to tc in this snapshot (0 mismatches);
+  #                        treat as derived duplicate; omit from ML feature matrices.
+  # Schema:t1       4,051  Tc at zero resistance (R = 0)
+  # Schema:t3       4,606  Tc at onset (R = 100% normal-state value)
+  # Schema:tcn      4,641  lowest temperature measured WITHOUT observing superconductivity
+  #                        (lower bound -- not a positive Tc detection)
+  # Schema:tcsus    5,624  Tc from magnetic susceptibility measurement
   # Schema:curiet   1,198  Curie temperature
-  # Schema:curiec     214  Curie constant (semantics undocumented)
+  # Schema:curiec     214  Curie constant
   # Schema:neelt    1,490  Neel temperature
   <TemperaturePropertyShape> {
     a [ Schema:tc Schema:t2 Schema:t1 Schema:t3 Schema:tcn Schema:tcsus
         Schema:curiet Schema:curiec Schema:neelt ]
-    # Values accessed via Measurement scaffold (see below)
+    # Values accessed via Measurement scaffold (see below).
+    # To gather ALL SuperConductingProperty subclasses for a sample, use SINGLE-STEP
+    # rdfs:subClassOf (not subClassOf*); see critical_warnings for the Virtuoso quirk:
+    #   ?propNode a ?propClass .
+    #   ?propClass rdfs:subClassOf Schema:SuperConductingProperty ; rdfs:label ?lbl .
   }
 
   # -- CRITICAL FIELD PROPERTIES -----------------------------------------------
@@ -131,31 +185,32 @@ shape_expressions: |
   }
 
   # -- CRYSTALLOGRAPHY ---------------------------------------------------------
-  # Schema:lata / latb / latc  lattice parameters a, b, c
+  # Schema:lata / latb / latc  lattice parameters a, b, c (subclasses of LatticeConstant)
   # UNIT WARNING (sio:SIO_000221 on datum):
   #   lata: "A"=9,115  ""=3,946  "nm"=65   (nm = 10x Angstrom -- scale error if mixed!)
   #   latb: "A"=1,788  ""=1,731  "nm"=7
   #   latc: "A"=7,686  ""=4,001  "nm"=83
   #   Always inspect or filter the unit field before comparing lattice values.
   # Schema:spaceg  ~9,000  space group string
-  # Schema:str3            structure type string
-  # Schema:oz              oxygen stoichiometry z
-  # Schema:dens            density
+  # Schema:str3            common name of structure (subclass of CrystalState)
+  # Schema:oz              oxygen stoichiometry z (subclass of MaterialProperty)
+  # Schema:dens            density (g/cm^3; subclass of MechanicalProperty)
   <CrystallographyPropertyShape> {
     a [ Schema:lata Schema:latb Schema:latc Schema:spaceg Schema:str3 Schema:oz Schema:dens ]
   }
 
   # -- CRYSTAL STRUCTURE NODE --------------------------------------------------
-  # Class typo: Schema:IntermalStructure (required verbatim; see critical_warnings)
-  # Instance IRIs use correctly-spelled "InternalStructure"
+  # Class IRI ASYMMETRY (see critical_warnings):
+  #   INSTANCE TYPE:  Schema:IntermalStructure (typo) -- USE FOR DATA QUERIES
+  #   ONTOLOGY CLASS: Schema:InternalStructure (correct spelling) -- only for ontology lookups
   # Structure type vocabulary:
   #   Named IRIs: Schema:str1_01..07 -- 6,813 records (19.1% of 35,752 structure nodes)
   #   Blank nodes: nodeID://b...      -- 28,939 records (80.9%)
   # Any IRI-based filter silently discards 80.9% of structure data.
   <IntermalStructureShape> {
-    a [ Schema:IntermalStructure ] ;
-    obo:BFO_0000051 IRI ?  ;  # named IRI (19.1%) or blank node (80.9%)
-    obo:RO_0000058  IRI *    # links to lattice parameter property nodes
+    a [ Schema:IntermalStructure ] ;          # typo'd class (instance type)
+    obo:BFO_0000051 IRI ?  ;                  # named IRI (19.1%) or blank node (80.9%)
+    obo:RO_0000058  IRI *                     # links to lattice parameter property nodes
   }
 
   # -- MEASUREMENT SCAFFOLD (96,167 Schema:Measurement nodes) ------------------
@@ -205,6 +260,21 @@ shape_expressions: |
     dct:creator                 xsd:string ;
     dct:title                   xsd:string ;
     prism:publicationDate       xsd:string ?   # 4-digit year; 32 records have empty string
+  }
+
+  # -- ONTOLOGY NODE (244 owl:Class entries co-loaded into the data graph) -----
+  # Use to translate a property class IRI into human-readable semantics, or to
+  # gather siblings of a class via rdfs:subClassOf*.
+  # Top-level property categories (with subclass counts):
+  #   SuperConductingProperty  37    NormalStateProperty  18
+  #   MechanicalProperty       12    MagneticProperty      5
+  #   ThermalProperty           9    StructuralProperty    7
+  #   MaterialStructureDescriptor 5  Component            11
+  <OntologyClassShape> {
+    a [ owl:Class ] ;
+    rdfs:label    xsd:string ;
+    rdfs:comment  xsd:string ?  ;
+    rdfs:subClassOf IRI *
   }
 
 sample_rdf_entries:
@@ -446,36 +516,42 @@ sparql_query_examples:
       ORDER BY DESC(?tcVal)
       LIMIT 10
 
-  - title: Average and maximum Tc grouped by named crystal structure type
+  - title: All superconducting properties for a sample with ontology-defined semantics
     description: |
-      Groups samples by the 7 named structure IRIs (Schema:str1_01..07).
-      SCOPE LIMITATION: named IRIs cover only 19.1% of structure data (6,813 of 35,752).
-      The remaining 80.9% (28,939 records) use blank nodes and are excluded by design.
-    question: What is the average and maximum Tc for each named crystal structure type?
+      Demonstrates the new capability enabled by the co-loaded SuperCon-ont ontology:
+      collect every direct subclass of Schema:SuperConductingProperty (tc, t1, t2, t3,
+      tcn, tcsus, tcwidth, hc1zero, hc2zero, gap, penet, cohere, dhc2dt, …) in one
+      shot, with each value annotated by the ontology's rdfs:label and rdfs:comment.
+      Replaces the v3 "average Tc by named structure" query, which was limited to
+      the 19.1% of structure data with named IRIs.
+
+      VIRTUOSO QUIRK: a single-step rdfs:subClassOf is used (not rdfs:subClassOf*).
+      Property paths combined with a join-bound ?propClass return 0 rows on this
+      endpoint -- see common_errors. SuperCon's hierarchy is shallow (one level from
+      property category to leaf), so single-step is sufficient.
+    question: What are all superconducting properties for sample msc_om0000949 and what does each one mean?
     complexity: advanced
     sparql: |
+      PREFIX smp:    <http://dice.nims.go.jp/ontology/SuperCon-ont/supercon-rdf/smp#>
       PREFIX sio:    <http://semanticscience.org/resource/>
       PREFIX Schema: <http://dice.nims.go.jp/ontology/SuperCon-ont/Schema#>
       PREFIX obo:    <http://purl.obolibrary.org/obo/>
+      PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT ?strType (AVG(?tcVal) AS ?avgTc) (MAX(?tcVal) AS ?maxTc) (COUNT(?sample) AS ?count)
+      SELECT ?propLabel ?propComment ?value ?unit
       FROM <http://rdfportal.org/dataset/supercon>
       WHERE {
-        ?sample a Schema:OxideAndMetallic ;
-                sio:SIO_000008 ?strNode, ?tcProp .
-        ?strNode a Schema:IntermalStructure ;
-                 obo:BFO_0000051 ?strType .
-        VALUES ?strType {
-          Schema:str1_01 Schema:str1_02 Schema:str1_03
-          Schema:str1_04 Schema:str1_05 Schema:str1_06 Schema:str1_07
-        }
-        ?tcProp a Schema:tc .
-        ?tcDatum obo:IAO_0000221 ?tcProp ;
-                 sio:SIO_000300 ?tcVal .
+        smp:msc_om0000949 sio:SIO_000008 ?propNode .
+        ?propNode a ?propClass .
+        ?propClass rdfs:subClassOf Schema:SuperConductingProperty ;
+                   rdfs:label ?propLabel .
+        OPTIONAL { ?propClass rdfs:comment ?propComment . }
+        ?datum obo:IAO_0000221 ?propNode ;
+               sio:SIO_000300 ?value .
+        OPTIONAL { ?datum sio:SIO_000221 ?unit . }
       }
-      GROUP BY ?strType
-      ORDER BY DESC(?avgTc)
-      LIMIT 20
+      ORDER BY ?propLabel
+      LIMIT 30
 
 cross_database_queries:
   shared_endpoint: nims
@@ -518,11 +594,13 @@ cross_references:
 architectural_notes:
   query_strategy:
     - "MANDATORY FIRST STEP: read critical_warnings -- the scaffold bug (IAO_0000221 on wrong node) causes silent 0-row failures"
-    - "CORRECTED scaffold (v3.2): ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value"
+    - "CORRECTED scaffold: ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value"
+    - "ONTOLOGY-DRIVEN DISCOVERY (new in v4): the SuperCon-ont OWL ontology is co-loaded into the data graph. Use SINGLE-STEP rdfs:subClassOf to gather siblings of a property class (all SuperConductingProperty subclasses, all MagneticProperty subclasses, etc.) instead of enumerating Schema:tcN class IRIs by hand. Property paths (subClassOf*/+) combined with a join-bound class variable are broken on Virtuoso -- see critical_warnings."
+    - "ONTOLOGY METADATA: every Schema: property class carries rdfs:label and rdfs:comment with human-readable semantics (e.g. tc = 'Tc (recommended)'; t1 = 'transition temperature (R = 0)'). Project these alongside values for self-documenting result sets."
     - "Exploratory: use SPARQL with LIMIT 10 (no keyword search API) to discover IRIs and values"
     - "Property type selection: use typed predicates (a Schema:tc, a Schema:hc2zero, etc.) -- no text search needed"
     - "Text search: bif:contains (Virtuoso, indexed) ONLY for Schema:SamplePreparation rdfs:comment -- the sole unstructured field"
-    - "Priority: Specific IRIs > Typed predicates > Graph navigation > bif:contains (only SamplePrep)"
+    - "Priority: Specific IRIs > Typed predicates > single-step rdfs:subClassOf hierarchy navigation > bif:contains (only SamplePrep)"
 
   schema_design:
     - "Central entity: Schema:OxideAndMetallic (165,969 instances); 80.8% skeleton nodes without measurement data"
@@ -532,6 +610,7 @@ architectural_notes:
     - "Two undocumented-but-large namespaces: cmp# (154,792 composition triples) and prc# (22,165 SamplePrep nodes)"
     - "Crystal structure types: str1_01..07 (19.1% named IRIs) + blank nodes (80.9%)"
     - "150+ Schema: property classes; this MIE covers all major physical categories"
+    - "Ontology layer (v4): 244 owl:Class entries with rdfs:label/comment; top-level categories SuperConductingProperty (37), NormalStateProperty (18), MechanicalProperty (12), ThermalProperty (9), StructuralProperty (7), MagneticProperty (5), MaterialStructureDescriptor (5), Component (11), ElementComposition (11)"
 
   performance:
     - "Always include a Schema:OxideAndMetallic type filter and FROM <http://rdfportal.org/dataset/supercon>"
@@ -576,7 +655,9 @@ data_statistics:
     structure_named_IRI_type: "6,813 (19.1% of 35,752 structure records)"
     structure_blank_node_type: "28,939 (80.9% of 35,752 structure records)"
     cmp_composition_links: 154792
-  verified_date: "2026-04-20"
+    ontology_owl_classes: 244
+    ontology_top_level_property_categories: 8
+  verified_date: "2026-04-28"
   verification_method: "Direct COUNT queries on each class against the supercon named graph"
   coverage:
     samples_with_Tc: "15.9% of OxideAndMetallic samples (26,358 / 165,969)"
@@ -588,7 +669,7 @@ data_statistics:
     verified_date: "2026-04-22"
 
 anti_patterns:
-  - title: Using the v3.1 (wrong) measurement scaffold
+  - title: Putting IAO_0000221 on the Measurement node instead of the Datum node
     problem: |
       Placing IAO_0000221 on the Measurement node instead of the datum node.
       This pattern returns 0 rows without an error -- a silent failure.
@@ -604,7 +685,7 @@ anti_patterns:
              sio:SIO_000300 ?value .
       # SHORTCUT (no Measurement hop needed):
       # ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value .
-    explanation: "Always verify the scaffold from critical_warnings before writing queries. The v3.1 description had the predicate on the wrong node."
+    explanation: "Always verify the scaffold from critical_warnings before writing queries. IAO_0000221 ('is about') belongs on the Datum, pointing to the property class node."
 
   - title: Text search for fields with typed predicates
     problem: |
@@ -662,16 +743,17 @@ anti_patterns:
     explanation: "Unit distribution for lata: A=9,115, empty=3,946 (assume A), nm=65. Always inspect sio:SIO_000221 on lattice datum nodes."
 
 common_errors:
-  - error: All measurement queries return 0 rows
+  - error: Query returns 0 rows with no error message
     causes:
-      - "Using the v3.1 scaffold with IAO_0000221 on the Measurement node (silent failure)"
+      - "IAO_0000221 placed on the Measurement node instead of the Datum node (scaffold bug)"
       - "Using dct:references instead of dct:referecens (corrected spelling silently matches nothing)"
-      - "Using Schema:InternalStructure instead of Schema:IntermalStructure for class assertions"
+      - "Using Schema:InternalStructure (correct spelling) for instance type assertion -- instance data uses the typo'd Schema:IntermalStructure"
+      - "rdfs:subClassOf* / + property path with a class variable bound from another join (Virtuoso optimizer bug)"
     solutions:
       - "Scaffold: ?datum obo:IAO_0000221 ?propNode ; sio:SIO_000300 ?value (IAO_0000221 on DATUM)"
       - "Reference predicate: dct:referecens (four-letter suffix 'cens', not 'nces')"
-      - "Structure class: Schema:IntermalStructure ('Intermal', not 'Internal')"
-      - "Instance IRIs (str:..._InternalStructure) are correctly spelled; typo is class name only"
+      - "Instance type: Schema:IntermalStructure (typo); ontology lookups use Schema:InternalStructure"
+      - "For class hierarchy navigation, use single-step rdfs:subClassOf (works for SuperCon's shallow hierarchy), or pre-materialise the subclass list and inline as VALUES"
 
   - error: High-Tc outliers from retracted papers included in analysis
     causes:

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -234,7 +234,8 @@ schema_info:
     - [keyword2]
   # 1-3 entries from the controlled taxonomy: protein, gene, variant, compound,
   # drug_target, pathway, reaction, ontology, structure, literature, taxonomy,
-  # microbe, glycan, antimicrobial, sequence, disease, materials, physics.
+  # microbe, glycan, antimicrobial, sequence, disease, materials, physics,
+  # enzymology, genomics.
   # Tag only categories that genuinely characterize the database.
   categories:
     - [category1]

--- a/togo_mcp/data/resources/endpoints.csv
+++ b/togo_mcp/data/resources/endpoints.csv
@@ -23,3 +23,6 @@ medgen,https://rdfportal.org/ncbi/sparql,ncbi,ncbi_esearch
 ddbj,https://rdfportal.org/ddbj/sparql,ddbj,sparql
 glycosmos,https://ts.glycosmos.org/sparql,glycosmos,sparql
 supercon,https://rdfportal.org/nims/sparql,nims,sparql
+bgee,https://rdfportal.org/sib/sparql,sib,sparql
+brenda,https://rdfportal.org/primary/sparql,primary,sparql
+hgnc,https://rdfportal.org/primary/sparql,primary,sparql


### PR DESCRIPTION
## Summary

Three coherent commits that together onboard three new RDF databases, refresh SuperCon to consume its newly-loaded ontology, and grow the controlled category taxonomy to absorb them cleanly.

### 1. Extend MIE category taxonomy (`e02c89c`)
Adds `enzymology` (enzyme function: kinetics, EC numbers, substrates — distinct from chemistry-equation `reaction`) and `genomics` (genome-scale / nomenclature — distinct from per-gene `gene`) to the spec's controlled-taxonomy table, the inline list in `MIE_prompt.md`, and the bootstrap script's `CATEGORY_RULES`.

### 2. SuperCon MIE v4.0 (`3389ef5`)
The SuperCon-ont OWL ontology (244 owl:Class entries) is now co-loaded into the data graph. Resolves previously-undocumented temperature semantics (`t1` = R=0 transition, `t2` = midpoint, `t3` = onset, `tcn` = lower-bound non-superconducting), reframes the `IntermalStructure`-typo trap as an asymmetry between instance type and ontology class, replaces the limited "Tc by named structure" query with an ontology-navigation query that surfaces each property's `rdfs:label` and `rdfs:comment`, and documents a Virtuoso property-path-join bug (workaround: single-step `rdfs:subClassOf`).

### 3. Onboard Bgee, BRENDA, HGNC (`993b3a1`)
Endpoint registrations and full MIE files for three databases already exposed on RDF Portal but not yet documented for TogoMCP. Categories use the existing taxonomy + the two new entries:
- **Bgee** (sib) — gene expression; categories `[gene, taxonomy]`. Documents the dual taxon-IRI namespaces, OMA gene-IRI scheme, polymorphic `genex:isExpressedIn`, and a cross-graph Bgee+UniProt query.
- **BRENDA** (primary) — enzyme database; categories `[reaction, protein, enzymology]`.
- **HGNC** (primary) — official human gene nomenclature; categories `[gene, genomics]`.

## Test plan

- [ ] `find_databases(category="enzymology")` → `[brenda]`
- [ ] `find_databases(category="genomics")` → `[hgnc]`
- [ ] `find_databases(category="reaction")` → `[brenda, rhea]`
- [ ] `find_databases(category="gene")` → includes `bgee`, `hgnc` alongside existing entries
- [ ] `list_categories()` returns 20 categories with no fragmented (single-DB-only) buckets that could have been merged with existing ones.
- [ ] SuperCon query 7 returns each property with its `rdfs:label` + `rdfs:comment` for sample `msc_om0000949`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)