### PR TITLE
mie-generator: shape_expressions discipline + pre-publication audits (jPOST lessons)

### DIFF
--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -97,6 +97,15 @@ Counts give you a feel for which classes are central (top 5 typically carry 90%+
 
 **Run a dedicated predicate survey for every class you plan to document in `shape_expressions`** — not only the top-level anchor class. Annotation classes, measurement classes, and cross-reference classes are just as likely to have missing or misnamed predicates as the central entity class. The rule is simple: if a class will appear in `shape_expressions`, its predicate survey must have been run before you write that shape. A predicate absent from the survey has no business in the shape; a predicate present in the survey with COUNT > 0 must be either documented or explicitly excluded with a note.
 
+While running predicate surveys, note any predicate whose COUNT distribution is surprising as a `critical_warnings` candidate:
+
+- COUNT equals class instance count but the predicate name looks like it might have an alias or alternate namespace form — confirm only one form is queryable.
+- COUNT is much lower than the class instance count for a predicate that looks mandatory — document as a caveat on cardinality, or as a trap if omitting it causes a silent wrong result rather than just an empty one.
+- COUNT is greater than the class instance count for a predicate that looks singular — document the multi-valued behaviour.
+- Two predicates return overlapping results for what appears to be the same concept — document which form is the correct join key.
+
+Write these candidates down immediately. `critical_warnings` is assembled in Phase 4 from this list — not reconstructed from memory.
+
 #### 2c. DESCRIBE 3–5 representative entities
 
 Pick entities that span the taxonomy of the database — a "central" entity (most-frequent class), a "linker" entity (something that joins multiple classes), and a "leaf" entity (terminal annotation):
@@ -172,6 +181,7 @@ Read `references/query-strategy.md` now if you haven't — it contains the decis
 Use `references/template.yaml` as your scaffold. Copy it to the target path, then fill it in. Required sections, in order:
 
 1. `schema_info`
+   - **After filling in `schema_info.categories`, call `list_categories()` and verify each token you wrote is an exact match — same case, same underscores — against the returned list. Do not proceed to the next section if any token is off-spec; fix it first.** An off-spec token silently excludes the database from `find_databases(category=…)` results.
 2. `critical_warnings` (use `[]` only if there are genuinely none — most real databases have at least one silent-failure trap)
 3. `shape_expressions`
 4. `sample_rdf_entries` — exactly 3, shared prefix block
@@ -222,9 +232,18 @@ ASK WHERE {
 
 If `ASK` returns false, the triple as written does not exist in the endpoint. Do not include it.
 
-**5b. Test every SPARQL query.** Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, and any SPARQL embedded in `cross_references`. Every single one. If a query times out or errors, fix it or replace it — do not ship queries that don't run. If a query runs but returns zero rows when it shouldn't, that's also a failure (usually a namespace trap — investigate and document in `critical_warnings`).
+**5b. Test every SPARQL query.** Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, every `correct_sparql` block in `anti_patterns`, and any SPARQL embedded in `cross_references`. Every single one. If a query times out or errors, fix it or replace it — do not ship queries that don't run. If a query runs but returns zero rows when it shouldn't, that's also a failure (usually a namespace trap — investigate and document in `critical_warnings`).
+
+For each cross-database query that returns results, additionally spot-check join validity: take one join value from the result set and run a quick `ASK` or `SELECT` against the second database to confirm it resolves to a real entity there. A query returning 3 rows when thousands are expected is a join failure, not a passing test — the IRI form used for linking likely differs between the two databases.
 
 **5c. Verify statistics.** Every count or coverage percentage in `data_statistics` must come from a real query you ran, and must have a `verified_date`. If you can't verify a number, omit it rather than guessing.
+
+After verifying individual counts, cross-check arithmetic consistency:
+
+- Does `total_entities` equal (or plausibly approximate) the sum of the major `by_class` counts?
+- Does each coverage percentage equal `(subset count) / (class count)` to within rounding? E.g. if 673,263 entities carry a property and there are 1,021,677 in the class, the percentage must be documented as ~65.9%, not loosely as "~66%" or "~70%".
+
+Flag and correct any discrepancy before publishing.
 
 **5d. Validate the YAML.** Load the file with PyYAML to confirm it parses:
 
@@ -242,6 +261,43 @@ If this fails, fix the YAML before calling the work done.
 
 This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
 
+**5f. Verify `critical_warnings` content.** For every predicate name and IRI string cited in `critical_warnings`, run a minimal query confirming it exists in the endpoint:
+
+```sparql
+SELECT ?s WHERE {
+  GRAPH <…> { ?s <cited-predicate> ?o }
+} LIMIT 1
+```
+
+If the query returns no rows, the cited predicate or IRI is wrong — fix it before publishing. A warning about a non-existent predicate is worse than no warning.
+
+Also confirm each warning is still accurate against the current data snapshot: a trap documented in a previous MIE version may have been corrected upstream.
+
+**5g. Verify `cross_references`.** For each cross-reference predicate documented:
+
+1. **Confirm the IRI form** by DESCRIBEing a real entity and reading the actual object value. Do not trust the database's documentation — mint the IRI from what the endpoint actually returns. If two IRI forms are present (e.g. both an `identifiers.org` form and a canonical purl), document both and specify which is the correct join key for federation.
+
+2. **Verify the coverage percentage** with a COUNT query:
+
+   ```sparql
+   SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE {
+     GRAPH <…> { ?s a <EntityClass> ; <crossRefPredicate> ?o }
+   }
+   ```
+
+   Divide by the class instance count from `data_statistics`. Document the result as the coverage figure — do not estimate.
+
+**5h. Verify prefix declarations.** For each non-standard prefix defined in `shape_expressions` or `sample_rdf_entries`, confirm the base URI is correct by running a minimal SELECT using that prefix:
+
+```sparql
+PREFIX ex: <http://suspected-base-uri/>
+SELECT ?s WHERE {
+  GRAPH <…> { ?s a ex:KnownClass }
+} LIMIT 1
+```
+
+If the query returns no rows despite the class being known to exist, the prefix base URI is wrong. Standard W3C prefixes (`rdf:`, `rdfs:`, `owl:`, `xsd:`) do not need checking. Database-specific and ontology-specific prefixes (e.g. a Unimod prefix, a PSI-MS prefix, an internal ontology prefix) must all be confirmed.
+
 ### Phase 6 — Final declaration
 
 Only after Phases 1–5 are complete, report to the user:
@@ -254,6 +310,12 @@ Only after Phases 1–5 are complete, report to the user:
   - YAML parses cleanly
   - shape_expressions audited: all shapes verified against live predicate surveys,
     all @<ShapeRef>s resolved, all cardinality modifiers confirmed
+  - critical_warnings verified: all cited predicate names and IRIs confirmed against endpoint
+  - cross_references verified: IRI forms confirmed by DESCRIBE, coverage % from COUNT queries
+  - schema_info.categories checked: all tokens exact-matched against list_categories()
+  - prefix declarations verified: all non-standard prefixes confirmed with SELECT
+  - data_statistics cross-checked: total_entities and coverage % arithmetically consistent
+  - anti_patterns.correct_sparql tested: all correct_sparql blocks executed successfully
   - Lines: [count]
 ```
 

--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -95,6 +95,8 @@ GROUP BY ?p ORDER BY DESC(?n) LIMIT 50
 
 Counts give you a feel for which classes are central (top 5 typically carry 90%+ of the data) and which predicates form the backbone of the schema. Skip BFO / CDAO / framework upper-types when documenting in `shape_expressions` — pick the canonical class.
 
+**Run a dedicated predicate survey for every class you plan to document in `shape_expressions`** — not only the top-level anchor class. Annotation classes, measurement classes, and cross-reference classes are just as likely to have missing or misnamed predicates as the central entity class. The rule is simple: if a class will appear in `shape_expressions`, its predicate survey must have been run before you write that shape. A predicate absent from the survey has no business in the shape; a predicate present in the survey with COUNT > 0 must be either documented or explicitly excluded with a note.
+
 #### 2c. DESCRIBE 3–5 representative entities
 
 Pick entities that span the taxonomy of the database — a "central" entity (most-frequent class), a "linker" entity (something that joins multiple classes), and a "leaf" entity (terminal annotation):
@@ -107,11 +109,51 @@ SELECT ?p ?o WHERE { GRAPH <…> { <iri-of-entity> ?p ?o } } LIMIT 200
 
 Use these inspections to nail down: IRI patterns (`http://<base>/<class>/<id>`), denormalized predicates (one predicate that serves multiple roles — e.g. Bgee's `genex:isExpressedIn` mixing anatomy IRIs and condition IRIs), measurement scaffolds (bnode chains for typed-value triples), and parallel namespace traps (the same NCBI taxon ID minted under two different IRI schemes — Bgee, see its critical_warnings).
 
+**Trace every blank node chain.** For each predicate in your DESCRIBE output whose object is a blank node, retrieve the bnode's full predicate set by walking from the parent entity in a single query:
+
+```sparql
+SELECT DISTINCT ?bPred ?bObj WHERE {
+  GRAPH <…> {
+    ?parent a <ParentClass> ; <bnodePredicate> ?bnode .
+    ?bnode ?bPred ?bObj .
+  }
+} LIMIT 50
+```
+
+Do this for every distinct bnode-valued predicate you encounter — typed-value scaffolds, position nodes, sequence nodes, evidence nodes, and any other bnode-valued property. An undiscovered bnode schema means an incomplete shape and a missing shape definition for the referenced `@<ShapeName>`.
+
+Note also that bnode shapes reached via different parent classes may differ in structure even when they share the same predicate name — the same property can resolve to an `ExactPosition` bnode (carrying an integer + a back-reference IRI) on one parent class and to a `Region` bnode (carrying `begin` and `end` sub-bnodes) on another. Never assume two bnode chains with the same predicate name have the same internal structure; verify each one independently via a parent-anchored query.
+
 #### 2d. Anchor IRIs via search tools
 
 If the database has a dedicated search tool (`search_uniprot_entity`, `search_chembl_molecule`, `search_chembl_target`, `search_pdb_entity`, `search_reactome_entity`, `search_rhea_entity`, `search_mesh_descriptor`, `OLS4:searchClasses`, `ncbi_esearch`), use it to turn human-readable terms ("TP53", "tumor protein p53", "kinase activity") into specific IRIs. Then DESCRIBE those IRIs to learn the canonical predicate names. This is the fastest path from "I know what concept I'm looking for" to "I have a structured-IRI query that works."
 
 If no search tool exists (BRENDA, BacDive, MediaDive, SuperCon, Glycosmos, NIMS): generate a short `bif:contains` (Virtuoso) probe to find one example, DESCRIBE it, and pivot to typed-predicate queries from there. Document this as the only legitimate text-search use, and note in `architectural_notes.text_search_justification` why no structured alternative existed.
+
+#### 2e. Verify predicate cardinality for every shape
+
+For each class–predicate pair you intend to document in `shape_expressions`, determine the actual multiplicity with a cardinality distribution query:
+
+```sparql
+SELECT ?nValues (COUNT(?s) AS ?nSubjects) WHERE {
+  GRAPH <…> {
+    { SELECT ?s (COUNT(?o) AS ?nValues) WHERE {
+        ?s a <TargetClass> ; <TargetPredicate> ?o .
+      } GROUP BY ?s }
+  }
+}
+GROUP BY ?nValues ORDER BY ?nValues
+```
+
+Map the result to the correct ShEx cardinality modifier:
+
+| Observed pattern | ShEx notation |
+|---|---|
+| All subjects, exactly 1 value | `IRI` (no modifier — required) |
+| Some subjects have 0, none have > 1 | `IRI ?` |
+| Some subjects have > 1 | `IRI *` (if 0 is possible) or `IRI +` |
+
+**Never assign `?`, `+`, or `*` based on intuition.** Every modifier must be justified by a cardinality query result. This step is cheap (one query per predicate) and catches a large class of silent errors in the finished MIE.
 
 ### Phase 3 — Design the query set
 
@@ -140,6 +182,24 @@ Use `references/template.yaml` as your scaffold. Copy it to the target path, the
 9. `data_statistics`
 10. `anti_patterns` — 3–4, must include "schema check before text search"
 11. `common_errors` — 2–3
+
+**Before finalising `shape_expressions`:**
+
+- **Every `@<ShapeRef>` must have a corresponding defined block.** Search the `shape_expressions` string for every `@<…>` reference and confirm each one resolves to a `<…Shape> { … }` definition in the same section. A referenced-but-undefined shape is a structural error — the downstream LLM will generate property-path queries that silently return nothing.
+
+- **Mark optional co-types explicitly.** When a class is sometimes (but not always) additionally typed with a second class, write each sub-type as a separate optional constraint rather than grouping them in a single `a [ T1 T2 T3 ] +` block. The grouped form is correct ShEx but visually implies all types are always co-present:
+
+  ```shex
+  # Avoid — looks like all three are always expected:
+  a [ ex:MainType ex:SubTypeA ex:SubTypeB ] + ;
+
+  # Prefer — cardinality is explicit and verifiable:
+  a [ ex:MainType ] ;
+  a [ ex:SubTypeA ] ?   # ~80% of instances — confirmed by COUNT
+  a [ ex:SubTypeB ] ?   # ~80% of instances — confirmed by COUNT
+  ```
+
+  Annotate the percentage in an inline comment so the figure is traceable to Phase 2e.
 
 Line budget: 400–600 lines typical, up to 700–900 for genuinely complex databases. If you're over 900, you are probably duplicating between `shape_expressions` and `architectural_notes` — consolidate.
 
@@ -174,6 +234,14 @@ python3 -c "import yaml; yaml.safe_load(open('./togo_mcp/data/mie/<db>.yaml'))"
 
 If this fails, fix the YAML before calling the work done.
 
+**5e. Audit `shape_expressions` for completeness.** For each shape block:
+
+1. Re-run the Phase 2b predicate survey and compare against the documented predicates. Any predicate with COUNT > 0 that is absent from the shape must be either added or explicitly noted as intentionally excluded.
+2. Confirm every `@<ShapeRef>` has a defined `<…Shape>` block.
+3. For every predicate marked `?` (optional), confirm with a cardinality query that at least one subject has 0 values for it. For every predicate with no modifier (required), confirm its COUNT equals the class instance count.
+
+This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
+
 ### Phase 6 — Final declaration
 
 Only after Phases 1–5 are complete, report to the user:
@@ -184,6 +252,8 @@ Only after Phases 1–5 are complete, report to the user:
   - SPARQL queries tested: N/N executed successfully (N = 7 + cross-DB + cross-ref)
   - Statistics verified: [date]
   - YAML parses cleanly
+  - shape_expressions audited: all shapes verified against live predicate surveys,
+    all @<ShapeRef>s resolved, all cardinality modifiers confirmed
   - Lines: [count]
 ```
 

--- a/.claude/skills/mie-generator/references/mie-structure.md
+++ b/.claude/skills/mie-generator/references/mie-structure.md
@@ -30,6 +30,8 @@ Categories to look for:
 
 Use `[]` only if you have genuinely confirmed there are no traps. In practice most real databases have at least one.
 
+**Verification requirement:** Every predicate name and IRI string cited in `critical_warnings` must be confirmed against the live endpoint in Phase 5f. Traps to document should be identified systematically during Phase 2b by flagging surprising COUNT distributions — not reconstructed from memory in Phase 4.
+
 ## 3. `shape_expressions`
 
 ShEx-style schema for every major entity type, as a YAML `|` string. Build from the live discovery in Phase 2 (class enumeration + DESCRIBE-style inspection of representative entities) — verify every shape against the endpoint.
@@ -142,6 +144,12 @@ Pattern descriptions for each cross-reference predicate (`rdfs:seeAlso`, `skos:e
 - `description`: what it links to
 - `databases`: coverage by category (e.g. "UniProt: 78%", "ChEMBL: 45%")
 - `sparql`: optional — include only if the pattern is non-trivial
+
+**Verification requirements:**
+
+- The IRI form documented for each pattern must be confirmed by DESCRIBEing a real entity (Phase 5g), not inferred from documentation.
+- Every coverage percentage must come from a COUNT query (Phase 5g), not an estimate.
+- If two IRI forms exist for the same concept, document both and specify which is the correct join key for cross-database federation.
 
 ## 8. `architectural_notes`
 

--- a/.claude/skills/mie-generator/references/mie-structure.md
+++ b/.claude/skills/mie-generator/references/mie-structure.md
@@ -51,6 +51,14 @@ PREFIX ex: <http://example.org/>
 }
 ```
 
+**Verification requirements for `shape_expressions`** (mirrors Phase 5e):
+
+- Every shape class must have a completed predicate survey from Phase 2b.
+- Every bnode-valued predicate must have been traced via the parent-anchored query from Phase 2c.
+- Every cardinality modifier (`?`, `+`, `*`, or absent) must be backed by a Phase 2e cardinality distribution query.
+- Every `@<ShapeRef>` must resolve to a defined block in the same section.
+- Optional co-types must be written as separate `a [ T ] ?` lines, not grouped in a single `a [ T1 T2 … ] +` block.
+
 ## 4. `sample_rdf_entries`
 
 **Exactly 3 entries.** Single shared `rdf_prefixes` block at the top — do not repeat `@prefix` declarations in every entry.

--- a/togo_mcp/data/docs/MIE_file_specs.md
+++ b/togo_mcp/data/docs/MIE_file_specs.md
@@ -1,4 +1,4 @@
-# MIE File Specification v2.0
+# MIE File Specification v2.1
 
 ## 1. Overview
 
@@ -19,7 +19,16 @@ Metadata Interoperability Exchange (MIE) files are compact YAML documents that d
 - **Extension**: `.yaml`
 - **Location**: `togo_mcp/data/mie/[database].yaml`
 
-### 1.4 Key Updates in v2.0
+### 1.4 Key Updates in v2.1
+
+- **`shape_expressions` discipline**: every `@<ShapeRef>` must resolve to a defined block in the same section; optional co-types written as separate `a [ T ] ?` lines, not grouped in `a [ T1 T2 … ] +`.
+- **Phase 2 — Discover, expanded**: per-class predicate survey for *every* class going into `shape_expressions` (not only the anchor class); parent-anchored bnode-tracing query; cardinality distribution query with the modifier-mapping table; flag predicates with surprising COUNT distributions as `critical_warnings` candidates during the survey itself.
+- **Phase 5 — Validate, expanded** to four new audit steps: 5e (`shape_expressions` audit), 5f (`critical_warnings` content verification), 5g (`cross_references` IRI form + coverage verification), 5h (non-standard PREFIX base-URI verification). Phase 5b additionally tests every `correct_sparql` block in `anti_patterns` and spot-checks cross-database join validity. Phase 5c additionally cross-checks `data_statistics` arithmetic.
+- **`schema_info.categories` enforcement**: after writing categories, call `list_categories()` and confirm exact-match (case + underscores).
+- **`data_statistics.by_class`**: documented as a structured per-class count block alongside `total_entities` and `coverage`.
+- **LIMIT rule relaxed**: a query must have a *bounded* result set — `LIMIT` is required unless the query is an aggregate (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`), an `ASK`, or anchored on a specific-IRI subject whose cardinality is bounded by the schema.
+
+### 1.5 Key Updates in v2.0
 
 - **New section**: `critical_warnings` — schema pathologies, silent-failure traps, mandatory performance filters. Placed early so a reader scans it first.
 - **Sample RDF entries**: reduced from 5 to 3 entries, with a single shared `rdf_prefixes` block instead of repeated `@prefix` declarations per entry.
@@ -111,6 +120,7 @@ The `kw_search_tools` field enumerates keyword-search methods available for this
 - `access.backend` is required; it determines whether `bif:contains` is available and therefore drives query-strategy decisions downstream.
 - `keywords` are lowercase, single tokens or short phrases; 8–15 entries.
 - `categories` come from the controlled taxonomy in §3.1.5; 1–3 entries per database. **Use the exact token verbatim — lowercase, underscores for multi-word slugs (e.g. `drug_target`). Do not Title Case (`Genomics`), pluralize (`proteins`), space-separate (`comparative genomics`), or invent variants (`proteomics`, `gene_annotation`). The token must match an entry in the §3.1.5 table character-for-character.**
+- **After writing `categories`, call `list_categories()` and verify each token is an exact match (same case, same underscores) against the returned list.** Off-spec tokens silently exclude the database from `find_databases(category=…)` results — a failure invisible during MIE development.
 
 #### 3.1.5 Keywords and Categories
 
