### PR TITLE
Surface upstream API errors; drop redundant ncbi_ prefix

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -164,7 +164,7 @@ async def search_uniprot_entity(
     }
     try:
         response = await _uniprot_client.get("/uniprotkb/search", params=params)
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="UniProt search")
         data = response.text
         return data
     except httpx.HTTPError as e:
@@ -190,7 +190,7 @@ async def search_chembl_generic(entity_type: str, query: str, limit: int = 20) -
         response = await _chembl_client.get(
             f"/chembl/api/data/{entity_type}/search.json", params=params
         )
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="ChEMBL search")
         return response.json()
     except httpx.HTTPError as e:
         print(f"Error querying ChEMBL {entity_type}: {e}")
@@ -464,7 +464,7 @@ async def get_pubchem_compound_id(compound_name: str) -> str:
     url = f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound_name}/cids/JSON"
     try:
         response = await _pubchem_client.get(url)
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="PubChem CID lookup")
         return response.text
     except httpx.HTTPError as e:
         print(f"Error fetching PubChem compound ID for {compound_name}: {e}")
@@ -486,7 +486,7 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
     params = {"id": pubchem_compound_id}
     try:
         response = await _pubchem_client.get(url, params=params)
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="PubChem compound attributes")
         return response.text
     except httpx.HTTPError as e:
         print(
@@ -555,7 +555,7 @@ async def search_pdb_entity(
         response = await _pdbj_client.get(
             f"/rest/newweb/search/{db}", params={"query": query}
         )
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="PDBj search")
         payload = response.json()
         total_results = payload.get("total", 0)
         result_list = [
@@ -610,7 +610,7 @@ async def search_mesh_descriptor(
     params = {"label": query, "match": "contains", "limit": limit}
     try:
         response = await _mesh_client.get("/mesh/lookup/descriptor", params=params)
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="MeSH descriptor lookup")
         return response.text
     except httpx.HTTPError as e:
         print(f"Error searching MeSH for {query}: {e}")
@@ -706,7 +706,7 @@ async def search_reactome_entity(
             params=params,
             headers={"Accept": "application/json"},
         )
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="Reactome search")
         data = response.json()
     except httpx.HTTPError as e:
         print(f"Error querying Reactome: {e}")
@@ -789,7 +789,7 @@ async def search_rhea_entity(
 
     try:
         response = await _rhea_client.get("/rhea", params=params)
-        response.raise_for_status()
+        raise_for_status_with_body(response, context="Rhea search")
 
         # Parse TSV response
         lines = response.text.strip().split("\n")

--- a/togo_mcp/ncbi_tools.py
+++ b/togo_mcp/ncbi_tools.py
@@ -25,7 +25,7 @@ from fastmcp import FastMCP
 import httpx
 from mcp.types import TextContent
 
-from .server import toolcall_log
+from .server import raise_for_status_with_body, toolcall_log
 
 # Get API key from environment
 NCBI_API_KEY = os.environ.get("NCBI_API_KEY")
@@ -239,7 +239,15 @@ async def _ncbi_esearch_api(
         async with httpx.AsyncClient(timeout=30.0) as client:
             try:
                 response = await client.get(base_url, params=params)
-                response.raise_for_status()
+                raise_for_status_with_body(
+                    response,
+                    context="NCBI esearch",
+                    client_error_hint=(
+                        "Verify db (e.g. gene, pubmed, clinvar) and term syntax. "
+                        "Use field tags like nifH[Gene Name] AND Archaea[Organism] "
+                        "for precision."
+                    ),
+                )
                 data = response.json()
 
                 # Check for errors in NCBI response
@@ -555,7 +563,14 @@ async def ncbi_esummary(
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.get(base_url, params=params)
-                response.raise_for_status()
+                raise_for_status_with_body(
+                    response,
+                    context="NCBI esummary",
+                    client_error_hint=(
+                        "Verify db and ids. ids must be a comma-separated list of "
+                        "valid identifiers for the chosen db."
+                    ),
+                )
                 data = response.json()
 
                 # Format the response nicely
@@ -631,7 +646,14 @@ async def ncbi_efetch(
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.get(base_url, params=params)
-                response.raise_for_status()
+                raise_for_status_with_body(
+                    response,
+                    context="NCBI efetch",
+                    client_error_hint=(
+                        "Verify db, ids, rettype, and retmode. Different db's accept "
+                        "different rettype/retmode combinations."
+                    ),
+                )
                 return [TextContent(type="text", text=response.text)]
 
         except Exception as e:

--- a/togo_mcp/ncbi_tools.py
+++ b/togo_mcp/ncbi_tools.py
@@ -335,7 +335,7 @@ def _normalize_ids(ids: str | list[str]) -> list[str]:
 
 
 @ncbi_mcp.tool()
-async def ncbi_esearch(
+async def esearch(
     database: str = "",
     query: str = "",
     max_results: int = 20,
@@ -475,7 +475,7 @@ async def ncbi_esearch(
 
 
 @ncbi_mcp.tool()
-async def ncbi_list_databases() -> list[TextContent]:
+async def list_databases() -> list[TextContent]:
     """
     List all supported NCBI databases with descriptions and example queries.
 
@@ -508,7 +508,7 @@ async def ncbi_list_databases() -> list[TextContent]:
 
 # Additional utility functions for future use
 @ncbi_mcp.tool()
-async def ncbi_esummary(
+async def esummary(
     database: str = "",
     ids: str | list[str] = "",
     db: str = "",
@@ -586,7 +586,7 @@ async def ncbi_esummary(
 
 
 @ncbi_mcp.tool()
-async def ncbi_efetch(
+async def efetch(
     database: str = "",
     ids: str | list[str] = "",
     rettype: str = "xml",

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -144,6 +144,54 @@ def resolve_endpoint_url(database: str, endpoint_name: str, endpoint_url: str) -
     )
 
 
+def raise_for_status_with_body(
+    response: httpx.Response,
+    *,
+    context: str = "",
+    client_error_hint: str | None = None,
+    server_error_hint: str | None = None,
+    body_max: int = 1500,
+) -> None:
+    """Drop-in replacement for ``response.raise_for_status()``.
+
+    Surfaces the upstream response body in the raised ``ValueError`` so that
+    when an external API replies with a useful diagnostic
+    (e.g. Virtuoso's ``SPARQL compiler, line 1: Undefined namespace prefix``,
+    or TogoID's ``{"message": "no route: pubchem <> chebi"}``), the calling
+    agent sees that diagnostic instead of httpx's generic
+    ``Client error '4xx' for url ...``.
+
+    Args:
+        response: The httpx response to check.
+        context: Short label identifying the operation (e.g. "TogoID convertId").
+        client_error_hint: Appended on 4xx responses; if None, a generic hint is used.
+        server_error_hint: Appended on 5xx responses; if None, a generic hint is used.
+        body_max: Truncate the body at this character count.
+
+    Raises:
+        ValueError: If the response is non-2xx.
+    """
+    if response.is_success:
+        return
+    body = response.text.strip()
+    snippet = body[:body_max] + ("\n…[truncated]" if len(body) > body_max else "")
+    label = f"{context} " if context else ""
+    if 400 <= response.status_code < 500:
+        hint = client_error_hint or (
+            "The response body above usually states the exact problem. "
+            "Verify input parameters and fix the request — do not retry the same input."
+        )
+    else:
+        hint = server_error_hint or (
+            "This may be transient or indicate the request is too heavy. "
+            "Consider narrowing scope or adding limits before retrying."
+        )
+    raise ValueError(
+        f"{label}HTTP {response.status_code} from {response.url}.\n"
+        f"Response body:\n{snippet}\n\n{hint}"
+    )
+
+
 # Making this a @mcp.tool() becomes an error, so we keep it as a function.
 async def execute_sparql(
     sparql_query: str,
@@ -185,25 +233,21 @@ async def execute_sparql(
             f"{exc.__class__.__name__}: {exc}"
         ) from exc
 
-    if response.is_success:
-        return response.text
-
-    body = response.text.strip()
-    snippet = body[:1500] + ("\n…[truncated]" if len(body) > 1500 else "")
-    if 400 <= response.status_code < 500:
-        raise ValueError(
-            f"SPARQL endpoint at {url} returned HTTP {response.status_code} (bad query). "
-            f"Endpoint diagnostic:\n{snippet}\n\n"
-            "The endpoint message above usually names the exact line/column. Common causes: "
-            "syntax error (missing brace/comma), undefined namespace prefix, unsupported "
-            "function. Fix the query — do not retry the same text."
-        )
-    raise ValueError(
-        f"SPARQL endpoint at {url} returned HTTP {response.status_code} (server error). "
-        f"Endpoint message:\n{snippet}\n\n"
-        "This may be transient or indicate the query is too heavy. Consider adding LIMIT, "
-        "stronger filters (specific IRIs, GRAPH clauses), or splitting the query."
+    raise_for_status_with_body(
+        response,
+        context="SPARQL endpoint",
+        client_error_hint=(
+            "The endpoint diagnostic above usually names the exact line/column. "
+            "Common causes: syntax error (missing brace/comma), undefined namespace "
+            "prefix, unsupported function. Fix the query — do not retry the same text."
+        ),
+        server_error_hint=(
+            "This may be transient or indicate the query is too heavy. Consider "
+            "adding LIMIT, stronger filters (specific IRIs, GRAPH clauses), or "
+            "splitting the query."
+        ),
     )
+    return response.text
 
 
 # The Primary MCP server

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -74,7 +74,7 @@ async def getAllRelation() -> dict:
     """
     toolcall_log("getAllRelation")
     response = await _client.get("/config/relation")
-    response.raise_for_status()
+    raise_for_status_with_body(response, context="TogoID getAllRelation")
     return response.json()
 
 
@@ -105,7 +105,14 @@ async def getRelation(source: str, target: str) -> list:
     """
     toolcall_log("getRelation")
     response = await _client.get(f"/config/relation/{source}-{target}")
-    response.raise_for_status()
+    raise_for_status_with_body(
+        response,
+        context="TogoID getRelation",
+        client_error_hint=(
+            "Verify both source and target dataset names. Use getAllRelation() "
+            "to list valid routes."
+        ),
+    )
     return response.json()
 
 
@@ -131,7 +138,7 @@ async def getAllDataset() -> dict:
     """
     toolcall_log("getAllDataset")
     response = await _client.get("/config/dataset")
-    response.raise_for_status()
+    raise_for_status_with_body(response, context="TogoID getAllDataset")
     return response.json()
 
 
@@ -156,7 +163,13 @@ async def getDataset(dataset: str) -> dict:
     """
     toolcall_log("getDataset")
     response = await _client.get(f"/config/dataset/{dataset}")
-    response.raise_for_status()
+    raise_for_status_with_body(
+        response,
+        context="TogoID getDataset",
+        client_error_hint=(
+            "Verify the dataset name. Use getAllDataset() to list valid datasets."
+        ),
+    )
     return response.json()
 
 
@@ -173,7 +186,7 @@ async def getDescription() -> dict:
     """
     toolcall_log("getDescription")
     response = await _client.get("/config/descriptions")
-    response.raise_for_status()
+    raise_for_status_with_body(response, context="TogoID getDescription")
     return response.json()
 
 
@@ -240,7 +253,16 @@ async def convertId(
     }
 
     response = await _client.get("/convert", params=params)
-    response.raise_for_status()
+    raise_for_status_with_body(
+        response,
+        context="TogoID convertId",
+        client_error_hint=(
+            "Verify the route exists (getAllRelation lists valid routes) and that "
+            "the IDs match the source dataset's expected format (getDataset shows "
+            "the format pattern). Common cause: wrong source/target ordering, or "
+            "no direct route between the two datasets."
+        ),
+    )
     return response.json().get("results")
 
 
@@ -274,5 +296,12 @@ async def countId(source: str, target: str, ids: str | list[str]) -> dict:
     response = await _client.get(
         f"/count/{source}-{target}", params={"ids": _ids_to_csv(ids)}
     )
-    response.raise_for_status()
+    raise_for_status_with_body(
+        response,
+        context="TogoID countId",
+        client_error_hint=(
+            "Verify the route exists (getAllRelation) and IDs match the source "
+            "dataset's format (getDataset)."
+        ),
+    )
     return response.json()


### PR DESCRIPTION
## Summary

Two independent fixes that improve agent feedback on tool failures and clean up tool naming.

### 1. Surface upstream response body via shared helper (`a04c380`)

`response.raise_for_status()` was throwing away every external API's diagnostic message and leaving the agent staring at httpx's generic `Client error '4xx' for url ...`. Most APIs we call return useful errors:
- Virtuoso → `SPARQL compiler, line 1: Undefined namespace prefix at 'xx' before '?o'`
- TogoID → `{"message": "no route: pubchem <> chebi"}`
- NCBI / UniProt / ChEMBL / PDBj / etc. → various JSON error payloads

Adds `raise_for_status_with_body(response, *, context, client_error_hint, server_error_hint, body_max=1500)` in `server.py` — a drop-in replacement that raises `ValueError` with the upstream body (truncated at 1.5k chars) plus a default hint per status class.

Refactors `execute_sparql` to use the helper. Replaces all 17 bare `raise_for_status()` call sites:
- `togo_mcp/togoid.py` — 7 sites
- `togo_mcp/ncbi_tools.py` — 3 sites (+ import)
- `togo_mcp/api_tools.py` — 8 sites (UniProt, ChEMBL, PubChem ×2, PDBj, MeSH, Reactome, Rhea)

Each site labeled with `context=` for clarity in error messages; tool-specific hints where we have specific knowledge (e.g. TogoID `convertId` points at `getAllRelation` / `getDataset`).

**Before** (the trace that prompted this):
```
HTTPStatusError: Client error '400 Bad Request' for url
'https://api.togoid.dbcls.jp/convert?ids=440995&route=pubchem%2Cchebi&...'
```

**After**:
```
TogoID convertId HTTP 400 from https://api.togoid.dbcls.jp/convert?...
Response body:
{"message":"no route: pubchem <> chebi"}

Verify the route exists (getAllRelation lists valid routes) and that the IDs match
the source dataset's expected format (getDataset shows the format pattern).
```

### 2. Drop redundant `ncbi_` prefix from `ncbi_tools` (`72f407b`)

`main.py` mounts `ncbi_mcp` under prefix `"ncbi"`, so every tool gets an automatic `ncbi_` added. The four tool functions were *also* named with their own `ncbi_` prefix, producing exposed names like `ncbi_ncbi_esearch`, `ncbi_ncbi_efetch` (visible as `mcp__togomcp__ncbi_ncbi_efetch` in earlier session logs).

Rename the four function headers to drop the redundant prefix. After mount, they expose as `ncbi_esearch` / `ncbi_esummary` / `ncbi_efetch` / `ncbi_list_databases` — matching every prose reference in the v4 Usage Guide, `MIE_prompt.md`, MIE YAML files, and `endpoints.csv`.

Confirmed via `FastMCP.get_tools()` introspection; zero `ncbi_ncbi_*` entries remain. Internal Python callers and tests are unaffected (no code outside `ncbi_tools.py` imports these functions by name). The neighboring `togoid_mcp` sub-server already followed this pattern; this aligns NCBI to it.

## Test plan

- [x] `tests/test_ncbi_tools.py` — 10/10 pass.
- [x] `from togo_mcp.ncbi_tools import ncbi_mcp` succeeds.
- [x] `FastMCP.get_tools()` lists `ncbi_esearch`, `ncbi_esummary`, `ncbi_efetch`, `ncbi_list_databases` (no doubled prefix).
- [x] Replay the original failing TogoID call returns the JSON-message diagnostic + actionable hint.
- [x] Original SPARQL syntax-error path still surfaces Virtuoso's compiler diagnostic via the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)