### PR TITLE
run_sparql: surface endpoint diagnostic on HTTP errors

### DIFF
--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -168,11 +168,42 @@ async def execute_sparql(
     """
     url = resolve_endpoint_url(database, endpoint_name, endpoint_url)
 
-    response = await _sparql_client.post(
-        url, data={"query": sparql_query}, headers={"Accept": "text/csv"}
+    try:
+        response = await _sparql_client.post(
+            url, data={"query": sparql_query}, headers={"Accept": "text/csv"}
+        )
+    except httpx.TimeoutException as exc:
+        raise ValueError(
+            f"SPARQL endpoint at {url} timed out after {_sparql_client.timeout.read}s. "
+            "The query is likely too heavy. Add LIMIT, narrow with specific IRIs or GRAPH "
+            "clauses, or split into smaller queries. Do not retry the same query without "
+            f"changes. ({exc.__class__.__name__})"
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise ValueError(
+            f"SPARQL endpoint at {url} could not be reached: "
+            f"{exc.__class__.__name__}: {exc}"
+        ) from exc
+
+    if response.is_success:
+        return response.text
+
+    body = response.text.strip()
+    snippet = body[:1500] + ("\n…[truncated]" if len(body) > 1500 else "")
+    if 400 <= response.status_code < 500:
+        raise ValueError(
+            f"SPARQL endpoint at {url} returned HTTP {response.status_code} (bad query). "
+            f"Endpoint diagnostic:\n{snippet}\n\n"
+            "The endpoint message above usually names the exact line/column. Common causes: "
+            "syntax error (missing brace/comma), undefined namespace prefix, unsupported "
+            "function. Fix the query — do not retry the same text."
+        )
+    raise ValueError(
+        f"SPARQL endpoint at {url} returned HTTP {response.status_code} (server error). "
+        f"Endpoint message:\n{snippet}\n\n"
+        "This may be transient or indicate the query is too heavy. Consider adding LIMIT, "
+        "stronger filters (specific IRIs, GRAPH clauses), or splitting the query."
     )
-    response.raise_for_status()
-    return response.text
 
 
 # The Primary MCP server


### PR DESCRIPTION
## Summary

`response.raise_for_status()` discards the SPARQL endpoint's response body, leaving the agent with just `Client error '400 Bad Request' for url ...`. RDF Portal endpoints (Virtuoso) return informative `text/plain` bodies that name the exact line, column, and offending token — this PR surfaces that diagnostic to the agent so it can self-correct.

**Before** (what the agent saw):
```
Client error '400 Bad Request' for url 'https://rdfportal.org/sib/sparql'
```

**After**:
```
SPARQL endpoint at https://rdfportal.org/sib/sparql returned HTTP 400 (bad query).
Endpoint diagnostic:
Virtuoso 37000 Error SP030: SPARQL compiler, line 1: Undefined namespace prefix at 'xx' before '?o'

SPARQL query:
SELECT * WHERE { ?s xx:foo ?o } LIMIT 1

The endpoint message above usually names the exact line/column. Common causes:
syntax error (missing brace/comma), undefined namespace prefix, unsupported
function. Fix the query — do not retry the same text.
```

## Behaviour by branch

- **2xx** — return body unchanged.
- **4xx** — `ValueError` with status + endpoint body (truncated at 1.5k chars) + fix-the-query hint.
- **5xx** — `ValueError` with body + "transient or too-heavy; add LIMIT/filters" hint.
- **`httpx.TimeoutException`** — `ValueError` reports the read timeout duration with a query-narrowing hint.
- **Other `httpx.HTTPError`** — concise reachability message.
- All paths chain the original exception via `raise … from exc`.

## Out of scope

Does **not** address silent-0-row failures (HTTP 200 + header-only CSV). That's the #1 failure pattern documented in several MIE `critical_warnings` (wrong namespace, typo'd predicate, missing GRAPH) but discussed and deferred — see the inline note in the commit message.

## Test plan

- [ ] Syntax error returns Virtuoso's line/column message.
- [ ] Undefined prefix returns the prefix name and surrounding context.
- [ ] Successful query still returns CSV body unchanged.
- [ ] Timeout simulation produces the duration-aware message (covered by code path; not exercised in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)