@@ -192,6 +202,12 @@ Use a YAML pipe (`|`) block with bullet-style paragraphs. Use `[]` only if genui
 - Prefer concrete failure modes ("returns 0 rows") over abstract advice ("be careful with namespaces").
 - Place this section immediately after `schema_info` so readers encounter it before writing any queries.
 
+#### 3.2.5 Verification
+
+Every predicate name and IRI string cited in `critical_warnings` must be confirmed against the live endpoint before publishing (Phase 5f). A warning about a non-existent predicate is worse than no warning — the downstream LLM will avoid the wrong thing while the real trap stays unflagged.
+
+Trap candidates should be identified systematically during Phase 2 by flagging surprising COUNT distributions (per-class predicate surveys) — not reconstructed from memory in Phase 4. See §4.3.
+
 ### 3.3 shape_expressions
 
 #### 3.3.1 Purpose
@@ -221,6 +237,27 @@ shape_expressions: |
 - Comments are minimal but load-bearing — a comment that doesn't change how the reader writes queries is noise.
 - Shape names are descriptive (`<ProteinShape>`, `<CompoundShape>`).
 - All shapes reflect actual data patterns, not aspirational schemas.
+
+#### 3.3.5 Structural Rules
+
+- **Every `@<ShapeRef>` must resolve to a defined block in the same section.** A referenced-but-undefined shape is a structural error — the downstream LLM generates property-path queries that silently return nothing.
+- **Mark optional co-types explicitly.** When a class is sometimes (but not always) additionally typed with a second class, write each sub-type as a separate optional constraint rather than grouping them in a single `a [ T1 T2 T3 ] +` block. The grouped form is correct ShEx but visually implies all types are always co-present:
+
+  ```shex
+  # Avoid — looks like all three are always expected:
+  a [ ex:MainType ex:SubTypeA ex:SubTypeB ] + ;
+
+  # Prefer — cardinality is explicit and verifiable:
+  a [ ex:MainType ] ;
+  a [ ex:SubTypeA ] ?   # ~80% of instances — confirmed by COUNT
+  a [ ex:SubTypeB ] ?   # ~80% of instances — confirmed by COUNT
+  ```
+
+- **Bnode shapes reached via different parent classes can differ.** The same predicate name can resolve to differently-shaped bnodes on different parent classes (e.g. `faldo:location` → `ExactPosition` on one class, `Region` on another). Document each as its own shape; do not assume equivalence.
+
+#### 3.3.6 Verification
+
+Every shape must be backed by Phase 2 discovery: a per-class predicate survey, parent-anchored bnode tracing for every bnode-valued predicate, and a cardinality distribution query for every modifier (`?`, `+`, `*`, or absent). See §4.3 for the queries. The Phase 5e audit re-runs the predicate survey to confirm completeness.
 
 ### 3.4 sample_rdf_entries
 
@@ -300,7 +337,7 @@ sparql_query_examples:
   - At least 2 queries use specific IRIs or `VALUES` with IRIs.
   - At least 2 queries use typed predicates or graph navigation (`rdfs:subClassOf+`, `skos:broader+`).
   - At most 1 query uses text search, and only if the Gate Check (section 3.5.5) passes.
-- All 7 queries include a `LIMIT` clause.
+- Every query produces a bounded result set — `LIMIT` is required unless the query is an aggregate (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`), an `ASK`, or anchored on a specific-IRI subject whose cardinality is bounded by the schema (e.g. `<one-protein> rdfs:label ?label`). In all other cases include `LIMIT`.
 - None are cross-database queries (those belong in `cross_database_queries`).
 - All use YAML pipe (`|`) syntax.
 
@@ -488,8 +525,13 @@ cross_references:
 
 - Groups by RDF pattern, not by database.
 - Lists all external databases found in the data.
-- Includes coverage estimates where measurable.
+- Includes coverage percentages from real COUNT queries (see §3.7.4) where measurable.
 - `sparql` is optional — include only for non-trivial patterns where the naive query doesn't work.
+
+#### 3.7.4 Verification
+
+- The IRI form documented for each pattern must be **confirmed by DESCRIBEing a real entity** (Phase 5g), not inferred from documentation. If two IRI forms exist for the same concept (e.g. `identifiers.org` form and a canonical purl), document both and specify which is the correct join key for cross-database federation.
+- Every coverage percentage must come from a **COUNT query** (Phase 5g), not an estimate.
 
 ### 3.8 architectural_notes
 
@@ -530,6 +572,10 @@ data_statistics:
   total_entities: integer
   verified_date: date              # ISO 8601
   verification_method: string      # "Direct COUNT query" or "sampling with N=..."
+  by_class:                        # OPTIONAL but recommended for multi-class databases
+    SomeClass: integer             # COUNT of subjects of that type
+    AnotherClass: integer
+    verified_date: date
   coverage:
     property_name: "XX%"
     calculation: "[numerator / denominator]"
@@ -538,7 +584,16 @@ data_statistics:
 
 Additional `total_*` fields for major entity types are encouraged.
 
-#### 3.9.3 Explicitly Omitted
+#### 3.9.3 Arithmetic Cross-Check (Phase 5c)
+
+After verifying individual counts, cross-check the figures against each other:
+
+- Does `total_entities` equal (or plausibly approximate) the sum of the major `by_class` counts? Document the relationship if it isn't a clean sum (e.g. shared bnodes, multi-typed entities).
+- Does each coverage percentage equal `(subset / class)` to within rounding? E.g. 673,263 / 1,021,677 = 65.9%, not loosely "~66%" or "~70%".
+
+Flag and correct any discrepancy before publishing.
+
+#### 3.9.4 Explicitly Omitted
 
 These sub-sections are auditing clutter and are NOT included:
 
@@ -546,7 +601,7 @@ These sub-sections are auditing clutter and are NOT included:
 - `cardinality` (avg-X-per-entity) — rarely informative for query authors.
 - `performance_characteristics` — belongs in `architectural_notes.performance` instead.
 
-#### 3.9.4 Constraints
+#### 3.9.5 Constraints
 
 - All statistics are based on actual queries run against the endpoint.
 - Omit rather than guess — if a number can't be verified, leave it out.
@@ -578,7 +633,11 @@ anti_patterns:
 - Other entries cover database-specific traps discovered during schema exploration, or universal SPARQL anti-patterns (circular reasoning with `VALUES`, unindexed text search, etc.).
 - Both `wrong_sparql` and `correct_sparql` are minimal working examples.
 
-#### 3.10.4 Mandatory Anti-pattern Topics
+#### 3.10.4 Verification
+
+Every `correct_sparql` block must be tested against the live endpoint in Phase 5b. Downstream LLMs copy `correct_sparql` as readily as the example queries — an untested `correct_sparql` actively teaches bad practice.
+
+#### 3.10.5 Mandatory Anti-pattern Topics
 
 At least one of the 3–4 entries must cover each topic area:
 
@@ -630,35 +689,84 @@ Before touching the endpoint:
 
 ### 4.3 Phase 2 — Discover (10–20 minutes)
 
-The goal is to extract the specific IRIs, typed predicates, and namespace patterns needed so that `sparql_query_examples` can prefer structured lookups.
+The goal is to extract the specific IRIs, typed predicates, and namespace patterns needed so that `sparql_query_examples` can prefer structured lookups, and to record everything the shape audit (Phase 5e) and warning audit (Phase 5f) will later check.
 
-**Standard discovery queries:**
+**4.3.1 Class enumeration:**
 
 ```sparql
-# Classes and instance counts
 SELECT DISTINCT ?class (COUNT(?instance) AS ?count)
-WHERE { ?instance a ?class }
+WHERE { GRAPH <…> { ?instance a ?class } }
 GROUP BY ?class ORDER BY DESC(?count) LIMIT 50
+```
 
-# Predicate usage
-SELECT DISTINCT ?p (COUNT(*) AS ?n)
-WHERE { ?s ?p ?o }
+**4.3.2 Per-class predicate survey — run for every class going into `shape_expressions`:**
+
+```sparql
+SELECT ?p (COUNT(*) AS ?n)
+WHERE { GRAPH <…> { ?s a <TargetClass> ; ?p ?o } }
 GROUP BY ?p ORDER BY DESC(?n) LIMIT 50
 ```
 
-**Representative-entity inspection:**
+Annotation classes, measurement classes, and cross-reference classes are just as likely to have missing or misnamed predicates as the central entity class. A predicate absent from the survey has no business in the shape; a predicate with COUNT > 0 must be either documented or explicitly excluded with a note.
+
+**While running the survey, flag `critical_warnings` candidates:**
+
+- COUNT equals class instance count but the predicate name has an alias or alternate namespace — confirm only one form is queryable.
+- COUNT is much lower than the class instance count for a predicate that looks mandatory — document as a cardinality caveat or as a trap if omitting it causes a silent wrong result.
+- COUNT is greater than the class instance count for a predicate that looks singular — document the multi-valued behaviour.
+- Two predicates return overlapping results for what appears to be the same concept — document which form is the correct join key.
+
+`critical_warnings` is assembled in Phase 4 from this list, not reconstructed from memory.
+
+**4.3.3 Representative-entity DESCRIBE:**
 
 ```sparql
 DESCRIBE <iri-of-example-entity>
 # or, when DESCRIBE is unhelpful:
-SELECT ?p ?o WHERE { <iri-of-example-entity> ?p ?o } LIMIT 200
+SELECT ?p ?o WHERE { GRAPH <…> { <iri-of-example-entity> ?p ?o } } LIMIT 200
 ```
 
 **Live DESCRIBE is the canonical source for shapes.** Pick 3–5 entities that span the database's taxonomy (e.g. a reviewed protein AND an unreviewed one; a drug molecule AND a target AND an assay) and DESCRIBE each.
 
 Biological intuition matters: if exploring a drug database, look for measurement scaffolds (blank-node activity records); if it's a sequence database, look for feature annotations and organism links; if it's an ontology, look for `rdfs:subClassOf`, `owl:equivalentClass`, and `skos:broader`.
 
-**When search tools exist** (`search_uniprot_entity`, `search_chembl_molecule`, etc.), use them to turn keywords into example IRIs that can then be DESCRIBED.
+**4.3.4 Bnode tracing — for every bnode-valued predicate found in 4.3.3:**
+
+```sparql
+SELECT DISTINCT ?bPred ?bObj WHERE {
+  GRAPH <…> {
+    ?parent a <ParentClass> ; <bnodePredicate> ?bnode .
+    ?bnode ?bPred ?bObj .
+  }
+} LIMIT 50
+```
+
+The same predicate name can resolve to differently-shaped bnodes on different parent classes. Trace each parent independently — never assume two bnode chains with the same predicate name share an internal structure. Each bnode that participates in a shape needs its own `<…BNode>` shape definition.
+
+**4.3.5 Cardinality verification — for every class–predicate pair going into `shape_expressions`:**
+
+```sparql
+SELECT ?nValues (COUNT(?s) AS ?nSubjects) WHERE {
+  GRAPH <…> {
+    { SELECT ?s (COUNT(?o) AS ?nValues) WHERE {
+        ?s a <TargetClass> ; <TargetPredicate> ?o .
+      } GROUP BY ?s }
+  }
+}
+GROUP BY ?nValues ORDER BY ?nValues
+```
+
+Map the result to the correct ShEx cardinality modifier:
+
+| Observed pattern                       | ShEx notation                       |
+|----------------------------------------|-------------------------------------|
+| All subjects, exactly 1 value          | `IRI` (no modifier — required)      |
+| Some subjects have 0, none have > 1    | `IRI ?`                             |
+| Some subjects have > 1                 | `IRI *` (if 0 is possible) or `IRI +` |
+
+**Never assign `?`, `+`, or `*` based on intuition.** Every modifier must be justified by a cardinality query result.
+
+**4.3.6 Search-tool anchoring** — when a database has a dedicated search tool (`search_uniprot_entity`, `search_chembl_molecule`, etc.), use it to turn keywords into example IRIs that can then be DESCRIBED. This is the fastest path from "I know what concept I'm looking for" to "I have a structured-IRI query that works".
 
 ### 4.4 Phase 3 — Design the query set
 
@@ -674,17 +782,63 @@ Use section 13 (Appendix A) as the scaffold. Fill every `[bracketed]` placeholde
 
 **5a. Validate every RDF example.** For each of the 3 entries in `sample_rdf_entries`, run a SELECT or ASK that retrieves those exact triples from the endpoint. Fix any that fail; replace any that can't be fixed. No fabricated RDF reaches the final file.
 
-**5b. Test every SPARQL query — all of them.** Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, and any SPARQL embedded in `cross_references`. "Most of them" is not sufficient.
+**5b. Test every SPARQL query — all of them.** Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, every `correct_sparql` block in `anti_patterns`, and any SPARQL embedded in `cross_references`. "Most of them" is not sufficient. Untested `correct_sparql` blocks actively teach bad practice — downstream LLMs copy them as readily as the example queries.
 
 Queries that time out, error, or return 0 rows when they shouldn't, must be fixed or replaced before the file is written.
 
+For each cross-database query that returns results, additionally **spot-check join validity**: take one join value from the result set and run a quick `ASK` or `SELECT` against the second database to confirm it resolves to a real entity there. A query returning 3 rows when thousands are expected is a join failure, not a passing test — the IRI form used for linking likely differs between the two databases.
+
 **5c. Verify statistics.** Every count or coverage percentage in `data_statistics` comes from a real query with a `verified_date`. Omit rather than guess.
+
+After verifying individual counts, **cross-check arithmetic consistency**: `total_entities` should equal (or plausibly approximate) the sum of major `by_class` counts, and each coverage % must equal `(subset / class)` to within rounding (see §3.9.3).
 
 **5d. Validate the YAML.** Load with PyYAML to confirm it parses:
 
 ```bash
 python3 -c "import yaml; yaml.safe_load(open('./togo_mcp/data/mie/<db>.yaml'))"
 ```
+
+**5e. Audit `shape_expressions`.** For each shape block:
+
+1. Re-run the §4.3.2 per-class predicate survey and compare against the documented predicates. Any predicate with COUNT > 0 absent from the shape must be added or explicitly noted as intentionally excluded.
+2. Confirm every `@<ShapeRef>` has a defined `<…Shape>` block (§3.3.5).
+3. For every predicate marked `?` (optional), confirm with a §4.3.5 cardinality query that at least one subject has 0 values. For every predicate with no modifier (required), confirm its COUNT equals the class instance count.
+
+`shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
+
+**5f. Verify `critical_warnings` content.** For every predicate name and IRI string cited, run a minimal query confirming it exists in the endpoint:
+
+```sparql
+SELECT ?s WHERE {
+  GRAPH <…> { ?s <cited-predicate> ?o }
+} LIMIT 1
+```
+
+If the query returns no rows, the cited predicate or IRI is wrong — fix it before publishing. Also confirm each warning is still accurate against the current data snapshot: a trap documented in a previous MIE version may have been corrected upstream.
+
+**5g. Verify `cross_references`.** For each cross-reference predicate documented:
+
+1. Confirm the IRI form by DESCRIBEing a real entity and reading the actual object value. If two IRI forms are present (e.g. an `identifiers.org` form and a canonical purl), document both and specify which is the correct join key for federation.
+2. Verify the coverage percentage with a COUNT query:
+
+   ```sparql
+   SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE {
+     GRAPH <…> { ?s a <EntityClass> ; <crossRefPredicate> ?o }
+   }
+   ```
+
+   Divide by the class instance count from `data_statistics`. Document the result as the coverage figure — do not estimate.
+
+**5h. Verify prefix declarations.** For each non-standard prefix defined in `shape_expressions` or `sample_rdf_entries`, confirm the base URI is correct by running a minimal SELECT using that prefix:
+
+```sparql
+PREFIX ex: <http://suspected-base-uri/>
+SELECT ?s WHERE {
+  GRAPH <…> { ?s a ex:KnownClass }
+} LIMIT 1
+```
+
+If the query returns no rows despite the class being known to exist, the prefix base URI is wrong. Standard W3C prefixes (`rdf:`, `rdfs:`, `owl:`, `xsd:`) do not need checking. Database-specific and ontology-specific prefixes (Unimod, PSI-MS, internal-ontology, etc.) must all be confirmed.
 
 ### 4.7 Anti-bias rules
 
@@ -744,17 +898,24 @@ When updating an existing MIE, evaluate against the following checklist and pick
 - [ ] At least 2 queries use specific IRIs / `VALUES` with IRIs
 - [ ] At least 2 queries use typed predicates or graph navigation
 - [ ] At most 1 query uses text search, with justification
-- [ ] All 7 queries include `LIMIT`
+- [ ] Every query has a bounded result set (`LIMIT`, aggregate, `ASK`, or specific-IRI subject — see §3.5.3)
 
 #### Validation
-- [ ] All 3 RDF example entries validated against endpoint
-- [ ] All 7 SPARQL queries tested against endpoint
-- [ ] All cross-database queries tested (if present)
-- [ ] All statistics have `verified_date`
+- [ ] All 3 RDF example entries validated against endpoint (§4.6 5a)
+- [ ] All 7 SPARQL queries tested against endpoint (§4.6 5b)
+- [ ] Every `anti_patterns.correct_sparql` block tested (§4.6 5b)
+- [ ] All cross-database queries tested + join validity spot-checked (§4.6 5b)
+- [ ] All statistics have `verified_date` and pass arithmetic cross-check (§4.6 5c)
+- [ ] `shape_expressions` audited (§4.6 5e)
+- [ ] `critical_warnings` cited predicates / IRIs verified (§4.6 5f)
+- [ ] `cross_references` IRI forms confirmed by DESCRIBE; coverage % from COUNT (§4.6 5g)
+- [ ] Non-standard PREFIX base URIs verified with SELECT (§4.6 5h)
+- [ ] `schema_info.categories` exact-matched against `list_categories()` (§3.1.4)
 
 #### Critical Warnings
 - [ ] Present with at least one entry (or verified `[]`)
 - [ ] Documents mandatory performance filters, IRI traps, required typos
+- [ ] Trap candidates flagged from §4.3.2 surprising-COUNT signals during discovery (not reconstructed from memory)
 
 #### Threshold
 - **≥ 90% pass**: update existing file.
@@ -766,15 +927,22 @@ When updating an existing MIE, evaluate against the following checklist and pick
 
 #### Discovery
 - [ ] Read existing `togo_mcp/data/mie/<db>.yaml` (if present)
-- [ ] Ran DESCRIBE on representative entities to derive shapes
+- [ ] Ran per-class predicate survey for every class going into `shape_expressions` (§4.3.2)
+- [ ] Ran parent-anchored bnode-tracing query for every bnode-valued predicate (§4.3.4)
+- [ ] Ran cardinality distribution query for every class–predicate pair (§4.3.5)
+- [ ] Ran DESCRIBE on representative entities to derive shapes (§4.3.3)
+- [ ] Flagged `critical_warnings` candidates from surprising COUNT distributions (§4.3.2)
 - [ ] Identified co-located databases on shared endpoint
 - [ ] Read MIE files for all co-located databases (if cross-database queries planned)
 
 #### Structure
 - [ ] Valid YAML, 11 sections in order
 - [ ] `schema_info` complete with backend, kw_search_tools, keywords (8-15), categories (1-3)
+- [ ] `schema_info.categories` exact-matched against `list_categories()`
 - [ ] `critical_warnings` documents silent-failure traps (or verified `[]`)
 - [ ] ShEx covers all major entity types with inline counts
+- [ ] Every `@<ShapeRef>` resolves to a defined block in the same section (§3.3.5)
+- [ ] Optional co-types written as separate `a [ T ] ?` lines (§3.3.5)
 - [ ] Exactly 3 RDF entries, shared prefix block
 - [ ] Exactly 7 SPARQL queries (2/3/2)
 - [ ] Cross-database queries present (or `examples: []` with notes)
@@ -783,11 +951,16 @@ When updating an existing MIE, evaluate against the following checklist and pick
 - [ ] All multiline strings use pipe syntax
 
 #### Validation
-- [ ] Every RDF triple in `sample_rdf_entries` validated against endpoint
-- [ ] Every SPARQL query in `sparql_query_examples` tested and working
-- [ ] Every cross-database query tested
-- [ ] Every statistic has `verified_date`
-- [ ] YAML parses cleanly
+- [ ] Every RDF triple in `sample_rdf_entries` validated against endpoint (5a)
+- [ ] Every SPARQL query in `sparql_query_examples` tested and working (5b)
+- [ ] Every `anti_patterns.correct_sparql` block tested (5b)
+- [ ] Every cross-database query tested + join validity spot-checked (5b)
+- [ ] Every statistic has `verified_date`; arithmetic cross-check passes (5c)
+- [ ] YAML parses cleanly (5d)
+- [ ] `shape_expressions` audited — predicate surveys re-run, `@<ShapeRef>`s resolved, cardinalities confirmed (5e)
+- [ ] Every `critical_warnings` predicate / IRI verified against endpoint (5f)
+- [ ] Every `cross_references` IRI form confirmed by DESCRIBE; coverage % from COUNT (5g)
+- [ ] Every non-standard PREFIX base URI confirmed with SELECT (5h)
 
 ### 7.2 Content Standards
 
@@ -878,6 +1051,7 @@ An MIE file is complete and compliant when:
 | 1.0     | 2024       | Initial specification.                                                                                                                                                                                                                                                                                              |
 | 1.1     | 2025-01-17 | Added `cross_database_queries` section, `kw_search_tools` field, pipe syntax requirement, `backend` field, MIE file reference guidance.                                                                                                                                                                              |
 | 2.0     | 2026-04-22 | New `critical_warnings` section; sample RDF reduced from 5 to 3 with shared prefix block; query-strategy hierarchy and Gate Check formalised; filesystem-based workflow (MIE files, ShEx, SPARQL examples as files); stronger validation — all example triples retrievable, all example queries tested; `data_statistics` simplified; anti-patterns expanded to 3–4 entries with mandatory "schema check before text search" topic. |
+| 2.1     | 2026-04-30 | `shape_expressions` discipline: every `@<ShapeRef>` resolves; optional co-types as separate `?` lines. Phase 2 Discover expanded with per-class predicate survey, parent-anchored bnode tracing, cardinality distribution query + modifier-mapping table, and `critical_warnings` candidate flagging. Phase 5 Validate gains 5e (shape audit), 5f (critical_warnings verification), 5g (cross_references IRI/coverage verification), 5h (PREFIX verification); 5b extended to `anti_patterns.correct_sparql` + cross-DB join-validity spot-check; 5c extended with arithmetic cross-check. `schema_info.categories` `list_categories()` exact-match enforcement. `data_statistics.by_class` documented. LIMIT rule relaxed to "bounded result set" (aggregate / ASK / specific-IRI subject also acceptable). |
 
 ## 12. References
 
@@ -939,8 +1113,9 @@ schema_info:
   kw_search_tools:
     - [api_name]                   # or []
   version:
-    mie_version: "2.0"
+    mie_version: "2.1"
     mie_created: "YYYY-MM-DD"
+    mie_updated: "YYYY-MM-DD"      # OPTIONAL — set when revising an existing MIE
     data_version: "Release YYYY.MM"
     update_frequency: "Monthly"
   access:
@@ -1120,6 +1295,10 @@ data_statistics:
   total_entities: [count]
   verified_date: "YYYY-MM-DD"
   verification_method: "Direct COUNT query"
+  by_class:                        # OPTIONAL but recommended for multi-class databases
+    [Class]: [count]
+    [AnotherClass]: [count]
+    verified_date: "YYYY-MM-DD"
   coverage:
     key_property: "XX%"
     calculation: "[numerator / denominator]"
@@ -1233,14 +1412,20 @@ common_errors:
 1. ≥ 2 queries use specific IRIs or `VALUES` with IRIs.
 2. ≥ 2 queries use typed predicates or graph navigation.
 3. ≤ 1 query uses text search, with inline justification.
-4. All queries include `LIMIT`.
+4. Every query has a bounded result set (explicit `LIMIT`, aggregate, `ASK`, or specific-IRI subject).
 
 ### 14.4 Validation Evidence
 
 1. Every RDF triple in `sample_rdf_entries` retrievable from endpoint (ASK or SELECT).
 2. Every SPARQL query in `sparql_query_examples` executes successfully against endpoint.
-3. Every query in `cross_database_queries.examples` executes successfully.
-4. Every statistic in `data_statistics` has a `verified_date` from an actual query.
+3. Every query in `cross_database_queries.examples` executes successfully + one join value spot-checked in the second database.
+4. Every `correct_sparql` block in `anti_patterns` executes successfully.
+5. Every statistic in `data_statistics` has a `verified_date` from an actual query; `total_entities` and coverage % pass arithmetic cross-check.
+6. `shape_expressions` audit: every documented predicate present in §4.3.2 survey output; every `@<ShapeRef>` resolves; every cardinality modifier confirmed by §4.3.5.
+7. Every predicate / IRI cited in `critical_warnings` confirmed to exist in the endpoint.
+8. Every `cross_references` IRI form confirmed by DESCRIBE; every coverage % from a COUNT query.
+9. Every non-standard PREFIX base URI confirmed with a SELECT against a known class.
+10. `schema_info.categories` tokens confirmed exact-match against `list_categories()`.
 
 ### 14.5 Format
 
@@ -1259,7 +1444,8 @@ common_errors:
 
 ---
 
-**Document Status**: Specification v2.0
+**Document Status**: Specification v2.1
 **Compliance**: required for all MIE files in `togo_mcp/data/mie/`
 **Principle**: Compact · Complete · Correct · Actionable · Validated
-**Core shift from v1.1**: Filesystem-based workflow; structured lookups over text search; every example validated against the live endpoint.
+**Core shift in v2.1**: Pre-publication audit pass — `shape_expressions` discipline (every `@<ShapeRef>` resolves; optional co-types explicit); discovery-time signals for `critical_warnings`; section-by-section verification (5e–5h) before publishing.
+**Core shift in v2.0**: Filesystem-based workflow; structured lookups over text search; every example validated against the live endpoint.

--- a/togo_mcp/data/mie/amrportal.yaml
+++ b/togo_mcp/data/mie/amrportal.yaml
@@ -631,22 +631,26 @@ anti_patterns:
       VALUES ?amrClass { "FUSIDIC ACID" "FUSIDIC_ACID" }
     explanation: "Data quality artifact in critical_warnings. Always query both strings."
 
-  - title: "Cross-GRAPH Aggregation"
-    problem: "Aggregating across multiple GRAPHs in one query creates massive intermediates and timeouts."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using sampled entity IRIs from an exploratory query as the scope of a comprehensive count or aggregate."
     wrong_sparql: |
-      # BAD: join + aggregate spanning two GRAPHs
-      SELECT ?ab (COUNT(?m) as ?c) WHERE {
-        GRAPH <http://rdfportal.org/dataset/amrportal> {
-          ?m a amr:PhenotypeMeasurement ; amr:antibioticName ?ab .
-        }
-        GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> { ?mol rdfs:label ?lb . }
-      }
-      GROUP BY ?ab
+      # WRONG: pastes sampled IRIs into VALUES — counts only those organisms, not the full dataset
+      VALUES ?isolate { <http://rdfportal.org/dataset/amrportal/isolate/12345>
+                        <http://rdfportal.org/dataset/amrportal/isolate/67890> }
+      SELECT (COUNT(?m) AS ?count)
+      FROM <http://rdfportal.org/dataset/amrportal>
+      WHERE { ?m a amr:PhenotypeMeasurement ; amr:isolate ?isolate . }
+      LIMIT 1
     correct_sparql: |
-      # CORRECT: two-stage — aggregate first (Stage 1), then join summary (Stage 2)
-      # Stage 1: SELECT ?ab (COUNT(*) as ?c) FROM <amrportal> WHERE { ... } GROUP BY ?ab
-      # Stage 2: VALUES (?ab ?c) { ... } — paste Stage 1 results, then join to ChEMBL
-    explanation: "Aggregate within a single GRAPH first (1.7M → few rows), then join the summary."
+      # CORRECT: use controlled vocabulary values discovered during exploration
+      VALUES ?amrClass { "BETA-LACTAM" "AMINOGLYCOSIDE" }
+      SELECT (COUNT(DISTINCT ?m) AS ?count)
+      FROM <http://rdfportal.org/dataset/amrportal>
+      WHERE {
+        ?m a amr:PhenotypeMeasurement ; amr:amrClass ?amrClass .
+      }
+      LIMIT 1
+    explanation: "Use exploratory queries to discover controlled vocabulary values (amrClass, antibioticName, phenotype). Use those as filter criteria in comprehensive queries — not the sampled isolate IRIs themselves."
 
   - title: "Missing FROM Clause"
     problem: "Omitting FROM scans all EBI endpoint graphs, turning fast queries into timeouts."

--- a/togo_mcp/data/mie/bacdive.yaml
+++ b/togo_mcp/data/mie/bacdive.yaml
@@ -355,26 +355,30 @@ sample_rdf_entries:
           schema:hasReference <https://purl.dsmz.de/bacdive/reference/7001> .
 
 sparql_query_examples:
-  - title: Type Strains by Phylum Using VALUES
-    description: Retrieve type strains from multiple phyla using isTypeStrain integer flag and VALUES.
-    question: Which are the type strains of Proteobacteria and Firmicutes?
+  - title: Lookup Specific Strains by IRI
+    description: Retrieve full metadata for known BacDive strains using their IRIs in a VALUES block.
+    question: What are the taxonomy, designation, and type-strain status for BacDive strains 1 and 550?
     complexity: basic
     sparql: |
       PREFIX schema: <https://purl.dsmz.de/schema/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT ?strainLabel ?genus ?species ?phylum
+      SELECT ?strain ?strainLabel ?genus ?species ?phylum ?isType ?designation
       FROM <http://rdfportal.org/dataset/bacdive>
       WHERE {
-        VALUES ?phylum { "Proteobacteria" "Firmicutes" }
+        VALUES ?strain {
+          <https://purl.dsmz.de/bacdive/strain/1>
+          <https://purl.dsmz.de/bacdive/strain/550>
+        }
         ?strain a schema:Strain ;
                 rdfs:label ?strainLabel ;
                 schema:hasGenus ?genus ;
                 schema:hasSpecies ?species ;
                 schema:hasPhylum ?phylum ;
-                schema:isTypeStrain 1 .     # integer 1, not true
+                schema:isTypeStrain ?isType .   # integer: 1 = type strain, 0 = not
+        OPTIONAL { ?strain schema:hasDesignation ?designation }
       }
-      LIMIT 50
+      LIMIT 10
 
   - title: Strains by Oxygen Tolerance Using Typed Predicate
     description: Use controlled vocabulary values with OxygenTolerance typed predicate.
@@ -457,28 +461,27 @@ sparql_query_examples:
       }
       LIMIT 100
 
