### PR TITLE
Log in JST: install tzdata + set TZ=Asia/Tokyo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Use a lightweight Python base image
 FROM docker.io/astral/uv:python3.12-bookworm-slim
 
+# Install tzdata so the TZ env var (set in compose.yaml) resolves correctly
+# instead of silently falling back to UTC.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
       - "${MAIN_PORT:-8000}:8000"
     environment:
       NCBI_API_KEY: ${NCBI_API_KEY}
+      TZ: Asia/Tokyo
     restart: unless-stopped
 
   togomcp-test:
@@ -15,4 +16,5 @@ services:
       - "${TEST_PORT:-8001}:8000"
     environment:
       NCBI_API_KEY: ${NCBI_API_KEY}
+      TZ: Asia/Tokyo
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Container log timestamps were emitting UTC because the deployment containers run in UTC by default. Switch them to JST.

- **`compose.yaml`** — add `TZ: Asia/Tokyo` to both `togomcp-main` and `togomcp-test` services.
- **`Dockerfile`** — apt-install `tzdata`. The `bookworm-slim` base ships without `/usr/share/zoneinfo`, so setting `TZ` alone would silently fall back to UTC.

Affects every log line in the container (FastMCP, httpx, the TogoMCP `toolcall_log` calls, uvicorn) — that's the upside of using the env-var path versus a Python-level Formatter.

## Test plan

- [x] Local: `TZ=Asia/Tokyo python -c "import time; time.tzset(); ..."` → `time.strftime('%Z')` returns `JST`; `logging.basicConfig` emits JST timestamps.
- [ ] Post-deploy: rebuild the container, restart the service, confirm `docker logs togomcp-main` shows JST timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)