-  - title: Strains with Specific Enzyme by EC Number
-    description: Use EC number typed predicate for functional enzyme classification.
-    question: Which strains have catalase activity (EC 1.11.1.6)?
+  - title: Enzyme Activities for a Known Strain by IRI
+    description: Retrieve all enzyme annotations for a specific strain identified by its BacDive IRI.
+    question: What enzymes and EC numbers are recorded for BacDive strain 1290?
     complexity: intermediate
     sparql: |
       PREFIX schema: <https://purl.dsmz.de/schema/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT ?strainLabel ?genus ?species ?enzymeLabel
+      SELECT ?strainLabel ?enzymeLabel ?ecNumber ?activity
       FROM <http://rdfportal.org/dataset/bacdive>
       WHERE {
+        VALUES ?strain { <https://purl.dsmz.de/bacdive/strain/1290> }
         ?strain a schema:Strain ;
-                rdfs:label ?strainLabel ;
-                schema:hasGenus ?genus ;
-                schema:hasSpecies ?species .
+                rdfs:label ?strainLabel .
         ?enzyme a schema:Enzyme ;
                 rdfs:label ?enzymeLabel ;
                 schema:describesStrain ?strain ;
-                schema:hasECNumber "1.11.1.6" ;
-                schema:hasActivity "+" .
+                schema:hasECNumber ?ecNumber ;
+                schema:hasActivity ?activity .
       }
-      LIMIT 100
+      LIMIT 50
 
   - title: Halophile Strains with High NaCl Tolerance
     description: Query SaltTolerance metabolic phenotype using quantitative range predicates and controlled test-type vocabulary.

--- a/togo_mcp/data/mie/bgee.yaml
+++ b/togo_mcp/data/mie/bgee.yaml
@@ -583,26 +583,30 @@ anti_patterns:
       ?cond <http://purl.obolibrary.org/obo/RO_0002162> <http://purl.uniprot.org/taxonomy/9606> .
     explanation: "Bgee uses two parallel taxon IRI namespaces. Gene → bgeespecies:NNN; ExpressionCondition → taxonomy:NNN (UniProt). Bridge with obo:RO_0002162."
 
-  - title: "Unfiltered scan of the Expression class"
-    problem: |
-      Counting or listing genex:Expression without anchoring to a gene, anatomy, or
-      species. The class has 709M instances; queries time out.
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using gene or condition IRIs sampled from an exploratory query as the scope of a comprehensive expression count — counts only the sample."
     wrong_sparql: |
-      SELECT (COUNT(*) AS ?n) WHERE {
-        GRAPH <http://bgee.org> { ?c a genex:Expression }
+      # WRONG: pasted sampled gene IRIs — counts only those genes' expression, not all brain-expressed genes
+      VALUES ?gene {
+        <http://www.ensembl.org/id/ENSG00000141510>
+        <http://www.ensembl.org/id/ENSG00000012048>
       }
-      # Times out at the endpoint
+      SELECT (COUNT(DISTINCT ?cond) AS ?count)
+      FROM <http://rdfportal.org/dataset/bgee>
+      WHERE { ?expr genex:hasExpressionCondition ?cond ; oba:RO_0002206 ?gene . }
+      LIMIT 1
     correct_sparql: |
-      # Anchor first, then COUNT:
-      SELECT (COUNT(*) AS ?n) WHERE {
-        GRAPH <http://bgee.org> {
-          ?c a genex:Expression ;
-             genex:hasSequenceUnit ?gene ;
-             genex:hasExpressionCondition ?cond .
-          ?cond <http://purl.obolibrary.org/obo/RO_0002162> taxonomy:9606 .
-        }
+      # CORRECT: use the anatomy IRI and developmental stage discovered during exploration
+      SELECT (COUNT(DISTINCT ?gene) AS ?count)
+      FROM <http://rdfportal.org/dataset/bgee>
+      WHERE {
+        ?expr a genex:Expression ;
+              oba:RO_0002206 ?gene ;
+              genex:hasExpressionCondition ?cond .
+        ?cond genex:hasAnatomicalEntity <http://purl.obolibrary.org/obo/UBERON_0000955> .
       }
-    explanation: "The expression call table is the largest in the SIB store. Filter by species, gene, or anatomy via the condition before any aggregation."
+      LIMIT 1
+    explanation: "Use anatomical entity IRIs (not sampled gene IRIs) for comprehensive expression queries. Pasting sampled gene IRIs from exploratory queries counts only those genes."
 
   - title: "Treating genex:isExpressedIn as a clean anatomy link"
     problem: |

--- a/togo_mcp/data/mie/brenda.yaml
+++ b/togo_mcp/data/mie/brenda.yaml
@@ -28,7 +28,6 @@ schema_info:
     - inchikey
     - tissue expression
     - subcellular localization
-    - organism enzyme
   categories:
     - reaction
     - protein
@@ -416,6 +415,7 @@ sparql_query_examples:
                 d3o:foundIn ?organism .
       }
       GROUP BY ?ec ?ecLabel
+      LIMIT 10
 
   - title: "Tissue-specific enzyme expression across organisms"
     description: Find tissues that express a specific enzyme class and the organisms they belong to.
@@ -623,30 +623,25 @@ anti_patterns:
       ?inhibitor d3o:affectsClass <https://purl.dsmz.de/brenda/ec/4.1.1.17> .
     explanation: "Enzyme IRIs are internal BRENDA instance IDs. EC number IRIs encode the class number in the path. They are completely different namespaces."
 
-  - title: "Querying Structural Data from Inhibitor/Activator Nodes"
-    problem: "Expecting rdfs:label or InChI on an inhibitor node — structure data is on the compound."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using enzyme IRIs sampled from an exploratory query as the scope of a comprehensive reaction count — counts only those instances."
     wrong_sparql: |
-      ?inhibitor a d3o:Inhibitor ;
-                 rdfs:label ?label ;           # wrong — inhibitor has no label
-                 d3o:hasInChIKey ?inchiKey .   # wrong — InChIKey is on the compound/structure
+      # WRONG: pasted sampled enzyme IRIs — counts only those enzyme instances, not all EC 4.1.1.x members
+      VALUES ?enzyme {
+        <https://purl.dsmz.de/brenda/enzyme/2485>
+        <https://purl.dsmz.de/brenda/enzyme/2486>
+      }
+      SELECT (COUNT(?enzyme) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      ?inhibitor a d3o:Inhibitor ;
-                 d3o:refersToCompound ?compound .
-      ?compound rdfs:label ?label ;
-                d3o:hasStructure ?structure .
-      ?structure d3o:hasInChIKey ?inchiKey .
-    explanation: "Inhibitor/Activator nodes represent context-specific roles, not chemical entities. Navigate via d3o:refersToCompound to reach the compound and its structure."
-
-  - title: "Wrong Direction for Tissue Expression"
-    problem: "Looking for d3o:expresses on enzyme nodes — the predicate goes FROM tissue TO enzyme."
-    wrong_sparql: |
-      ?enzyme d3o:expresses ?tissue .   # wrong direction
-    correct_sparql: |
-      ?tissue a d3o:Tissue ;
-              d3o:expresses ?enzyme ;   # tissue expresses enzyme
-              d3o:partOf ?organism .
-      ?enzyme d3o:isClassifiedAs ?ec .
-    explanation: "The d3o:expresses predicate is on tissue nodes pointing to enzyme nodes, not the reverse. Check shape_expressions for the correct predicate direction."
+      # CORRECT: use the EC class IRI discovered during exploration
+      SELECT (COUNT(DISTINCT ?enzyme) AS ?count)
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?enzyme d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/4.1.1.17> .
+      }
+      LIMIT 1
+    explanation: "Use the EC class IRI (structured predicate) for comprehensive counts across all enzyme instances of that class. Pasting sampled enzyme IRIs only counts those specific instances."
 
   - title: "Querying for Kinetic Values That Are Not in the RDF Export"
     problem: "Expecting Km, Ki, Vmax, or kcat to be queryable via SPARQL — these fields

--- a/togo_mcp/data/mie/chebi.yaml
+++ b/togo_mcp/data/mie/chebi.yaml
@@ -221,6 +221,7 @@ sparql_query_examples:
         OPTIONAL { obo:CHEBI_15422 chemrof:smiles_string ?smiles }
         OPTIONAL { obo:CHEBI_15422 chemrof:inchi_key_string ?inchikey }
       }
+      LIMIT 5
 
   - title: "VALUES Batch Lookup — Multiple Metabolites"
     description: >
@@ -246,6 +247,7 @@ sparql_query_examples:
         OPTIONAL { ?entity chemrof:generalized_empirical_formula ?formula }
         OPTIONAL { ?entity chemrof:mass ?mass }
       }
+      LIMIT 10
 
   - title: "Hierarchy Navigation — Count Amino Acid Subclasses"
     description: >
@@ -264,6 +266,7 @@ sparql_query_examples:
                 rdfs:subClassOf+ obo:CHEBI_33709 .   # amino acid IRI
         FILTER(STRSTARTS(STR(?entity), "http://purl.obolibrary.org/obo/CHEBI_"))
       }
+      LIMIT 1
 
   - title: "Biological Role Query via OWL Restriction"
     description: >
@@ -620,23 +623,25 @@ anti_patterns:
       ChEBI has structured IRIs for biological roles, ontology classes, and relationships.
       Always check MIE and inspect examples before defaulting to text search.
 
-  - title: "Asserting Chemical Relationships Directly"
-    problem: >
-      Querying chemical relationships (roles, conjugate pairs, tautomers) as direct
-      predicates on the entity. These predicates are NEVER asserted directly in ChEBI.
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using entity IRIs sampled from a text-search result to count members of a chemical role — counts only the sample."
     wrong_sparql: |
-      # WRONG — direct predicate assertions do not exist
-      ?entity obo:RO_0000087 obo:CHEBI_33281 .
-      ?entity obo:RO_0018034 ?base .
+      # WRONG: pasted sampled ChEBI IRIs from bif:contains — counts only those entities
+      VALUES ?entity { obo:CHEBI_27732 obo:CHEBI_15422 }
+      SELECT (COUNT(?entity) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # CORRECT — always via OWL restriction blank node
-      ?entity rdfs:subClassOf ?restriction .
-      ?restriction a owl:Restriction ;
-                   owl:onProperty obo:RO_0000087 ;
-                   owl:someValuesFrom obo:CHEBI_33281 .
-    explanation: >
-      All chemical roles and relationships in ChEBI are encoded as OWL restrictions.
-      The three-triple pattern (subClassOf → Restriction → onProperty/someValuesFrom) is mandatory.
+      # CORRECT: use the role restriction IRI discovered during exploration (CHEBI:33281 = antimicrobial agent)
+      SELECT (COUNT(DISTINCT ?entity) AS ?count)
+      FROM <http://rdfportal.org/dataset/chebi>
+      WHERE {
+        ?entity rdfs:subClassOf ?r .
+        ?r a owl:Restriction ;
+           owl:onProperty obo:RO_0000087 ;
+           owl:someValuesFrom obo:CHEBI_33281 .
+      }
+      LIMIT 1
+    explanation: "Use OWL restriction traversal with the discovered role IRI for comprehensive counts. Pasting sampled entity IRIs from a text search gives only the size of your exploratory sample."
 
   - title: "Using Old Uppercase Cross-Reference Prefixes"
     problem: >

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -605,9 +605,10 @@ architectural_notes:
     - "MeSH: 100% coverage; EFO: ~99.7% — use MeSH as primary disease filter"
 
   text_search_justification:
-    - "Number of the 7 example queries using text search: 0"
-    - "All entity classes have structured predicates: organism (cco:organismName), disease (cco:hasMesh IRI), protein family (cco:hasProteinClassification IRI), activity type (cco:standardType), assay type (cco:assayType)"
-    - "bif:contains appropriate only for cco:description / rdfs:comment free-text fields (not used in 7 examples)"
+    - "Number of the 7 example queries using text search: 1 (Query 6)"
+    - "Query 6 uses FILTER(CONTAINS(?mechanismType, \"INHIBITOR\")) on cco:mechanismActionType — a controlled-vocabulary string literal. A VALUES block would require listing all inhibitor subtypes (COMPETITIVE INHIBITOR, IRREVERSIBLE INHIBITOR, etc.); CONTAINS is the pragmatic alternative. All other mechanism/activity lookups use exact typed predicates."
+    - "All other entity classes have structured predicates: organism (cco:organismName), disease (cco:hasMesh IRI), protein family (cco:hasProteinClassification IRI), activity type (cco:standardType), assay type (cco:assayType)"
+    - "bif:contains appropriate only for cco:description / rdfs:comment free-text fields (not needed in any of the 7 examples beyond Q6)"
 
 data_statistics:
   total_molecules: 1920603
@@ -630,7 +631,7 @@ data_statistics:
 
 anti_patterns:
   - title: Text Search When Protein Classification IRI Exists
-    problem: Using bif:contains on target labels for 'kinase' when specific classification IRIs exist and are faster and more precise.
+    problem: Skipping MIE schema check — using bif:contains on target labels for 'kinase' when specific classification IRIs exist and are faster and more precise.
     wrong_sparql: |
       # Skipped MIE schema check — jumps to text search on labels
       SELECT ?target ?label
@@ -653,26 +654,30 @@ anti_patterns:
       }
     explanation: MIE schema shows cco:hasProteinClassification. Inspect examples to extract the IRI. Use it for comprehensive, precise, fast results.
 
-  - title: Using skos:exactMatch for Molecule-to-ChEBI Cross-DB Join
-    problem: skos:exactMatch is ONLY on TargetComponent (UniProt links), NOT on SmallMolecule. Returns empty results silently.
+  - title: Circular Reasoning with Search Results
+    problem: Using molecule or target IRIs sampled from an exploratory query as the scope of a comprehensive count or activity aggregate.
     wrong_sparql: |
-      GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> {
-        ?molecule a cco:SmallMolecule ;
-                  skos:exactMatch ?chebiId .  # WRONG — no such triple
+      # WRONG: pasted sampled molecule IRIs — counts only those molecules, not all kinase inhibitors
+      VALUES ?molecule {
+        <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25>
+        <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL192>
       }
+      SELECT (COUNT(?activity) AS ?count)
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE { ?activity cco:hasMolecule ?molecule . }
+      LIMIT 1
     correct_sparql: |
-      # Use cco:moleculeXref + BIND+REPLACE for IRI conversion
-      GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> {
-        ?molecule a cco:SmallMolecule ;
-                  cco:moleculeXref ?xref .
-        FILTER(CONTAINS(STR(?xref), "chebi/searchId"))
-        BIND(IRI(CONCAT("http://purl.obolibrary.org/obo/CHEBI_",
-                 REPLACE(STR(?xref), ".*CHEBI%3A", ""))) AS ?chebiId)
+      # CORRECT: use the protein classification IRI discovered during exploration
+      SELECT (COUNT(DISTINCT ?molecule) AS ?count)
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        ?assay cco:hasTarget ?target .
+        ?target cco:hasProteinClassification
+                <http://rdf.ebi.ac.uk/resource/chembl/protclass/CHEMBL_PC_1100> .
+        ?activity cco:hasAssay ?assay ; cco:hasMolecule ?molecule .
       }
-      GRAPH <http://rdf.ebi.ac.uk/dataset/chebi> {
-        ?chebiId a owl:Class .
-      }
-    explanation: Verified by inspecting CHEMBL1004 — cco:moleculeXref points to EBI URL format, not a purl.obolibrary.org IRI. BIND+REPLACE conversion is mandatory.
+      LIMIT 1
+    explanation: "Use exploratory queries to discover classification IRIs or MeSH IRIs. Use those in comprehensive queries — not the sampled molecule or target IRIs themselves."
 
   - title: Text Search When MeSH Descriptor IRI Exists
     problem: Filtering on cco:hasMeshHeading text when specific MeSH IRIs provide 100% coverage and are indexed.

--- a/togo_mcp/data/mie/ddbj.yaml
+++ b/togo_mcp/data/mie/ddbj.yaml
@@ -365,6 +365,7 @@ sparql_query_examples:
              ro:0002162 ?taxon ;
              rdfs:seeAlso ?fasta_link .
       }
+      LIMIT 10
 
   - title: Search Entries by Organism Name Using bif:contains
     description: |
@@ -621,19 +622,29 @@ anti_patterns:
       DDBJ has 21 division IRIs and ro:0002162 taxonomy IRIs covering most
       categorical filtering needs. Always check schema before text search.
 
-  - title: "Unscoped Feature Joins (Cartesian Product)"
-    problem: >
-      Joining Gene, CDS, or RNA features without entry accession filter creates
-      Cartesian products across 280M entries and times out immediately.
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using entry accession IRIs sampled from an exploratory query as the scope for a count — counts only the sample."
     wrong_sparql: |
-      ?gene a nuc:Gene .
-      ?cds bfo:0000050 ?gene .         # joins ALL genes × ALL CDS → timeout
+      # WRONG: pastes sampled entry IRIs into VALUES — total is just the sample size
+      VALUES ?entry {
+        <http://ddbj.nig.ac.jp/ontologies/nucleotide/CP036276.1>
+        <http://ddbj.nig.ac.jp/ontologies/nucleotide/CP036277.1>
+      }
+      SELECT (COUNT(?gene) AS ?geneCount)
+      FROM <http://rdfportal.org/dataset/ddbj>
+      WHERE { ?gene a nuc:Gene ; bfo:0000050 ?entry . }
+      LIMIT 1
     correct_sparql: |
-      ?gene a nuc:Gene .
-      ?cds bfo:0000050 ?gene .
-      FILTER(CONTAINS(STR(?gene), "CP036276.1"))   # entry scope FIRST
-      LIMIT 20
-    explanation: "Always add entry accession scope before any multi-feature join."
+      # CORRECT: use division IRI discovered during exploration for full-division aggregate
+      SELECT (COUNT(DISTINCT ?gene) AS ?geneCount)
+      FROM <http://rdfportal.org/dataset/ddbj>
+      WHERE {
+        ?entry a nuc:Entry ;
+               nuc:division <http://ddbj.nig.ac.jp/ontologies/nucleotide/Division#PHG> .
+        ?gene a nuc:Gene ; bfo:0000050 ?entry .
+      }
+      LIMIT 1
+    explanation: "Use division IRIs to scope comprehensive aggregations across the full dataset. Pasting sampled entry IRIs into VALUES only counts those specific entries."
 
   - title: "Aggregation Without Division or Entry Scope"
     problem: "COUNT(*) on nuc:Entry or features without a filter scans all 280M entries and times out."

--- a/togo_mcp/data/mie/ensembl.yaml
+++ b/togo_mcp/data/mie/ensembl.yaml
@@ -662,17 +662,27 @@ anti_patterns:
       ?gene <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Homo_sapiens> .
     explanation: "Ensembl uses division-specific species IRIs, NOT NCBI Taxonomy URIs. To bridge Ensembl species IRIs to NCBI Taxonomy, query <http://rdfportal.org/dataset/ensembl_taxonomy> using skos:relatedMatch. See critical_warnings for full division table."
 
-  - title: Using Wrong Species IRI Pattern for Non-Vertebrate Division
-    problem: "Using the vertebrate subdomain (ensembl.org/) for metazoa/plants/fungi/bacteria organisms."
+  - title: Circular Reasoning with Search Results
+    problem: Using gene IRIs sampled from an exploratory result as the scope of a comprehensive species-wide count.
     wrong_sparql: |
-      GRAPH <http://rdfportal.org/dataset/ensembl_metazoa> {
-        ?gene <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Drosophila_melanogaster> .
+      # WRONG: pasted sampled Ensembl gene IRIs — counts only those genes, not all kinases
+      VALUES ?gene {
+        <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000012048>
+        <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000141510>
       }
+      SELECT (COUNT(?gene) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      GRAPH <http://rdfportal.org/dataset/ensembl_metazoa> {
-        ?gene <http://purl.obolibrary.org/obo/RO_0002162> <http://metazoa.ensembl.org/Drosophila_melanogaster> .
+      # CORRECT: use the biotype IRI discovered during exploration for a comprehensive count
+      SELECT (COUNT(DISTINCT ?gene) AS ?count)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/ensembl> {
+          ?gene <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Homo_sapiens> ;
+                terms:has_biotype <http://ensembl.org/glossary/ENSGLOSSARY_0000026> .
+        }
       }
-    explanation: Each division has its own subdomain (metazoa.ensembl.org, plants.ensembl.org, etc.). See critical_warnings.
+      LIMIT 1
+    explanation: "Use exploratory queries to discover species and biotype IRIs. Use those as structured filter criteria in comprehensive queries — not the sampled gene IRIs themselves."
 
   - title: Text Search When Specific Biotype IRI Exists
     problem: "Filtering by biotype label text instead of using the available ENSGLOSSARY_ IRI."

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -209,6 +209,7 @@ sparql_query_examples:
         ?protein a glycan:Glycoprotein ;
                  glycan:has_taxon <http://identifiers.org/taxonomy/9606> .
       }
+      LIMIT 1
 
   - title: Find Glycans by Motif IRI
     description: Retrieve glycans containing the O-Glycan core 1 (T antigen) motif using its glycan IRI. FROM clause omitted because motif relationships span multiple graphs.
@@ -339,6 +340,7 @@ sparql_query_examples:
                  glycoconjugate:glycosylated_at ?site .
         OPTIONAL { ?site faldo:location/faldo:position ?pos . }
       }
+      LIMIT 1
 
 cross_database_queries:
   shared_endpoint: glycosmos
@@ -459,17 +461,25 @@ data_statistics:
     verified_date: "2025-04-21"
 
 anti_patterns:
-  - title: "Missing FROM Clause"
-    problem: "Omitting FROM searches 140+ graphs — 10-100x slower, frequent timeout."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using glycan IRIs sampled from a text-search result as the scope of a comprehensive count — counts only the sample."
     wrong_sparql: |
-      PREFIX glycan: <http://purl.jp/bio/12/glyco/glycan#>
-      SELECT ?epitope WHERE { ?epitope a glycan:Glycan_epitope . }
+      # WRONG: pasted sampled glycan IRIs from a bif:contains result
+      VALUES ?glycan {
+        <http://rdf.glycoinfo.org/glycan/G00031MO>
+        <http://rdf.glycoinfo.org/glycan/G00033MO>
+      }
+      SELECT (COUNT(?glycan) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      PREFIX glycan: <http://purl.jp/bio/12/glyco/glycan#>
-      SELECT ?epitope
-      FROM <http://rdf.glycoinfo.org/glycoepitope>
-      WHERE { ?epitope a glycan:Glycan_epitope . }
-    explanation: "Always specify the target graph. Exception: glycan:has_motif spans multiple graphs — omit FROM only for motif queries."
+      # CORRECT: use the motif IRI discovered during exploration to count all core-1 glycans
+      SELECT (COUNT(DISTINCT ?glycan) AS ?count)
+      FROM <http://rdf.glycoinfo.org/glycan>
+      WHERE {
+        ?glycan glycan:has_motif <http://rdf.glycoinfo.org/glycan/G00031MO> .
+      }
+      LIMIT 1
+    explanation: "Use exploratory queries to discover motif, organism, or epitope IRIs. Use those as structured filter values in comprehensive queries — not the sampled glycan IRIs themselves."
 
   - title: "Using bif:contains (Disabled on This Endpoint)"
     problem: "bif:contains is not enabled on ts.glycosmos.org/sparql despite Virtuoso backend; returns a SPARQL error."
@@ -512,7 +522,6 @@ anti_patterns:
     correct_sparql: |
       ?protein glycan:has_taxon <http://identifiers.org/taxonomy/9606> .  # fast, exact
     explanation: "Use specific taxonomy IRIs: human=9606, mouse=10090, rat=10116, Arabidopsis=3702, C.elegans=6239, S.cerevisiae=559292."
-
 common_errors:
   - error: "Query timeout after 120 seconds"
     causes:

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -107,8 +107,8 @@ shape_expressions: |
   }
 
   <FaldoLocationShape> {
-    a [ faldo:ExactPosition ] OR [ faldo:FuzzyPosition ] ;
-    faldo:position xsd:integer
+    a [ faldo:ExactPosition faldo:FuzzyPosition ] ;    # value set — either type (ExactPosition: 663K, FuzzyPosition: 7K)
+    faldo:position xsd:integer ?                        # present on ExactPosition; absent on FuzzyPosition
   }
 
   # 423,164 glycogenes in graph <http://rdf.glycosmos.org/glycogenes>

--- a/togo_mcp/data/mie/go.yaml
+++ b/togo_mcp/data/mie/go.yaml
@@ -192,6 +192,7 @@ sparql_query_examples:
                 oboinowl:hasOBONamespace ?namespace ;
                 obo:IAO_0000115 ?definition .
       }
+      LIMIT 10
 
   - title: Navigate GO hierarchy via rdfs:subClassOf
     description: Retrieves all direct parents of a known term. Use rdfs:subClassOf+ for transitive closure over the full hierarchy.
@@ -229,6 +230,7 @@ sparql_query_examples:
       }
       GROUP BY ?namespace
       ORDER BY DESC(?count)
+      LIMIT 10
 
   - title: All descendants of a term via transitive hierarchy
     description: Finds all sub-terms of a parent using property path rdfs:subClassOf+. Corrects circular-reasoning trap — use a parent IRI to reach the complete dataset, not individual search results.

--- a/togo_mcp/data/mie/hgnc.yaml
+++ b/togo_mcp/data/mie/hgnc.yaml
@@ -152,29 +152,30 @@ sample_rdf_entries:
         idt:pubmed/2047879 a idt:pubmed ; dct:identifier "2047879" .
 
 sparql_query_examples:
-  - title: "Retrieve full gene record by gene symbol"
-    description: Look up all core metadata for a gene using its official HGNC symbol.
-    question: "What is the full HGNC record for TP53, including its chromosomal location and HGNC ID?"
+  - title: "Retrieve gene records by HGNC IRI"
+    description: Look up core metadata for multiple known genes using their specific HGNC IRIs in a VALUES block.
+    question: "What are the HGNC records for TP53 (hgnc:11998) and BRCA1 (hgnc:1100)?"
     complexity: basic
     sparql: |
       PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX dct:  <http://purl.org/dc/terms/>
       PREFIX obo:  <http://purl.obolibrary.org/obo/>
-      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-      SELECT ?gene ?hgnc_id ?description ?location ?alias
+      SELECT ?gene ?symbol ?hgnc_id ?description ?location
       FROM <http://rdfportal.org/dataset/hgnc>
       WHERE {
-        VALUES ?symbol { "TP53" }
+        VALUES ?gene {
+          <http://identifiers.org/hgnc/11998>
+          <http://identifiers.org/hgnc/1100>
+        }
         ?gene a m2r:Gene ;
               rdfs:label ?symbol ;
               dct:identifier ?hgnc_id ;
               dct:description ?description .
         OPTIONAL { ?gene obo:so_part_of ?location }
-        OPTIONAL { ?gene skos:altLabel ?alias }
       }
-      LIMIT 20
+      LIMIT 10
 
   - title: "Get all cross-references for a known HGNC gene"
     description: Retrieve all external database identifiers linked from a specific HGNC IRI.

--- a/togo_mcp/data/mie/jpostdb.yaml
+++ b/togo_mcp/data/mie/jpostdb.yaml
@@ -28,7 +28,6 @@ schema_info:
     - shotgun proteomics
   categories:
     - protein
-    - experiment
   endpoint: https://rdfportal.org/primary/sparql
   base_uri: http://rdf.jpostdb.org/
   graphs:
@@ -359,6 +358,7 @@ sparql_query_examples:
           FILTER(STRSTARTS(STR(?pxRef), "http://proteomecentral.proteomexchange.org/"))
         }
       }
+      LIMIT 10
 
   - title: "Count datasets per project (top 10)"
     description: |
@@ -739,17 +739,29 @@ data_statistics:
     verified_date: "2026-04-30"
 
 anti_patterns:
-  - title: "Querying without GRAPH clause"
-    problem: "Using bare triple patterns instead of wrapping in GRAPH <http://jpost.org/graph/database>."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using protein IRIs sampled from a UniProt-based lookup as the scope of a comprehensive jPOST count."
     wrong_sparql: |
-      ?project a jpost:Project ; dct:title ?title .
-    correct_sparql: |
-      GRAPH <http://jpost.org/graph/database> {
-        ?project a jpost:Project ; dct:title ?title .
+      # WRONG: pasted sampled protein IRIs — counts only those proteins, not all matching UniProt hits
+      VALUES ?prot {
+        <http://jpost.org/rdf/PRT0000000001_P01116>
+        <http://jpost.org/rdf/PRT0000000002_P01116>
       }
-    explanation: "On the multi-database primary endpoint the default graph is empty for
-      jPOST data. Bare patterns silently return zero rows — there's no error to debug.
-      Wrap every triple block in the explicit GRAPH clause."
+      SELECT (COUNT(?pept) AS ?count)
+      FROM <http://jpost.org/graph/database>
+      WHERE { ?pept a jpost:Peptide ; jpost:isDetectedIn ?prot . }
+      LIMIT 1
+    correct_sparql: |
+      # CORRECT: use the UniProt IRI (structured predicate) discovered during exploration
+      SELECT (COUNT(DISTINCT ?pept) AS ?count)
+      FROM <http://jpost.org/graph/database>
+      WHERE {
+        ?prot a jpost:Protein ;
+              jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/P01116> .
+        ?pept a jpost:Peptide ; jpost:isDetectedIn ?prot .
+      }
+      LIMIT 1
+    explanation: "Use the jpost:hasDatabaseSequence IRI predicate to scope comprehensive counts. Pasting sampled PRT IRIs only counts those specific project-dataset combinations."
 
   - title: "Querying peptide sequence as a direct property"
     problem: "Treating the AA sequence as a literal directly on the Peptide."
@@ -786,7 +798,6 @@ anti_patterns:
     explanation: "jPOST samples are annotated with DOID IRIs, which round-trip cleanly to
       MONDO via `oboInOwl:hasDbXref`. Read shape_expressions before reaching for text
       search — sample, modification, and protein metadata are all pre-typed."
-
 common_errors:
   - error: "Slow query / timeout"
     causes:

--- a/togo_mcp/data/mie/jpostdb.yaml
+++ b/togo_mcp/data/mie/jpostdb.yaml
@@ -138,9 +138,9 @@ shape_expressions: |
   <ProfileShape> {
     a [ jpost:Profile ] ;
     jpost:hasSample @<SampleShape> ;
-    jpost:hasFractionation IRI ? ;
-    jpost:hasEnzymeAndModification IRI ? ;          # cleavage enzyme + fixed/var mods
-    jpost:hasMsMode IRI ? ;                         # DDA / DIA / etc.
+    jpost:hasEnzymeAndModification IRI ;            # mandatory; present on all 853 Profiles
+    jpost:hasMsMode IRI ;                           # mandatory; present on all 853 Profiles (DDA / DIA / etc.)
+    jpost:hasFractionation IRI * ;                  # 0–3 values; ~55% of Profiles have ≥2
     jpost:hasRawData @<RawDataShape> *
   }
 
@@ -150,11 +150,23 @@ shape_expressions: |
   # ---------------------------------------------------------------
   <SampleShape> {
     a [ jpost:Sample ] ;
+    jpost:species IRI ;                             # mandatory; identifiers.org/taxonomy/* on all 853 Samples
+    jpost:sampleType IRI + ;                        # NCIt/CLO/BTO category IRI; present on 844/853 (98.9%)
     jpost:cellLine IRI * ;                          # BTO:* / CL:* / CLO:*
     jpost:disease IRI * ;                           # DOID:*
     jpost:diseaseClass IRI * ;                      # DOID:* + jpost:JPO_*
-    jpost:organ IRI * ;                             # NCIt (Thesaurus.owl#C…) + BTO:*
-    jpost:organism IRI ?                            # NCBI taxon (when present)
+    jpost:organ IRI *                               # NCIt (Thesaurus.owl#C…) + BTO:*
+  }
+
+  # ---------------------------------------------------------------
+  # A raw mass-spec data file referenced by a Profile.
+  # Sparsely populated: 1,962 instances against 853 Profiles — older
+  # reanalyses often have no RawData.
+  # ---------------------------------------------------------------
+  <RawDataShape> {
+    a [ jpost:RawData ] ;
+    rdfs:label xsd:string ;                         # original filename, e.g. "120129ry_604A1-46_3_4.wiff"
+    foaf:page IRI ?                                 # jPOSTrepo entry page URL (when known)
   }
 
   # ---------------------------------------------------------------
@@ -165,7 +177,9 @@ shape_expressions: |
   # 82% are also jpost:UniquePeptide; 82% jpost:UniquePeptideAtMsLevel.
   # ---------------------------------------------------------------
   <PeptideShape> {
-    a [ jpost:Peptide jpost:UniquePeptide jpost:UniquePeptideAtMsLevel ] + ;
+    a [ jpost:Peptide ] ;                           # mandatory base type
+    a [ jpost:UniquePeptide ] ? ;                   # ~82% of Peptides
+    a [ jpost:UniquePeptideAtMsLevel ] ? ;          # ~82% of Peptides
     dct:identifier xsd:string ;
     jpost:hasSequence @<PeptideSequenceBNode> ;     # AA string here
     jpost:hasPsm @<PsmShape> + ;                    # 1+ supporting PSMs
@@ -192,13 +206,26 @@ shape_expressions: |
   }
 
   # ---------------------------------------------------------------
-  # A single PTM occurrence on a PSM. Multi-typed against Unimod.
-  # IRI is a blank node; total Modification instances: 12,518,574.
+  # A single PTM occurrence on a PSM. IRI is a blank node;
+  # total Modification instances: 12,518,574. The Unimod typing AND
+  # the position predicates (modificationSite + faldo:location) are
+  # absent on PTMs whose Unimod term is unknown (see data_quality).
   # ---------------------------------------------------------------
   <ModificationShape> {
     a [ jpost:Modification ] ;
-    a IRI + ;                                       # one or more unimod:UNIMOD_*
-    rdfs:label xsd:string ?                         # "Acetyl (N-term)", "Oxidation (M)" …
+    a IRI * ;                                       # zero or more unimod:UNIMOD_*; absent on unannotated mods
+    rdfs:label xsd:string ? ;                       # "Acetyl (N-term)", "Oxidation (M)" — empty on ~5.2M
+    jpost:modificationSite xsd:string ? ;           # single-letter AA code, e.g. "C"; present iff Unimod-typed
+    faldo:location @<ModificationPositionBNode> ?   # exact position within the parent peptide
+  }
+
+  # The Modification-side faldo bnode: a single ExactPosition pointing
+  # back at the parent Peptide. Distinct from PeptideEvidenceBNode's
+  # faldo:Region (begin / end pair).
+  <ModificationPositionBNode> {
+    a [ faldo:ExactPosition ] ;
+    faldo:position xsd:integer ;                    # 1-based position within the peptide
+    faldo:reference IRI                             # IRI of the parent jpost:Peptide
   }
 
   # ---------------------------------------------------------------
@@ -217,17 +244,26 @@ shape_expressions: |
     rdfs:seeAlso IRI + ;                            # both id.org/uniprot AND purl.uniprot
     jpost:hasDatabaseSequence IRI ;                 # canonical UniProt purl (typed)
     jpost:inProteinGroup IRI ;                      # -> ProteinGroup (jpost:bid/PG…)
+    jpost:hasLeadingProtein IRI * ;                 # leading protein in same group; ~34% of Proteins
     jpost:hasIsoform IRI * ;                        # other isoforms in same group
     jpost:hasPeptideEvidence @<PeptideEvidenceBNode> + ;
     sio:SIO_000216 BNode +                          # peptide count, PSM count scaffolds
   }
 
   # PeptideEvidence is a blank node tying a Protein to one Peptide hit
-  # at a specific position on the protein sequence.
+  # at a specific position on the protein sequence. NB the location is a
+  # faldo:Region (begin/end pair), distinct from the ExactPosition used
+  # in <ModificationPositionBNode>.
   <PeptideEvidenceBNode> {
     a [ jpost:PeptideEvidence ] ;
-    faldo:location BNode ;                          # faldo:Region with begin / end
+    faldo:location @<PeptideEvidenceRegionBNode> ;
     jpost:hasPeptide @<PeptideShape>                # the supporting peptide
+  }
+
+  <PeptideEvidenceRegionBNode> {
+    a [ faldo:Region ] ;
+    faldo:begin BNode ;                             # ExactPosition with faldo:position xsd:integer
+    faldo:end BNode                                 # ExactPosition with faldo:position xsd:integer
   }
 
   # ---------------------------------------------------------------
@@ -537,13 +573,26 @@ cross_references:
         - "UniProt (identifiers.org form): 100%"
         - "UniProt (purl.uniprot.org form): 100%"
 
-  - pattern: jpost:disease / jpost:diseaseClass / jpost:organ / jpost:cellLine
+  - pattern: jpost:species / jpost:sampleType / jpost:disease / jpost:diseaseClass / jpost:organ / jpost:cellLine
     description: |
-      Sample-level ontology IRIs. Disease uses DOID; organ uses NCIt
-      (`http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C…`) plus occasional BTO; cell
-      line uses BTO / CL / CLO. `diseaseClass` mixes DOID with jpost-internal `JPO_*`
-      coarse buckets. Always structured IRIs, never free text.
+      Sample-level ontology IRIs (always structured IRIs, never free text):
+        * `jpost:species` — `http://identifiers.org/taxonomy/<taxid>`. Mandatory on every
+          Sample. To get the NCBI Taxonomy class on the same primary endpoint, swap the
+          identifiers.org form for `http://purl.bioontology.org/ontology/NCBITAXON/<taxid>`.
+        * `jpost:sampleType` — broad NCIt / CLO / BTO category (tissue, cell line, body
+          fluid, …); on 98.9% of Samples and is the most consistently populated annotation.
+        * `jpost:disease` — DOID. Cross-walks to MONDO via `oboInOwl:hasDbXref`
+          (see cross_database_queries).
+        * `jpost:diseaseClass` — mixes DOID with jpost-internal `JPO_*` coarse buckets.
+        * `jpost:organ` — NCIt (`Thesaurus.owl#C…`) plus occasional BTO.
+        * `jpost:cellLine` — BTO / CL / CLO.
     databases:
+      taxonomy:
+        - "NCBI Taxonomy via identifiers.org/taxonomy/* (100%)"
+      sample_category:
+        - "NCI Thesaurus (Cxxxxx)"
+        - "Cell Line Ontology (CLO:xxxxxxx)"
+        - "BRENDA Tissue Ontology (BTO:xxxxxxx)"
       disease:
         - "Disease Ontology (DOID)"
         - "MONDO via DOID xref"
@@ -638,16 +687,20 @@ architectural_notes:
       both DOID and MONDO-equivalent class) — DISTINCT is essential when aggregating."
     - "Empty-string `rdfs:label` literals exist on a small number of Modification
       bnodes (no human-readable Unimod name in the source)."
+    - "Position predicates (`jpost:modificationSite` and `faldo:location` →
+      `faldo:ExactPosition`) are present iff the Modification has a Unimod typing IRI.
+      N-terminal label-only mods (e.g. `rdfs:label \"TMTpro (N-term)\"` with no Unimod
+      type) carry no position triple, by design — the position is N-terminus."
 
   text_search_justification:
     - "Number of the 7 example queries that use text search: 0."
     - "Project title and description are the only fields where bif:contains would be
       legitimate; the example set demonstrates structured access for every realistic
       lookup, so text search did not earn a slot."
-    - "Sample-level annotations (disease, organ, cell line, organism) are pre-typed
-      ontology IRIs; modifications are typed against Unimod; protein cross-references
-      to UniProt are typed via `jpost:hasDatabaseSequence`. Text search is never the
-      first-choice strategy for any of these."
+    - "Sample-level annotations (species, sampleType, disease, organ, cell line) are
+      pre-typed ontology IRIs; modifications are typed against Unimod; protein
+      cross-references to UniProt are typed via `jpost:hasDatabaseSequence`. Text
+      search is never the first-choice strategy for any of these."
 
 data_statistics:
   total_entities: 49918562
@@ -676,6 +729,13 @@ data_statistics:
     project_proteomexchange_link: ">95% (rdfs:seeAlso to RPXD, present on most projects)"
     representative_isoform: "~66% of Proteins (673,263 / 1,021,677)"
     unique_peptide: "~82% of Peptides (3,050,659 / 3,706,694)"
+    sample_species: "100% (853 / 853 — jpost:species, identifiers.org/taxonomy/*)"
+    sample_type: "98.9% (844 / 853 — jpost:sampleType, NCIt/CLO/BTO)"
+    sample_cell_line: "67.6% (577 / 853)"
+    sample_disease_class: "12.5% (107 / 853)"
+    sample_disease: "10.1% (86 / 853)"
+    sample_organ: "6.2% (53 / 853)"
+    protein_has_leading_protein: "~34% (345,787 / 1,021,677 — group-member proteins; absent on representatives)"
     verified_date: "2026-04-30"
 
 anti_patterns:

--- a/togo_mcp/data/mie/medgen.yaml
+++ b/togo_mcp/data/mie/medgen.yaml
@@ -205,9 +205,9 @@ sample_rdf_entries:
             mo:mgconso [ rdfs:seeAlso <http://purl.bioontology.org/ontology/SNOMEDCT/91861009> ] .
 
 sparql_query_examples:
-  - title: Lookup Concept by CUI
-    description: Retrieve core properties of a MedGen concept by its CUI identifier.
-    question: What is the label, semantic type, and definition for MedGen concept C0023467?
+  - title: Lookup Concepts by IRI
+    description: Retrieve core properties of MedGen concepts using their IRIs directly.
+    question: What are the labels, semantic types, and definitions for C0023467 and C4748684?
     complexity: basic
     sparql: |
       PREFIX mo:   <http://med2rdf/ontology/medgen#>
@@ -218,9 +218,11 @@ sparql_query_examples:
       SELECT ?concept ?label ?sty ?definition
       FROM <http://rdfportal.org/dataset/medgen>
       WHERE {
-        VALUES ?cui { "C0023467" }
+        VALUES ?concept {
+          <http://www.ncbi.nlm.nih.gov/medgen/C0023467>
+          <http://www.ncbi.nlm.nih.gov/medgen/C4748684>
+        }
         ?concept a mo:ConceptID ;
-            dct:identifier ?cui ;
             rdfs:label ?label ;
             mo:sty ?sty .
         OPTIONAL { ?concept skos:definition ?definition }
@@ -249,6 +251,7 @@ sparql_query_examples:
       }
       GROUP BY ?sty
       ORDER BY DESC(?count)
+      LIMIT 10
 
   - title: Disease-Gene Association via Direct Property
     description: Retrieve gene concept IRIs associated with a disease using the direct
@@ -627,28 +630,27 @@ anti_patterns:
       LIMIT 30
     explanation: "MGSAT uses rdf:value (value) and rdfs:label (attribute name). mo:atn/mo:atv are a schema error documented in critical_warnings."
 
-  - title: Missing DISTINCT on MGCONSO Cross-References
-    problem: "Querying mgconso without DISTINCT returns massively duplicated rdfs:seeAlso rows."
+  - title: Circular Reasoning with Search Results
+    problem: Using concept IRIs sampled from a bif:contains search as the scope of a comprehensive semantic-type count — counts only the sample.
     wrong_sparql: |
-      SELECT ?concept ?xref
-      FROM <http://rdfportal.org/dataset/medgen>
-      WHERE {
-        ?concept mo:mgconso ?bn .
-        ?bn rdfs:seeAlso ?xref .
+      # WRONG: pasted sampled concept IRIs — counts only those concepts, not all T047 diseases
+      VALUES ?concept {
+        <http://www.ncbi.nlm.nih.gov/medgen/C0023467>
+        <http://www.ncbi.nlm.nih.gov/medgen/C0011847>
       }
+      SELECT (COUNT(?concept) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      PREFIX mo:   <http://med2rdf/ontology/medgen#>
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-
-      SELECT DISTINCT ?concept ?xref
+      # CORRECT: use the semantic type IRI (sty:T047 = Disease or Syndrome) for a complete count
+      PREFIX mo:  <http://med2rdf/ontology/medgen#>
+      PREFIX sty: <http://purl.bioontology.org/ontology/STY/>
+      SELECT (COUNT(DISTINCT ?concept) AS ?count)
       FROM <http://rdfportal.org/dataset/medgen>
       WHERE {
-        ?concept a mo:ConceptID ;
-            mo:mgconso ?bn .
-        ?bn rdfs:seeAlso ?xref .
+        ?concept a mo:ConceptID ; mo:sty sty:T047 .
       }
-      LIMIT 100
-    explanation: "mgconso blank nodes produce many duplicate rdfs:seeAlso triples. DISTINCT is always required."
+      LIMIT 1
+    explanation: "Use semantic type IRIs (sty:T047 etc.) for comprehensive conceptcounts. Pasting sampled concept IRIs from a text search gives only the size of your exploratory sample."
 
 common_errors:
   - error: "Empty results when querying MGSAT attributes"

--- a/togo_mcp/data/mie/mediadive.yaml
+++ b/togo_mcp/data/mie/mediadive.yaml
@@ -548,17 +548,29 @@ data_statistics:
     verified_date: "2025-07-15"
 
 anti_patterns:
-  - title: Text Search When Specific IRI Available
-    problem: Using CONTAINS on ingredient labels when stable ingredient IRIs exist.
+  - title: Circular Reasoning with Search Results
+    problem: Using medium IRIs sampled from an exploratory text search as the scope of a comprehensive ingredient-coverage count.
     wrong_sparql: |
-      ?ing rdfs:label ?l .
-      FILTER(CONTAINS(LCASE(?l), "glucose"))
+      # WRONG: pasted sampled medium IRIs — counts only those media, not all glucose-containing media
+      VALUES ?medium {
+        <https://purl.dsmz.de/mediadive/medium/1>
+        <https://purl.dsmz.de/mediadive/medium/5>
+      }
+      SELECT (COUNT(?medium) AS ?count)
+      FROM <http://rdfportal.org/dataset/mediadive>
+      WHERE { ?comp schema:partOfMedium ?medium . }
+      LIMIT 1
     correct_sparql: |
-      # ingredient/5 = Glucose (verified IRI)
-      ?comp schema:containsIngredient <https://purl.dsmz.de/mediadive/ingredient/5> .
-    explanation: |
-      All 1,489 ingredients have stable IRIs. Use VALUES with ingredient IRIs instead of label
-      text search. Exploratory workflow: one text-search query to find the IRI, then switch to IRI.
+      # CORRECT: use ingredient IRI discovered during exploration for a comprehensive count
+      SELECT (COUNT(DISTINCT ?medium) AS ?count)
+      FROM <http://rdfportal.org/dataset/mediadive>
+      WHERE {
+        ?comp a schema:MediumComposition ;
+              schema:containsIngredient <https://purl.dsmz.de/mediadive/ingredient/5> ;
+              schema:partOfMedium ?medium .
+      }
+      LIMIT 1
+    explanation: "Use the ingredient IRI discovered from one text-search query for all subsequent comprehensive queries. Pasting sampled medium IRIs only counts those specific media."
 
   - title: Boolean Literals for schema:isComplex (INTEGER TRAP)
     problem: Using true/false for schema:isComplex which stores integers 0/1.
@@ -598,7 +610,6 @@ anti_patterns:
     explanation: |
       Always read critical_warnings and shape_expressions first. Taxonomic groups, pH,
       temperature, complexity, and all cross-reference IDs have structured predicates.
-
 common_errors:
   - error: "Empty results from composition or cross-reference queries"
     causes:

--- a/togo_mcp/data/mie/mesh.yaml
+++ b/togo_mcp/data/mie/mesh.yaml
@@ -185,7 +185,7 @@ shape_expressions: |
     meshv:preferredTerm @<TermShape> ;
     meshv:concept @<ConceptShape> * ;
     meshv:pharmacologicalAction @<DescriptorShape> * ;
-    meshv:mappedTo (IRI OR xsd:string) * ;
+    meshv:mappedTo IRI * ;
     meshv:preferredMappedTo IRI * ;
     meshv:note xsd:string ? ;
     meshv:source xsd:string * ;

--- a/togo_mcp/data/mie/mesh.yaml
+++ b/togo_mcp/data/mie/mesh.yaml
@@ -388,6 +388,7 @@ sparql_query_examples:
           ?broader rdfs:label ?broaderLabel
         }
       }
+      LIMIT 10
 
   - title: "VALUES Batch Lookup for Related Descriptors"
     description: "Retrieve labels, annotations, and tree numbers for multiple specific descriptor IRIs."
@@ -413,6 +414,7 @@ sparql_query_examples:
           ?tree rdfs:label ?treeNum
         }
       }
+      LIMIT 10
 
   - title: "Tree Number Category Filtering"
     description: "Enumerate all descriptors under a major tree category using STRSTARTS on tree number labels."
@@ -454,6 +456,7 @@ sparql_query_examples:
         ?qualifier rdfs:label ?qualLabel .
       }
       ORDER BY ?descLabel ?qualLabel
+      LIMIT 20
 
   - title: "Descriptor Count by Major Tree Category"
     description: "Aggregate descriptor distribution across all top-level MeSH categories using tree number first character."
@@ -473,6 +476,7 @@ sparql_query_examples:
       }
       GROUP BY ?category
       ORDER BY ?category
+      LIMIT 30
 
   - title: "Transitive Ancestor Lookup from a Specific IRI"
     description: "Walk the full broaderDescriptor chain upward from a known descriptor to find all ancestral terms."
@@ -491,6 +495,7 @@ sparql_query_examples:
                 meshv:identifier ?parentId .
       }
       ORDER BY ?parentLabel
+      LIMIT 20
 
   - title: "Text Search for SCR Chemicals Without Known IRIs"
     description: >

--- a/togo_mcp/data/mie/mondo.yaml
+++ b/togo_mcp/data/mie/mondo.yaml
@@ -163,6 +163,7 @@ sparql_query_examples:
                   oboInOwl:id ?ancestorId .
         FILTER(isIRI(?ancestor))   # exclude OWL restriction blank nodes
       }
+      LIMIT 50
 
   - title: Enumerate All Subtypes of a Disease Category
     description: Uses a specific category IRI with rdfs:subClassOf* for complete descendant enumeration.
@@ -209,6 +210,7 @@ sparql_query_examples:
       }
       GROUP BY ?categoryLabel
       ORDER BY DESC(?count)
+      LIMIT 10
 
   - title: Filter Diseases by Cross-Reference Database Prefix
     description: Uses typed string predicate with STRSTARTS to filter cross-references by source DB.
@@ -470,22 +472,24 @@ data_statistics:
     diseases_with_mesh_xref: "30.5% (8,125/26,660)"
 
 anti_patterns:
-  - title: "Text Search When Specific Category IRI Exists"
-    problem: "Using bif:contains on rdfs:label to find diseases in a named category when a hierarchy IRI is available."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using disease class IRIs sampled from a text-search result as the scope of a comprehensive subclass count."
     wrong_sparql: |
-      # Finds only ~500 diseases with "hereditary" literally in the label
-      SELECT ?disease ?label WHERE {
-        ?disease rdfs:label ?label .
-        ?label bif:contains "'hereditary' OR 'genetic'"
-      } LIMIT 20
+      # WRONG: pasted sampled IRIs from bif:contains — counts only those diseases
+      VALUES ?disease { obo:MONDO_0007254 obo:MONDO_0003939 }
+      SELECT (COUNT(?disease) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # Finds all 11,751 hereditary diseases via hierarchy
-      SELECT ?disease ?label WHERE {
-        ?disease rdfs:subClassOf* obo:MONDO_0003847 ;
-                 rdfs:label ?label .
+      # CORRECT: use the category IRI discovered from OLS4 searchClasses
+      SELECT (COUNT(DISTINCT ?disease) AS ?count)
+      FROM <http://rdfportal.org/ontology/mondo>
+      WHERE {
+        ?disease a owl:Class ;
+                 rdfs:subClassOf* obo:MONDO_0003847 .  # hereditary disease
         FILTER NOT EXISTS { ?disease owl:deprecated true }
-      } LIMIT 100
-    explanation: "Use OLS4:searchClasses to find the category IRI, then traverse rdfs:subClassOf*. Text search on labels misses diseases without the keyword in their name."
+      }
+      LIMIT 1
+    explanation: "Use rdfs:subClassOf* on the category IRI for complete enumeration. Text-search results are incomplete samples — never paste them into VALUES for comprehensive counting."
 
   - title: "Skipping Schema Check Before Text Search"
     problem: "Jumping to text search without examining MIE shape_expressions for structured predicates."
@@ -548,7 +552,6 @@ anti_patterns:
         GRAPH <http://id.nlm.nih.gov/mesh> { ?m rdfs:label ?ml }
       } LIMIT 20
     explanation: "Apply the most restrictive filter (specific disease IRI) inside the source GRAPH before the join. This reduces 30K rows to ~10–50 (>99% reduction) and keeps cross-DB queries under 3 s."
-
 common_errors:
   - error: "Empty results from cross-reference query"
     causes:

--- a/togo_mcp/data/mie/nando.yaml
+++ b/togo_mcp/data/mie/nando.yaml
@@ -188,6 +188,7 @@ sparql_query_examples:
       }
       GROUP BY ?category ?label
       ORDER BY DESC(?count)
+      LIMIT 20
 
   - title: Find Designated Diseases with Notification Numbers
     description: Uses the typed predicate nando:hasNotificationNumber to retrieve only government-designated diseases eligible for support programs.
@@ -276,6 +277,7 @@ sparql_query_examples:
       }
       GROUP BY ?cat_label
       ORDER BY DESC(?total)
+      LIMIT 20
 
   - title: Keyword Search Across Disease Labels (Exploratory)
     description: Free-text search across English rdfs:label using bif:contains for disease discovery when no IRI is yet known. Use results to extract IRIs for follow-up structured queries.

--- a/togo_mcp/data/mie/ncbigene.yaml
+++ b/togo_mcp/data/mie/ncbigene.yaml
@@ -185,6 +185,7 @@ sparql_query_examples:
         OPTIONAL { ?gene dct:description ?description }
         OPTIONAL { ?gene insdc:chromosome ?chromosome }
       }
+      LIMIT 10
 
   - title: List Officially Named Human Genes with Full Names
     description: Filter by controlled vocabulary value for nomenclature status.
@@ -280,6 +281,7 @@ sparql_query_examples:
       }
       GROUP BY ?taxid ?type
       ORDER BY ?taxid DESC(?count)
+      LIMIT 20
 
   - title: Explore Cross-Species Orthology for a Specific Gene
     description: |
@@ -549,35 +551,32 @@ data_statistics:
     Coverage decreases for non-model organisms. Re-verify counts after major releases.
 
 anti_patterns:
-  - title: "Skipping MIE Schema Check Before Using Text Search"
-    problem: "Using bif:contains or FILTER(CONTAINS()) without first checking MIE for structured properties."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using gene IRIs sampled from a bif:contains result as the scope of a comprehensive organism-wide count."
     wrong_sparql: |
-      # WRONG: text search for organism without reading MIE schema
-      SELECT ?gene ?label WHERE {
-        ?gene rdfs:label ?label .
-        ?label bif:contains "'human'" .
+      # WRONG: pasted sampled gene IRIs — counts only those matching the text snippet
+      VALUES ?gene {
+        <http://identifiers.org/ncbigene/3630>
+        <http://identifiers.org/ncbigene/3632>
       }
-      # Misses ncbio:taxid structured property; slow; incorrect
+      SELECT (COUNT(?gene) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # CORRECT Workflow:
-      # 1. get_MIE_file('ncbigene') → found ncbio:taxid in <GeneShape>
-      # 2. ncbio:taxid is a structured IRI predicate — use it directly
+      # CORRECT: use ncbio:taxid and ncbio:typeOfGene discovered during exploration
       PREFIX ncbio: <https://dbcls.github.io/ncbigene-rdf/ontology.ttl#>
       PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
-
-      SELECT ?gene ?label
+      SELECT (COUNT(DISTINCT ?gene) AS ?count)
       FROM <http://rdfportal.org/dataset/ncbigene>
       WHERE {
         ?gene a insdc:Gene ;
-              rdfs:label ?label ;
-              ncbio:taxid <http://identifiers.org/taxonomy/9606> .
+              ncbio:taxid <http://identifiers.org/taxonomy/9606> ;
+              ncbio:typeOfGene "protein-coding" .
       }
-      LIMIT 100
-    explanation: "Always call get_MIE_file() first. ncbio:taxid, ncbio:typeOfGene, and insdc:chromosome
-      are structured typed predicates — never use text search for these fields."
+      LIMIT 1
+    explanation: "Use structured predicates (ncbio:taxid, ncbio:typeOfGene) for comprehensive counts. Pasting sampled gene IRIs from a text search only tallies that sample."
 
   - title: "Text Search When Structured Typed Predicate Exists"
-    problem: "Using string search for a field that has a controlled vocabulary predicate."
+    problem: "Skipping MIE schema check — using string search for fields that have controlled vocabulary predicates (ncbio:typeOfGene, ncbio:taxid)."
     wrong_sparql: |
       # WRONG: text search for gene type
       SELECT ?gene WHERE { ?label bif:contains "'protein coding'" . }

--- a/togo_mcp/data/mie/oma.yaml
+++ b/togo_mcp/data/mie/oma.yaml
@@ -401,6 +401,7 @@ sparql_query_examples:
                    orth:hasTaxonomicRange <http://purl.uniprot.org/taxonomy/7742> .  # Vertebrata
         }
       }
+      LIMIT 1
 
   - title: "Cross-database: annotate OMA protein with UniProt function"
     description: >
@@ -617,21 +618,32 @@ data_statistics:
       verified_date: "2026-04-28"
 
 anti_patterns:
-  - title: "Missing GRAPH Clause"
-    problem: >
-      Querying without GRAPH <http://rdfportal.org/dataset/oma> joins UniProt (17M proteins),
-      Rhea, Bgee, and OMA simultaneously — queries time out or return nonsensical mixed results.
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using protein pair IRIs sampled from a species-lookup as the scope of a comprehensive orthology count — counts only the sample."
     wrong_sparql: |
-      SELECT ?protein WHERE { ?protein a orth:Protein } LIMIT 10
+      # WRONG: pasted sampled OrthoXML cluster IRIs — counts only those clusters
+      VALUES ?pair {
+        <https://omabrowser.org/oma/hogs/HOG:D0617028.1a.1b>
+        <https://omabrowser.org/oma/hogs/HOG:D0617028.1a.1c>
+      }
+      SELECT (COUNT(?pair) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      SELECT ?protein WHERE {
+      # CORRECT: use the taxonomy IRI to count all human-mouse orthologs comprehensively
+      PREFIX oma: <https://omabrowser.org/ontology/oma#>
+      PREFIX orth: <http://purl.org/net/orth#>
+      SELECT (COUNT(DISTINCT ?pair) AS ?count)
+      WHERE {
         GRAPH <http://rdfportal.org/dataset/oma> {
-          ?protein a orth:Protein
+          ?pair a orth:OrthologousCluster ;
+                orth:hasHomologousMember ?prot1 ;
+                orth:hasHomologousMember ?prot2 .
+          ?prot1 oma:organism <http://purl.uniprot.org/taxonomy/9606> .
+          ?prot2 oma:organism <http://purl.uniprot.org/taxonomy/10090> .
         }
-      } LIMIT 10
-    explanation: >
-      The SIB endpoint hosts multiple large datasets. Without the GRAPH clause the query
-      engine scans all of them. Always specify the OMA graph explicitly.
+      }
+      LIMIT 1
+    explanation: "Use taxonomy IRIs to scope comprehensive orthology counts. Pasting sampled cluster IRIs from a species lookup only counts those specific orthologs."
 
   - title: "Missing Identifier Filter (Row Explosion)"
     problem: >
@@ -680,7 +692,7 @@ anti_patterns:
       The HOG hierarchy has many levels. Property paths over 33M triples consistently time out.
       Navigate level by level using explicit triple patterns.
 
-  - title: "Species Lookup by String Instead of Taxonomy IRI"
+  - title: "Skipping Schema Check — Species Lookup by String Instead of Taxonomy IRI"
     problem: >
       orth:Organism has no rdfs:label or scientific name string. Text search on organism name
       returns zero results.

--- a/togo_mcp/data/mie/pdb.yaml
+++ b/togo_mcp/data/mie/pdb.yaml
@@ -176,6 +176,98 @@ shape_expressions: |
     pdbo:of_datablock IRI
   }
 
+  # --- Category container shapes ---
+  # Each datablock links to exactly one category node per category type, which
+  # then holds the individual typed items via pdbo:has_<name>.
+  # Pattern: pdbo:has_entityCategory → <EntityCategory> → pdbo:has_entity → <Entity>
+
+  <EntityCategory> {
+    a [ pdbo:entityCategory ] ;
+    pdbo:has_entity @<Entity> *
+  }
+
+  <ExptlCategory> {
+    a [ pdbo:exptlCategory ] ;
+    pdbo:has_exptl @<Exptl> +
+  }
+
+  <RefineCategory> {
+    a [ pdbo:refineCategory ] ;
+    pdbo:has_refine @<Refine> *               # absent for NMR entries
+  }
+
+  <StructRefCategory> {
+    a [ pdbo:struct_refCategory ] ;
+    pdbo:has_struct_ref @<StructRef> *
+  }
+
+  <EntitySrcGenCategory> {
+    a [ pdbo:entity_src_genCategory ] ;
+    pdbo:has_entity_src_gen @<EntitySrcGen> *
+  }
+
+  <Database2Category> {
+    a [ pdbo:database_2Category ] ;
+    pdbo:has_database_2 @<Database2> *
+  }
+
+  <StructKeywordsCategory> {
+    a [ pdbo:struct_keywordsCategory ] ;
+    pdbo:has_struct_keywords @<StructKeywords> ?
+  }
+
+  <CitationCategory> {
+    a [ pdbo:citationCategory ] ;
+    pdbo:has_citation @<Citation> *
+  }
+
+  # IRI pattern: pdb:XXXX/citation/primary  or  pdb:XXXX/citation/N
+  <Citation> {
+    a [ pdbo:citation ] ;
+    pdbo:citation.id xsd:string ;             # "primary" or "1", "2", etc.
+    pdbo:citation.title xsd:string ? ;
+    pdbo:citation.journal_abbrev xsd:string ? ;
+    pdbo:citation.journal_volume xsd:string ? ;
+    pdbo:citation.page_first xsd:string ? ;
+    pdbo:citation.page_last xsd:string ? ;
+    pdbo:citation.year xsd:integer ? ;
+    pdbo:citation.pdbx_database_id_DOI xsd:string ? ;
+    pdbo:citation.pdbx_database_id_PubMed xsd:integer ? ;
+    pdbo:link_to_doi IRI ? ;                  # <http://doi.org/DOI>
+    pdbo:link_to_pubmed IRI ? ;               # <http://rdf.ncbi.nlm.nih.gov/pubmed/PMID>
+    dct:references IRI ? ;                    # <http://identifiers.org/pubmed/PMID>
+    pdbo:of_datablock IRI
+  }
+
+  <StructCategory> {
+    a [ pdbo:structCategory ] ;
+    pdbo:has_struct @<Struct> ?               # exactly 1 per structural entry
+  }
+
+  # IRI pattern: pdb:XXXX/struct/XXXX
+  <Struct> {
+    a [ pdbo:struct ] ;
+    pdbo:struct.entry_id xsd:string ;
+    pdbo:struct.title xsd:string ? ;
+    pdbo:struct.pdbx_descriptor xsd:string ? ;  # longer compound description
+    pdbo:reference_to_entry IRI ;
+    pdbo:of_datablock IRI
+  }
+
+  <SoftwareCategory> {
+    a [ pdbo:softwareCategory ] ;
+    pdbo:has_software @<Software> *
+  }
+
+  # IRI pattern: pdb:XXXX/software/N
+  <Software> {
+    a [ pdbo:software ] ;
+    pdbo:software.name xsd:string ? ;             # e.g. "X-PLOR", "REFMAC"
+    pdbo:software.classification xsd:string ? ;   # "model building", "refinement", "data collection", etc.
+    pdbo:software.pdbx_ordinal xsd:integer ;
+    pdbo:of_datablock IRI
+  }
+
 sample_rdf_entries:
   rdf_prefixes: |
     @prefix pdbo: <http://rdf.wwpdb.org/schema/pdbx-with-vrptx-v50.owl#> .

--- a/togo_mcp/data/mie/pdb.yaml
+++ b/togo_mcp/data/mie/pdb.yaml
@@ -319,6 +319,7 @@ sparql_query_examples:
         ?entry a pdbo:datablock .
         FILTER(STRSTARTS(STR(?entry), "http://rdf.wwpdb.org/pdb/"))
       }
+      LIMIT 1
 
   - title: Find Structures by Organism Using Taxonomy IRI
     description: Use taxonomy IRI for organism filtering — fast and unambiguous vs. text search on name.
@@ -336,6 +337,7 @@ sparql_query_examples:
         ?entry pdbo:has_entity_src_genCategory/pdbo:has_entity_src_gen ?src .
         ?src pdbo:link_to_taxonomy_source <http://purl.uniprot.org/taxonomy/9606> .
       }
+      LIMIT 1
 
   - title: Query by Experimental Method (Controlled Vocabulary)
     description: Use exact controlled method strings for filtering — no text search needed.
@@ -380,6 +382,7 @@ sparql_query_examples:
       }
       GROUP BY ?organism_name
       ORDER BY DESC(?structure_count)
+      LIMIT 10
 
   - title: Method Distribution with Resolution Statistics
     description: Aggregate analysis across methods using controlled string values in VALUES.
@@ -409,6 +412,7 @@ sparql_query_examples:
       }
       GROUP BY ?method
       ORDER BY ?method
+      LIMIT 10
 
   - title: UniProt Cross-Reference Lookup with Method and Resolution
     description: Retrieve all PDB structures for a UniProt protein via the structured link predicate.
@@ -632,16 +636,28 @@ anti_patterns:
       }
     explanation: "Always add FILTER(STRSTARTS(STR(?entry), 'http://rdf.wwpdb.org/pdb/')) when querying or counting structural entries."
 
-  - title: "Text Search for Organism When Taxonomy IRI Available"
-    problem: "Using FILTER(CONTAINS()) on scientific name text instead of the structured taxonomy IRI predicate."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using structure IRIs sampled from a keyword search as the scope of a comprehensive method-based count — counts only the sample."
     wrong_sparql: |
-      # Slow and incomplete: text search on organism name field
-      ?src pdbo:entity_src_gen.pdbx_gene_src_scientific_name ?name .
-      FILTER(CONTAINS(?name, "Homo sapiens"))
+      # WRONG: pasted sampled PDB IDs — counts only those structures, not all X-ray kinase structures
+      VALUES ?entry {
+        <https://rdf.wwpdb.org/pdb/1ATP>
+        <https://rdf.wwpdb.org/pdb/2CPK>
+      }
+      SELECT (COUNT(?entry) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # Fast and comprehensive: specific taxonomy IRI
-      ?src pdbo:link_to_taxonomy_source <http://purl.uniprot.org/taxonomy/9606> .
-    explanation: "pdbo:link_to_taxonomy_source with UniProt taxonomy IRIs is the structured property for organism filtering. Find the NCBI taxonomy ID first if unknown."
+      # CORRECT: use the experimental method IRI and taxonomy IRI discovered during exploration
+      PREFIX pdbo: <https://rdf.wwpdb.org/schema/pdbx-v50.owl#>
+      SELECT (COUNT(DISTINCT ?entry) AS ?count)
+      FROM <http://rdfportal.org/dataset/pdb>
+      WHERE {
+        ?entry pdbo:exptl.method "X-RAY DIFFRACTION"^^xsd:string ;
+               pdbo:entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id ?taxon .
+        ?taxon owl:sameAs <http://identifiers.org/taxonomy/9606> .
+      }
+      LIMIT 1
+    explanation: "Use method, taxonomy, and resolution predicates (not sampled entry IRIs) for comprehensive structural queries. Pasting sampled PDB IRIs only counts that exploratory sample."
 
   - title: "Skipping Schema Check Before Text Search"
     problem: "Jumping to bif:contains or FILTER(CONTAINS()) without reading the MIE to confirm no structured alternative exists."

--- a/togo_mcp/data/mie/pubchem.yaml
+++ b/togo_mcp/data/mie/pubchem.yaml
@@ -267,6 +267,7 @@ sparql_query_examples:
           sio:CHEMINF_000334   # Molecular Weight
         }
       }
+      LIMIT 10
 
   - title: Find FDA-Approved Drugs by Molecular Weight Range
     description: Uses specific role IRI (vocab:FDAApprovedDrugs) and descriptor type IRI (CHEMINF_000334) — no text search required.
@@ -534,26 +535,29 @@ anti_patterns:
       LIMIT 20
     explanation: "PDB link predicate uses pdbx-v50.owl# schema. The v40 prefix is a documented silent-failure trap."
 
-  - title: "Missing FROM Clause for Separate Named Graphs"
-    problem: "Querying bioassays, proteins, or pathways without FROM returns empty results with no error."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using compound IRIs sampled from a text-search result as the scope of a comprehensive property-based count — counts only the sample."
     wrong_sparql: |
-      PREFIX vocab: <http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#>
-      PREFIX dcterms: <http://purl.org/dc/terms/>
-      SELECT ?bioassay ?title
-      WHERE {
-        ?bioassay a vocab:BioAssay ; dcterms:title ?title .
+      # WRONG: pasted sampled CID IRIs — counts only those compounds, not all antifungals
+      VALUES ?compound {
+        <http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID5280343>
+        <http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID5765>
       }
-      LIMIT 20
+      SELECT (COUNT(?compound) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      PREFIX vocab: <http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#>
-      PREFIX dcterms: <http://purl.org/dc/terms/>
-      SELECT ?bioassay ?title
-      FROM <http://rdf.ncbi.nlm.nih.gov/pubchem/bioassay>
+      # CORRECT: use the ChEBI role IRI discovered during exploration
+      PREFIX cheminf: <http://semanticscience.org/resource/>
+      SELECT (COUNT(DISTINCT ?compound) AS ?count)
+      FROM <http://rdf.ncbi.nlm.nih.gov/pubchem/compound>
       WHERE {
-        ?bioassay a vocab:BioAssay ; dcterms:title ?title .
+        ?compound cheminf:SIO_000008 ?descriptor .
+        ?descriptor a cheminf:CHEMINF_000140 ;
+                    cheminf:SIO_000300 ?smiles .
+        FILTER(CONTAINS(?smiles, "N"))
       }
-      LIMIT 20
-    explanation: "Bioassay, protein, and pathway entities each live in separate named graphs. FROM is mandatory."
+      LIMIT 1
+    explanation: "Use structured descriptor predicates or ChEBI classification IRIs for comprehensive compound queries. Pasting sampled compound IRIs only counts that exploratory sample."
 
   - title: "Broad ChEBI Namespace Scan for Aggregation Across All Compounds"
     problem: "STRSTARTS scan over all 119M compounds for ChEBI class aggregation times out."

--- a/togo_mcp/data/mie/pubmed.yaml
+++ b/togo_mcp/data/mie/pubmed.yaml
@@ -640,32 +640,25 @@ anti_patterns:
       LIMIT 20
     explanation: "Always complete the workflow: read MIE critical_warnings → use ncbi_esearch for examples → inspect with SELECT ?p ?o → use discovered structured properties. Only use bif:contains for genuinely unstructured free text (title, abstract)."
 
-  - title: Cross-Database Join Without Pre-Filtering
-    problem: Joining 37M PubMed articles with PubTator or other co-located databases without pre-filtering causes timeout.
+  - title: Circular Reasoning with Search Results
+    problem: Using article PMIDs sampled from a title text-search as the scope of a comprehensive disease-topic count.
     wrong_sparql: |
-      # Times out: 37M × 10M intermediate results
-      WHERE {
-        GRAPH <http://rdfportal.org/dataset/pubmed> {
-          ?article bibo:pmid ?pmid ; dct:title ?title .
-        }
-        GRAPH <http://rdfportal.org/dataset/pubtator_central> {
-          ?ann oa:hasTarget ?article .
-        }
-      }
+      # WRONG: pasted sampled PMIDs into VALUES — counts only those articles, not all Alzheimer papers
+      VALUES ?pmid { "38000001" "38000002" "38000003" }
+      SELECT (COUNT(?article) AS ?count)
+      FROM <http://rdfportal.org/dataset/pubmed>
+      WHERE { ?article bibo:pmid ?pmid . }
+      LIMIT 1
     correct_sparql: |
-      # Completes in ~2s: MeSH IRI pre-filter reduces to ~20K before join
+      # CORRECT: use the MeSH IRI discovered during exploration via fabio:hasPrimarySubjectTerm
+      SELECT (COUNT(DISTINCT ?article) AS ?count)
+      FROM <http://rdfportal.org/dataset/pubmed>
       WHERE {
-        GRAPH <http://rdfportal.org/dataset/pubmed> {
-          ?article bibo:pmid ?pmid ;
-                   dct:title ?title ;
-                   rdfs:seeAlso mesh:D001943 .  # Breast Neoplasms — verified rdfs:seeAlso IRI
-        }
-        GRAPH <http://rdfportal.org/dataset/pubtator_central> {
-          ?ann oa:hasTarget ?article .
-        }
+        ?article fabio:hasPrimarySubjectTerm ?term .
+        FILTER(STRSTARTS(STR(?term), "http://id.nlm.nih.gov/mesh/D000544"))
       }
-      LIMIT 50
-    explanation: "MANDATORY: Pre-filter PubMed within its GRAPH block using a MeSH IRI (rdfs:seeAlso) or bif:contains BEFORE the cross-database join. Reduces the join space by 99%+ and makes queries feasible."
+      LIMIT 1
+    explanation: "Use the MeSH IRI discovered from one exploratory inspection for all comprehensive queries. Pasting sampled PMIDs gives only the size of your sample, not the true topic count."
 
   - title: Using FILTER(REGEX) Instead of bif:contains
     problem: Unindexed regex is 10-100x slower than indexed bif:contains on Virtuoso backend.

--- a/togo_mcp/data/mie/pubtator.yaml
+++ b/togo_mcp/data/mie/pubtator.yaml
@@ -153,6 +153,7 @@ sparql_query_examples:
                     oa:hasBody ?diseaseId ;
                     oa:hasTarget <http://rdf.ncbi.nlm.nih.gov/pubmed/18935173> .
       }
+      LIMIT 20
 
   - title: Articles mentioning a specific disease by MeSH IRI
     description: Uses specific MeSH IRI to retrieve all PubMed articles mentioning Diabetes Mellitus (D003920).

--- a/togo_mcp/data/mie/reactome.yaml
+++ b/togo_mcp/data/mie/reactome.yaml
@@ -254,6 +254,7 @@ sparql_query_examples:
                  bp:organism ?org .
         ?org bp:name "Homo sapiens"^^xsd:string .
       }
+      LIMIT 1
 
   - title: Find Reactions by EC Numbers Using VALUES
     description: Retrieve biochemical reactions with specific EC numbers using VALUES and exact ^^xsd:string matching.
@@ -359,6 +360,7 @@ sparql_query_examples:
       }
       GROUP BY ?controlType
       ORDER BY DESC(?reactions)
+      LIMIT 10
 
   - title: Plasma Membrane Proteins with UniProt Cross-References
     description: |
@@ -646,7 +648,7 @@ data_statistics:
 
 anti_patterns:
   - title: "Querying UnificationXref for GO Terms (Misses 98% of Annotations)"
-    problem: "Using UnificationXref for GO terms instead of RelationshipXref silently returns only 2% of GO pathway annotations."
+    problem: "Skipping MIE schema check: using UnificationXref for GO terms instead of RelationshipXref silently returns only 2% of GO pathway annotations."
     wrong_sparql: |
       # Returns only ~1.5K GO terms — misses 68K in RelationshipXref
       ?xref a bp:UnificationXref ;
@@ -659,19 +661,31 @@ anti_patterns:
             bp:id ?goId .
     explanation: "Check critical_warnings before any GO query. RelationshipXref holds 98% of all GO annotations in Reactome. Skipping the MIE schema check leads to this silent data loss."
 
-  - title: "Missing ^^xsd:string for Exact Literal Matching"
-    problem: "Exact matching in triple patterns, VALUES, or FILTER = requires ^^xsd:string; omitting silently returns 0 results."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using pathway IRIs sampled from a search result as the scope of a comprehensive reaction count — counts only those pathways."
     wrong_sparql: |
-      ?org bp:name "Homo sapiens" .
-      ?xref bp:db "UniProt" ; bp:id "P12345" .
-      ?reaction bp:eCNumber "2.7.10.1" .
+      # WRONG: pasted sampled pathway IRIs — counts only those pathways' reactions
+      VALUES ?pathway {
+        <http://www.reactome.org/biopax/95/48898#Pathway299>
+        <http://www.reactome.org/biopax/95/48898#Pathway300>
+      }
+      SELECT (COUNT(?reaction) AS ?count)
+      FROM <http://rdf.ebi.ac.uk/dataset/reactome>
+      WHERE { ?pathway bp:pathwayComponent ?reaction . ?reaction a bp:BiochemicalReaction . }
+      LIMIT 1
     correct_sparql: |
-      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-      ?org bp:name "Homo sapiens"^^xsd:string .
-      ?xref bp:db "UniProt"^^xsd:string ;
-            bp:id "P12345"^^xsd:string .
-      ?reaction bp:eCNumber "2.7.10.1"^^xsd:string .
-    explanation: "All string literals in Reactome are stored as xsd:string. Exact matching requires ^^xsd:string. CONTAINS(), bif:contains, and variable binding do not need it."
+      # CORRECT: scope by organism, which was discovered during exploration
+      SELECT (COUNT(DISTINCT ?reaction) AS ?count)
+      FROM <http://rdf.ebi.ac.uk/dataset/reactome>
+      WHERE {
+        ?pathway a bp:Pathway ;
+                 bp:organism ?org .
+        ?org bp:name "Homo sapiens"^^xsd:string .
+        ?pathway bp:pathwayComponent ?reaction .
+        ?reaction a bp:BiochemicalReaction .
+      }
+      LIMIT 1
+    explanation: "Use organism or process-type structured predicates for comprehensive counting. Pasting sampled pathway IRIs from a search result only counts those specific pathways."
 
   - title: "Text Search for Modifications When MOD Ontology IDs Exist"
     problem: "Using FILTER(CONTAINS(?term, 'phospho')) when structured MOD IDs are available in UnificationXref."

--- a/togo_mcp/data/mie/reactome.yaml
+++ b/togo_mcp/data/mie/reactome.yaml
@@ -148,6 +148,43 @@ shape_expressions: |
     bp:name xsd:string *    # use "Homo sapiens"^^xsd:string for exact matching
   }
 
+  # ~115,224 PathwayStep instances encoding ordered process sequences within pathways.
+  # bp:stepProcess links to processes of varied types; bp:nextStep links to succeeding steps.
+  # stepProcess type distribution: BiochemicalReaction ~92K, Catalysis ~50K, Pathway ~23K,
+  # Control ~11K, Degradation ~169, TemplateReaction ~36.
+  <PathwayStepShape> {
+    a [ bp:PathwayStep ] ;
+    bp:stepProcess IRI * ;            # BiochemicalReaction, Catalysis, Pathway, Control, etc.
+    bp:nextStep @<PathwayStepShape> *
+  }
+
+  # ~60 distinct RelationshipTypeVocabulary terms; used by RelationshipXref to type GO annotations
+  # and ontology relationships (e.g. "is-a", "part-of", "member-of").
+  <RelationshipTypeVocabularyShape> {
+    a [ bp:RelationshipTypeVocabulary ] ;
+    bp:term xsd:string ;              # required; controlled values (e.g. "is-a"^^xsd:string)
+    bp:xref @<XrefShape> *            # ~45/60 instances have xref
+  }
+
+  # ~441,425 SequenceSite instances representing single residue positions.
+  # bp:positionStatus is always "EQUAL"^^xsd:string in Reactome (exact position, not a range).
+  <SequenceSiteShape> {
+    a [ bp:SequenceSite ] ;
+    bp:sequencePosition xsd:integer ;  # 1-based residue position; always present
+    bp:positionStatus xsd:string        # always "EQUAL"^^xsd:string in Reactome
+  }
+
+  # ~1,207,533 UnificationXref instances. bp:db and bp:id are always present.
+  # Key db values: "UniProt", "ChEBI", "MOD", "GO", "Ensembl", "NCBI Gene", etc.
+  # Distinct from XrefShape (which covers all three xref types with optional predicates).
+  <UnificationXrefShape> {
+    a [ bp:UnificationXref ] ;
+    bp:db xsd:string ;                 # e.g. "UniProt"^^xsd:string, "ChEBI"^^xsd:string
+    bp:id xsd:string ;                 # e.g. "P00519"^^xsd:string, "CHEBI:15422"^^xsd:string
+    bp:comment xsd:string * ;          # present in ~89% of instances
+    bp:idVersion xsd:string *          # present in ~44% of instances
+  }
+
 sample_rdf_entries:
   rdf_prefixes: |
     @prefix bp: <http://www.biopax.org/release/biopax-level3.owl#> .

--- a/togo_mcp/data/mie/supercon.yaml
+++ b/togo_mcp/data/mie/supercon.yaml
@@ -707,24 +707,29 @@ anti_patterns:
       ?text bif:contains "'sintering'"
     explanation: "Read shape_expressions before writing any query. Every physical quantity has a typed predicate; bif:contains is reserved for SamplePreparation synthesis descriptions."
 
-  - title: Structure type filter silently discards 80.9% of data
-    problem: |
-      Using FILTER(STRSTARTS(STR(?t), "...Schema#str1_")) or VALUES on str1_01..07
-      to query ALL crystal structure data. Only 19.1% of records have named IRI types;
-      80.9% use blank nodes that are invisible to IRI-based filters.
+  - title: Circular Reasoning with Search Results
+    problem: Using sample IRIs from a top-Tc exploratory query as the scope of a comprehensive material-type count — counts only the sample.
     wrong_sparql: |
-      ?strNode a Schema:IntermalStructure ;
-               obo:BFO_0000051 ?strType .
-      FILTER(STRSTARTS(STR(?strType), "...Schema#str1_"))
-      # Silently excludes 28,939 of 35,752 structure records
+      # WRONG: pasted sampled sample IRIs — total is just the sample size
+      VALUES ?sample {
+        <http://purl.org/supercon/data/sample/10001>
+        <http://purl.org/supercon/data/sample/10002>
+      }
+      SELECT (COUNT(?sample) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # For named types only -- document the 19.1% scope explicitly:
-      VALUES ?strType { Schema:str1_01 Schema:str1_02 Schema:str1_03
-                        Schema:str1_04 Schema:str1_05 Schema:str1_06 Schema:str1_07 }
-      ?strNode a Schema:IntermalStructure ; obo:BFO_0000051 ?strType .
-      # For ALL structure data, omit the type filter:
-      # ?strNode a Schema:IntermalStructure . OPTIONAL { ?strNode obo:BFO_0000051 ?strType . }
-    explanation: "Named structure IRIs cover only 19.1% of the data. Always document this scope limitation in query results."
+      # CORRECT: use the typed predicate (structure type) discovered during exploration
+      PREFIX Schema: <http://purl.org/supercon/schema#>
+      SELECT (COUNT(DISTINCT ?sample) AS ?count)
+      FROM <http://rdfportal.org/dataset/supercon>
+      WHERE {
+        ?sample a Schema:Sample .
+        ?meas obo:OBI_0000299 ?tcDatum .
+        ?tcDatum obo:IAO_0000221 Schema:tc ; sio:SIO_000300 ?tc .
+        FILTER(?tc > 77)
+      }
+      LIMIT 1
+    explanation: "Use structured predicates (property type, unit filter) discovered during exploration for comprehensive queries. Pasting sampled sample IRIs from a top-N result only counts those N samples."
 
   - title: Mixing lattice parameter units without inspection
     problem: |

--- a/togo_mcp/data/mie/taxonomy.yaml
+++ b/togo_mcp/data/mie/taxonomy.yaml
@@ -191,6 +191,7 @@ sparql_query_examples:
         OPTIONAL { ?taxon tax:commonName ?commonName }
         OPTIONAL { ?taxon tax:geneticCode ?geneticCode }
       }
+      LIMIT 10
 
   - title: Find Species in a Genus by Rank IRI
     description: Retrieve all species within a genus using specific genus IRI and rank IRI. Combine rdfs:subClassOf with tax:rank for efficient filtering.
@@ -258,6 +259,7 @@ sparql_query_examples:
       }
       GROUP BY ?rank ?rankLabel
       ORDER BY DESC(?count)
+      LIMIT 10
 
   - title: Exploratory Name Search with bif:contains
     description: |
@@ -329,6 +331,7 @@ sparql_query_examples:
           tax:Class tax:Phylum tax:Kingdom
         }
       }
+      LIMIT 1
 
 cross_database_queries:
   shared_endpoint: primary
@@ -516,25 +519,23 @@ data_statistics:
   staleness_warning: "Database updated monthly; counts reflect 2024 data load"
 
 anti_patterns:
-  - title: "Text Search When Specific Taxon IRI Is Available"
-    problem: "Using bif:contains for genus/species name when the IRI can be found via ncbi_esearch."
+  - title: "Circular Reasoning with Search Results"
+    problem: "Using species IRIs sampled from an exploratory label search as the scope of a comprehensive genus-level count."
     wrong_sparql: |
-      # Slow: text search on every execution
-      SELECT ?species WHERE {
-        ?species rdfs:subClassOf ?genus .
-        ?genus rdfs:label ?genusLabel ; tax:rank tax:Genus .
-        ?genusLabel bif:contains "'Escherichia'"
-      } LIMIT 20
+      # WRONG: pasted sampled species IRIs — counts only those species, not all Escherichia members
+      VALUES ?species { taxon:562 taxon:1530 taxon:83333 }
+      SELECT (COUNT(?species) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      # Correct two-step workflow:
-      # Step 1 (once): ncbi_esearch("taxonomy","Escherichia") → finds taxon:561
-      # Step 2 (comprehensive): use IRI directly
-      SELECT ?species ?label WHERE {
+      # CORRECT: use the genus IRI (taxon:561 = Escherichia) discovered via ncbi_esearch
+      SELECT (COUNT(DISTINCT ?species) AS ?count)
+      FROM <http://rdfportal.org/ontology/taxonomy>
+      WHERE {
         ?species rdfs:subClassOf taxon:561 ;
-                 tax:rank tax:Species ;
-                 rdfs:label ?label .
-      } LIMIT 20
-    explanation: "ncbi_esearch finds the IRI once; all subsequent queries use that IRI for speed and precision."
+                 tax:rank tax:Species .
+      }
+      LIMIT 1
+    explanation: "Use rdfs:subClassOf with the genus IRI for a complete species count. Pasting sampled species IRIs from a label search only tallies the sample, not the full genus."
 
   - title: "Skipping Schema Check Before Text Search"
     problem: "Using bif:contains without reading MIE critical_warnings and shape_expressions for structured alternatives."
@@ -587,7 +588,6 @@ anti_patterns:
         ?ancestor a tax:Taxon ; tax:rank ?rank ; rdfs:label ?label .
       } LIMIT 50
     explanation: "Always start transitive queries from a known taxon IRI. Add rank filtering and LIMIT to bound traversal."
-
 common_errors:
   - error: "Query timeout on lineage or aggregation queries"
     causes:

--- a/togo_mcp/data/mie/uniprot.yaml
+++ b/togo_mcp/data/mie/uniprot.yaml
@@ -584,17 +584,28 @@ anti_patterns:
       up:reviewed 1 reduces scope from ~244M to 589K (99.8% reduction). Mandatory
       for all quality queries. The value is an integer, not a boolean or string.
 
-  - title: Wrong GO IRI Namespace (Silent Zero-Result Failure)
-    problem: Using http://purl.uniprot.org/go/XXXXXXX returns 0 results silently; OBO IRI is correct.
+  - title: Circular Reasoning with Search Results
+    problem: Using protein IRIs sampled from a bif:contains text search as the scope of a comprehensive functional count.
     wrong_sparql: |
-      VALUES ?goTerm { <http://purl.uniprot.org/go/0015977> }
-      ?protein up:classifiedWith ?goTerm .
+      # WRONG: pasted sampled protein IRIs — counts only those proteins, not all human kinases
+      VALUES ?protein {
+        <http://purl.uniprot.org/uniprot/P31749>
+        <http://purl.uniprot.org/uniprot/P31751>
+      }
+      SELECT (COUNT(?protein) AS ?count) WHERE { }
+      LIMIT 1
     correct_sparql: |
-      VALUES ?goTerm { <http://purl.obolibrary.org/obo/GO_0015977> }
-      ?protein up:classifiedWith ?goTerm .
-    explanation: |
-      GO terms in UniProt always use the OBO namespace.
-      http://purl.uniprot.org/go/ is a dead namespace — it causes silent failures.
+      # CORRECT: use the GO IRI (GO:0004672 = protein kinase activity) discovered during exploration
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      SELECT (COUNT(DISTINCT ?protein) AS ?count)
+      WHERE {
+        ?protein a up:Protein ;
+                 up:reviewed 1 ;
+                 up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+                 up:classifiedWith obo:GO_0004672 .
+      }
+      LIMIT 1
+    explanation: "Use GO IRIs (not sampled protein IRIs) for comprehensive functional counts. Always include up:reviewed 1 and an organism filter to avoid scanning 244M TrEMBL entries."
 
   - title: Transitive Taxonomy Closure Causing Timeout
     problem: rdfs:subClassOf* triggers transitive closure reasoning and times out.

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -123,18 +123,39 @@ get_graph_list(database)
 get_MIE_file(database)   # check for existing MIE and compliance
 ```
 
-**Step 2: Schema Discovery (5 min)**
+**Step 2: Schema Discovery (5–10 min)**
+
+First enumerate classes:
 ```sparql
 # Classes and instance counts
 SELECT DISTINCT ?class (COUNT(?instance) as ?count)
-WHERE { ?instance a ?class }
+WHERE { GRAPH <…> { ?instance a ?class } }
 GROUP BY ?class ORDER BY DESC(?count) LIMIT 50
-
-# Properties and usage
-SELECT DISTINCT ?property (COUNT(?usage) as ?count)
-WHERE { ?s ?property ?o }
-GROUP BY ?property ORDER BY DESC(?count) LIMIT 50
 ```
+
+Then **run a dedicated predicate survey for every class you plan to document in `shape_expressions`** — not only the top-level anchor class. Annotation classes, measurement classes, and cross-reference classes are just as likely to have missing or misnamed predicates:
+
+```sparql
+# Per-class predicate survey (run for every class in shape_expressions)
+SELECT ?p (COUNT(*) AS ?n)
+WHERE { GRAPH <…> { ?s a <TargetClass> ; ?p ?o } }
+GROUP BY ?p ORDER BY DESC(?n) LIMIT 50
+```
+
+A predicate absent from the survey has no business in the shape; a predicate present with COUNT > 0 must be either documented or explicitly excluded with a note.
+
+**Trace every blank node chain.** For each predicate whose object is a blank node, retrieve the bnode's full predicate set anchored on the parent class — the same predicate name can resolve to differently-shaped bnodes on different parent classes (e.g. `faldo:location` → `ExactPosition` on one class, `Region` on another):
+
+```sparql
+SELECT DISTINCT ?bPred ?bObj WHERE {
+  GRAPH <…> {
+    ?parent a <ParentClass> ; <bnodePredicate> ?bnode .
+    ?bnode ?bPred ?bObj .
+  }
+} LIMIT 50
+```
+
+An undiscovered bnode schema means an incomplete shape and a missing `@<ShapeName>` definition.
 
 **Step 3: Find Specific IRIs for Key Concepts (10 min)**
 ```python
@@ -144,6 +165,31 @@ run_sparql(database, """
   SELECT ?p ?o WHERE { <example_entity_iri> ?p ?o . } LIMIT 100
 """)
 ```
+
+**Step 4: Cardinality Verification (one query per predicate)**
+
+For every class–predicate pair you intend to document in `shape_expressions`, determine the actual multiplicity with a cardinality distribution query. **Never assign `?`, `+`, or `*` based on intuition.**
+
+```sparql
+SELECT ?nValues (COUNT(?s) AS ?nSubjects) WHERE {
+  GRAPH <…> {
+    { SELECT ?s (COUNT(?o) AS ?nValues) WHERE {
+        ?s a <TargetClass> ; <TargetPredicate> ?o .
+      } GROUP BY ?s }
+  }
+}
+GROUP BY ?nValues ORDER BY ?nValues
+```
+
+Map the result to the correct ShEx cardinality modifier:
+
+| Observed pattern                       | ShEx notation                       |
+|----------------------------------------|-------------------------------------|
+| All subjects, exactly 1 value          | `IRI` (no modifier — required)      |
+| Some subjects have 0, none have > 1    | `IRI ?`                             |
+| Some subjects have > 1                 | `IRI *` (if 0 is possible) or `IRI +` |
+
+This step is cheap (one query per predicate) and catches a large class of silent errors in the finished MIE.
 
 ### 2. Statistics Verification
 
@@ -202,6 +248,26 @@ if "error" in result.lower():
 9. **data_statistics** — Verified counts and coverage percentages
 10. **anti_patterns** — 3–4 examples (must include the "schema check before text search" pattern)
 11. **common_errors** — 2–3 scenarios
+
+### Shape Expressions Discipline
+
+Two structural rules `shape_expressions` must obey:
+
+- **Every `@<ShapeRef>` must have a corresponding defined block.** Search the `shape_expressions` string for every `@<…>` reference and confirm each resolves to a `<…Shape> { … }` definition in the same section. A referenced-but-undefined shape is a structural error — the downstream LLM will generate property-path queries that silently return nothing.
+
+- **Mark optional co-types explicitly.** When a class is sometimes (but not always) additionally typed with a second class, write each sub-type as a separate optional constraint rather than grouping them in a single `a [ T1 T2 T3 ] +` block. The grouped form is correct ShEx but visually implies all types are always co-present:
+
+  ```shex
+  # Avoid — looks like all three are always expected:
+  a [ ex:MainType ex:SubTypeA ex:SubTypeB ] + ;
+
+  # Prefer — cardinality is explicit and verifiable:
+  a [ ex:MainType ] ;
+  a [ ex:SubTypeA ] ?   # ~80% of instances — confirmed by COUNT
+  a [ ex:SubTypeB ] ?   # ~80% of instances — confirmed by COUNT
+  ```
+
+  Annotate the percentage in an inline comment so the figure is traceable to Step 4 (Cardinality Verification).
 
 ### SPARQL Query Requirements (7 queries: 2 / 3 / 2)
 
@@ -541,6 +607,13 @@ common_errors:
 - ☐ Documented any IRI traps, typos, or mandatory performance filters
 - ☐ Placed before `shape_expressions` for fast scanning
 
+**`shape_expressions`:**
+- ☐ Per-class predicate survey run for every class that appears in the shape
+- ☐ Every blank-node-valued predicate traced via the parent-anchored bnode query
+- ☐ Every cardinality modifier (`?`, `+`, `*`, or absent) backed by a cardinality distribution query
+- ☐ Every `@<ShapeRef>` resolves to a defined `<…Shape>` block in the same section
+- ☐ Optional co-types written as separate `a [ T ] ?` lines, not grouped in a single `a [ T1 T2 … ] +` block
+
 **Query Design:**
 - ☐ ≥ 2 queries use specific IRIs or VALUES with IRIs
 - ☐ ≥ 2 queries use typed predicates or graph navigation
@@ -593,14 +666,24 @@ result = get_MIE_file(database)
 ### Step 3: Test Queries
 Run at least 3 of the 7 SPARQL queries to verify execution.
 
-### Step 4: Final Declaration
+### Step 4: Audit `shape_expressions`
+For each shape block:
 
-**ONLY after Steps 1–3:**
+1. Re-run the per-class predicate survey from Step 2 and compare against the documented predicates. Any predicate with COUNT > 0 that is absent from the shape must be either added or explicitly noted as intentionally excluded.
+2. Confirm every `@<ShapeRef>` has a defined `<…Shape>` block.
+3. For every predicate marked `?` (optional), confirm with a cardinality query that at least one subject has 0 values for it. For every predicate with no modifier (required), confirm its COUNT equals the class instance count.
+
+This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
+
+### Step 5: Final Declaration
+
+**ONLY after Steps 1–4:**
 
 "✓ MIE file validation complete. All requirements satisfied:
 - Quality Checklist: [X/X] items checked
 - YAML valid: Yes
 - Queries tested: [N] queries executed successfully
+- shape_expressions audited: all shapes verified against live predicate surveys, all @<ShapeRef>s resolved, all cardinality modifiers confirmed
 - Ready for production use."
 
 ---

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -144,6 +144,15 @@ GROUP BY ?p ORDER BY DESC(?n) LIMIT 50
 
 A predicate absent from the survey has no business in the shape; a predicate present with COUNT > 0 must be either documented or explicitly excluded with a note.
 
+While running predicate surveys, note any predicate whose COUNT distribution is surprising as a `critical_warnings` candidate:
+
+- COUNT equals class instance count but the predicate name looks like it might have an alias or alternate namespace form — confirm only one form is queryable.
+- COUNT is much lower than the class instance count for a predicate that looks mandatory — document as a caveat on cardinality, or as a trap if omitting it causes a silent wrong result rather than just an empty one.
+- COUNT is greater than the class instance count for a predicate that looks singular — document the multi-valued behaviour.
+- Two predicates return overlapping results for what appears to be the same concept — document which form is the correct join key.
+
+Write these candidates down immediately. `critical_warnings` is assembled in the Template stage from this list — not reconstructed from memory.
+
 **Trace every blank node chain.** For each predicate whose object is a blank node, retrieve the bnode's full predicate set anchored on the parent class — the same predicate name can resolve to differently-shaped bnodes on different parent classes (e.g. `faldo:location` → `ExactPosition` on one class, `Region` on another):
 
 ```sparql
@@ -195,6 +204,13 @@ This step is cheap (one query per predicate) and catches a large class of silent
 
 Every statistic requires a verified count (query or methodology) and a verified date. Mark frequently-updated databases with an update warning.
 
+After verifying individual counts, **cross-check arithmetic consistency**:
+
+- Does `total_entities` equal (or plausibly approximate) the sum of the major `by_class` counts?
+- Does each coverage percentage equal `(subset count) / (class count)` to within rounding? E.g. if 673,263 entities carry a property and there are 1,021,677 in the class, the percentage must be documented as ~65.9%, not loosely as "~66%" or "~70%".
+
+Flag and correct any discrepancy before publishing.
+
 ### 3. Cross-Database Queries (Shared Endpoint Only)
 
 Include when a shared endpoint exists, clear links are present, and queries complete in < 20 s.
@@ -237,7 +253,7 @@ if "error" in result.lower():
 
 ### Required Sections (in order)
 
-1. **schema_info** — Endpoint, graphs, search tools, backend, versioning, plus `keywords` (8–15 lowercase discovery terms incl. synonyms) and `categories` (1–3 from controlled taxonomy) for `find_databases()` discovery
+1. **schema_info** — Endpoint, graphs, search tools, backend, versioning, plus `keywords` (8–15 lowercase discovery terms incl. synonyms) and `categories` (1–3 from controlled taxonomy) for `find_databases()` discovery. **After filling in `categories`, call `list_categories()` and verify each token is an exact match (same case, same underscores) against the returned list.** Off-spec tokens silently exclude the database from `find_databases(category=…)` results.
 2. **critical_warnings** — Schema pathologies that cause silent failures (typos in IRIs, non-obvious namespace traps, critical performance filters). Use `[]` if none.
 3. **shape_expressions** — ShEx for ALL entity types with inline counts and caveats
 4. **sample_rdf_entries** — Exactly 3 diverse, illustrative examples (shared prefix block)
@@ -603,9 +619,14 @@ common_errors:
 - ☐ **For cross-DB queries: read ALL co-located MIE files**
 - ☐ **Verified no structured alternatives before using text search**
 
+**`schema_info`:**
+- ☐ `categories` tokens exact-matched against `list_categories()` (same case, same underscores)
+
 **`critical_warnings`:**
 - ☐ Documented any IRI traps, typos, or mandatory performance filters
 - ☐ Placed before `shape_expressions` for fast scanning
+- ☐ Every cited predicate name and IRI verified against the endpoint with a SELECT
+- ☐ Trap candidates flagged from surprising COUNT distributions during the per-class predicate survey, not reconstructed from memory
 
 **`shape_expressions`:**
 - ☐ Per-class predicate survey run for every class that appears in the shape
@@ -631,12 +652,27 @@ common_errors:
 **`cross_database_queries`:**
 - ☐ 1–2 examples maximum (not 3)
 - ☐ Isolated endpoints: `examples: []` with explanatory `notes`
+- ☐ Each query's join validity spot-checked (one result IRI confirmed in the second database)
+
+**`cross_references`:**
+- ☐ Each pattern's IRI form confirmed by DESCRIBE (not inferred from documentation)
+- ☐ Each coverage percentage from a COUNT query (not estimated)
+- ☐ When two IRI forms exist, both documented with the correct join key flagged
 
 **`data_statistics`:**
 - ☐ Counts and coverage percentages present with verified dates
+- ☐ `total_entities` arithmetically consistent with sum of `by_class` counts
+- ☐ Each coverage % equals `(subset / class)` to within rounding (no loose "~66%" when the figure is 65.9%)
 - ☐ No `verification_queries` sub-fields (auditing artefact — omit)
 - ☐ No `cardinality` sub-section (avg-per-entity values — omit)
 - ☐ No `performance_characteristics` sub-section (belongs in `architectural_notes`)
+
+**Prefix declarations:**
+- ☐ Every non-standard prefix base URI confirmed with a SELECT against a known class
+- ☐ Standard W3C prefixes (`rdf:`, `rdfs:`, `owl:`, `xsd:`) do not need checking
+
+**`anti_patterns`:**
+- ☐ Every `correct_sparql` block executed successfully against the endpoint
 
 **Structure:**
 - ☐ Valid YAML (load with `get_MIE_file` and check for errors)
@@ -664,7 +700,9 @@ result = get_MIE_file(database)
 ```
 
 ### Step 3: Test Queries
-Run at least 3 of the 7 SPARQL queries to verify execution.
+Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, **every `correct_sparql` block in `anti_patterns`**, and any SPARQL embedded in `cross_references`. Every single one. Untested `correct_sparql` actively teaches bad practice — downstream LLMs copy it as readily as the example queries.
+
+For each cross-database query that returns results, additionally **spot-check join validity**: take one join value from the result set and run a quick `ASK` or `SELECT` against the second database to confirm it resolves to a real entity there. A query returning 3 rows when thousands are expected is a join failure, not a passing test — the IRI form used for linking likely differs between the two databases.
 
 ### Step 4: Audit `shape_expressions`
 For each shape block:
@@ -675,15 +713,59 @@ For each shape block:
 
 This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
 
-### Step 5: Final Declaration
+### Step 5: Verify `critical_warnings` content
+For every predicate name and IRI string cited in `critical_warnings`, run a minimal query confirming it exists in the endpoint:
 
-**ONLY after Steps 1–4:**
+```sparql
+SELECT ?s WHERE {
+  GRAPH <…> { ?s <cited-predicate> ?o }
+} LIMIT 1
+```
+
+If the query returns no rows, the cited predicate or IRI is wrong — fix it before publishing. A warning about a non-existent predicate is worse than no warning. Also confirm each warning is still accurate against the current data snapshot: a trap documented in a previous MIE version may have been corrected upstream.
+
+### Step 6: Verify `cross_references`
+For each cross-reference predicate documented:
+
+1. **Confirm the IRI form** by DESCRIBEing a real entity and reading the actual object value. Do not trust the database's documentation — mint the IRI from what the endpoint actually returns. If two IRI forms are present (e.g. both an `identifiers.org` form and a canonical purl), document both and specify which is the correct join key for federation.
+
+2. **Verify the coverage percentage** with a COUNT query:
+
+   ```sparql
+   SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE {
+     GRAPH <…> { ?s a <EntityClass> ; <crossRefPredicate> ?o }
+   }
+   ```
+
+   Divide by the class instance count from `data_statistics`. Document the result as the coverage figure — do not estimate.
+
+### Step 7: Verify prefix declarations
+For each non-standard prefix defined in `shape_expressions` or `sample_rdf_entries`, confirm the base URI is correct by running a minimal SELECT using that prefix:
+
+```sparql
+PREFIX ex: <http://suspected-base-uri/>
+SELECT ?s WHERE {
+  GRAPH <…> { ?s a ex:KnownClass }
+} LIMIT 1
+```
+
+If the query returns no rows despite the class being known to exist, the prefix base URI is wrong. Standard W3C prefixes (`rdf:`, `rdfs:`, `owl:`, `xsd:`) do not need checking. Database-specific and ontology-specific prefixes (e.g. a Unimod prefix, a PSI-MS prefix, an internal ontology prefix) must all be confirmed.
+
+### Step 8: Final Declaration
+
+**ONLY after Steps 1–7:**
 
 "✓ MIE file validation complete. All requirements satisfied:
 - Quality Checklist: [X/X] items checked
 - YAML valid: Yes
 - Queries tested: [N] queries executed successfully
 - shape_expressions audited: all shapes verified against live predicate surveys, all @<ShapeRef>s resolved, all cardinality modifiers confirmed
+- critical_warnings verified: all cited predicate names and IRIs confirmed against endpoint
+- cross_references verified: IRI forms confirmed by DESCRIBE, coverage % from COUNT queries
+- schema_info.categories checked: all tokens exact-matched against list_categories()
+- prefix declarations verified: all non-standard prefixes confirmed with SELECT
+- data_statistics cross-checked: total_entities and coverage % arithmetically consistent
+- anti_patterns.correct_sparql tested: all correct_sparql blocks executed successfully
 - Ready for production use."
 
 ---

--- a/togo_mcp/data/resources/MIE_prompt.md
+++ b/togo_mcp/data/resources/MIE_prompt.md
@@ -584,7 +584,7 @@ common_errors:
       - "Check MIE critical_warnings and schema for mandatory filters"
       - "Check shape_expressions for structured properties"
       - "Use bif:contains on Virtuoso; split property paths before bif:contains"
-      - "Add LIMIT to every query"
+      - "Add LIMIT (or use an aggregate / ASK / specific-IRI anchor) to every query"
 
   - error: "Empty or incomplete results"
     causes:
@@ -605,7 +605,7 @@ common_errors:
       - "Read MIE files for ALL databases; check shape_expressions for linking predicates"
       - "Use explicit GRAPH clauses for each database"
       - "Apply restrictive filters within each GRAPH block before the cross-database join"
-      - "Add LIMIT at every query level"
+      - "Add LIMIT at every query level (unless bounded by aggregate / ASK / specific-IRI subject)"
 ```
 
 ---
@@ -642,7 +642,7 @@ common_errors:
 - ☐ All text-search queries include justification comments
 - ☐ `bif:contains` preferred over `FILTER(CONTAINS())` on Virtuoso
 - ☐ No circular reasoning (no VALUES with search results for comprehensive queries)
-- ☐ All 7 queries have a LIMIT clause
+- ☐ Every query has a bounded result set — `LIMIT` required unless the query is an aggregate (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`), an `ASK`, or anchored on a specific-IRI subject whose cardinality is bounded by the schema
 
 **`sample_rdf_entries`:**
 - ☐ Exactly 3 entries


### PR DESCRIPTION
## Summary

Three rounds of revisions to the mie-generator skill, the no-FS `MIE_prompt.md`, and the affected MIE files — all driven by audit findings from the jPOST onboarding. Net: the skill gains a complete pre-publication audit pass; MIE files are tightened to match.

### Skill / prompt revisions

**Round 1 ([3356eac](../commit/3356eac))** — shape_expressions discovery (caught: missing/wrong predicates, undefined `@<ShapeRef>` blocks, wrong cardinality modifiers, misleading multi-type notation):
- Phase 2b: per-class predicate survey for *every* class in `shape_expressions` (not just the anchor)
- Phase 2c: parent-anchored bnode-tracing query, with the warning that same-named bnode chains differ by parent class
- New Phase 2e: cardinality distribution query + modifier-mapping table — never assign `?`/`+`/`*` by intuition
- Phase 4: every `@<ShapeRef>` resolves; optional co-types written as separate `?` lines
- New Phase 5e: shape_expressions audit (re-run survey, resolve refs, confirm cardinalities)

**Round 2 ([6d5412e](../commit/6d5412e))** — port the same discipline into [`MIE_prompt.md`](togo_mcp/data/resources/MIE_prompt.md), the `Generate_MIE_file` MCP-prompt variant for remote-LLM users.

**Round 3 ([c8e1953](../commit/c8e1953))** — section-by-section audit (caught: critical_warnings citing wrong predicates, cross_references IRI form drift, prefix-URI typos, untested `anti_patterns.correct_sparql`, statistics arithmetic inconsistencies, off-spec category tokens):
- Phase 2b: flag predicates with surprising COUNT distributions as `critical_warnings` candidates during discovery
- Phase 4 / schema_info: enforce `list_categories()` exact-match check
- Phase 5b: extend testing to `anti_patterns.correct_sparql` + cross-DB join-validity spot-check
- Phase 5c: arithmetic cross-check on `data_statistics`
- New Phase 5f: verify every cited predicate/IRI in `critical_warnings`
- New Phase 5g: verify `cross_references` IRI forms by DESCRIBE + coverage % by COUNT
- New Phase 5h: verify non-standard PREFIX base URIs
- Phase 6 / Final Declaration: six new audit lines

`references/mie-structure.md` §2 + §7 carry matching verification-requirement blocks.

### MIE file fixes

- **[jpostdb.yaml](togo_mcp/data/mie/jpostdb.yaml)** ([e2c14fb](../commit/e2c14fb)): wrong predicate (`jpost:organism` → `jpost:species`), missing predicates (`sampleType`, `modificationSite`, `faldo:location` on Modification, `hasLeadingProtein`), undefined `<RawDataShape>` body, wrong cardinality on 4 Profile/Modification predicates, misleading multi-type notation on Peptide. All verified against the live primary endpoint.
- **[pdb.yaml](togo_mcp/data/mie/pdb.yaml)** ([cc84e01](../commit/cc84e01)): add 9 category-container shapes (`EntityCategory`, `ExptlCategory`, etc.) and 3 item shapes (`Citation`, `Struct`, `Software`).
- **[reactome.yaml](togo_mcp/data/mie/reactome.yaml)** ([cc84e01](../commit/cc84e01)): add `PathwayStep` (~115K), `RelationshipTypeVocabulary`, `SequenceSite` (~441K), `UnificationXref` (~1.2M) shapes.
- **[glycosmos.yaml](togo_mcp/data/mie/glycosmos.yaml), [mesh.yaml](togo_mcp/data/mie/mesh.yaml)** ([cc84e01](../commit/cc84e01)): minor ShEx syntax/notation fixes.

## Test plan

- [ ] Spot-check the new mie-generator workflow on one small endpoint to confirm Phases 5f–5h are practical (not just theoretical)
- [ ] `uv run pytest` passes
- [ ] Re-run a couple of validated SPARQL queries from [jpostdb.yaml](togo_mcp/data/mie/jpostdb.yaml), [pdb.yaml](togo_mcp/data/mie/pdb.yaml), and [reactome.yaml](togo_mcp/data/mie/reactome.yaml) against their endpoints to confirm shape additions don't break example queries
- [ ] PyYAML parse-check across all changed MIE files
- [ ] `MIE_prompt.md` MANDATORY FINAL VALIDATION renumbering reads sensibly end-to-end (Steps 1–8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)