### PR TITLE
Tools: graceful error returns instead of raising (silent-failure fix)

### DIFF
--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -167,9 +167,14 @@ async def search_uniprot_entity(
         raise_for_status_with_body(response, context="UniProt search")
         data = response.text
         return data
-    except httpx.HTTPError as e:
-        print(f"Error querying UniProt: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(f"UniProt search failed: {type(e).__name__}: {e}")
+        return (
+            f"Error: UniProt REST API request failed ({type(e).__name__}: {e}). "
+            "Usually transient — retry once after a brief delay. If it keeps "
+            "failing, fall back to SPARQL: "
+            "run_sparql(database='uniprot', sparql_query=...)."
+        )
 
 
 # DB: ChEMBL
@@ -192,9 +197,16 @@ async def search_chembl_generic(entity_type: str, query: str, limit: int = 20) -
         )
         raise_for_status_with_body(response, context="ChEMBL search")
         return response.json()
-    except httpx.HTTPError as e:
-        print(f"Error querying ChEMBL {entity_type}: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(f"ChEMBL {entity_type} search failed: {type(e).__name__}: {e}")
+        return {
+            "error": (
+                f"ChEMBL REST API request failed ({type(e).__name__}: {e}). "
+                "Usually transient — retry once after a brief delay. If it "
+                "keeps failing, fall back to SPARQL: "
+                "run_sparql(database='chembl', sparql_query=...)."
+            )
+        }
 
 
 @mcp.tool()
@@ -466,9 +478,17 @@ async def get_pubchem_compound_id(compound_name: str) -> str:
         response = await _pubchem_client.get(url)
         raise_for_status_with_body(response, context="PubChem CID lookup")
         return response.text
-    except httpx.HTTPError as e:
-        print(f"Error fetching PubChem compound ID for {compound_name}: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(
+            f"PubChem CID lookup failed for {compound_name!r}: "
+            f"{type(e).__name__}: {e}"
+        )
+        return (
+            f"Error: PubChem CID lookup failed for {compound_name!r} "
+            f"({type(e).__name__}: {e}). Usually transient — retry once after "
+            "a brief delay. If it keeps failing, fall back to SPARQL: "
+            "run_sparql(database='pubchem', sparql_query=...)."
+        )
 
 
 @mcp.tool()
@@ -488,11 +508,18 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
         response = await _pubchem_client.get(url, params=params)
         raise_for_status_with_body(response, context="PubChem compound attributes")
         return response.text
-    except httpx.HTTPError as e:
-        print(
-            f"Error fetching PubChem compound attributes for {pubchem_compound_id}: {e}"
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(
+            f"PubChem compound-attributes fetch failed for "
+            f"{pubchem_compound_id!r}: {type(e).__name__}: {e}"
         )
-        raise
+        return (
+            f"Error: PubChem compound-attributes fetch failed for "
+            f"{pubchem_compound_id!r} ({type(e).__name__}: {e}). Usually "
+            "transient — retry once after a brief delay. If it keeps failing, "
+            "fall back to SPARQL: run_sparql(database='pubchem', "
+            "sparql_query=...)."
+        )
 
 
 # DB: PDB
@@ -564,9 +591,19 @@ async def search_pdb_entity(
         ]
         response_dict = {"total": total_results, "results": result_list}
         return json.dumps(response_dict)
-    except httpx.HTTPError as e:
-        print(f"Error searching PDB {db} for {query}: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(
+            f"PDBj search failed for db={db!r} query={query!r}: "
+            f"{type(e).__name__}: {e}"
+        )
+        return json.dumps({
+            "error": (
+                f"PDBj REST API request failed ({type(e).__name__}: {e}). "
+                "Usually transient — retry once after a brief delay. If it "
+                "keeps failing, fall back to SPARQL: "
+                "run_sparql(database='pdb', sparql_query=...)."
+            )
+        })
 
 
 # DB: MeSH
@@ -612,9 +649,17 @@ async def search_mesh_descriptor(
         response = await _mesh_client.get("/mesh/lookup/descriptor", params=params)
         raise_for_status_with_body(response, context="MeSH descriptor lookup")
         return response.text
-    except httpx.HTTPError as e:
-        print(f"Error searching MeSH for {query}: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(
+            f"MeSH descriptor lookup failed for {query!r}: "
+            f"{type(e).__name__}: {e}"
+        )
+        return (
+            f"Error: MeSH descriptor lookup failed ({type(e).__name__}: {e}). "
+            "Usually transient — retry once after a brief delay. If it keeps "
+            "failing, fall back to SPARQL: "
+            "run_sparql(database='mesh', sparql_query=...)."
+        )
 
 
 # DB: Reactome
@@ -708,9 +753,15 @@ async def search_reactome_entity(
         )
         raise_for_status_with_body(response, context="Reactome search")
         data = response.json()
-    except httpx.HTTPError as e:
-        print(f"Error querying Reactome: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(f"Reactome search failed: {type(e).__name__}: {e}")
+        return (
+            f"Error: Reactome REST API request failed ({type(e).__name__}: "
+            f"{e}). Reactome's search endpoint can be slow or briefly "
+            "unavailable. Retry once after a brief delay. If it keeps "
+            "failing, fall back to SPARQL: "
+            "run_sparql(database='reactome', sparql_query=...)."
+        )
 
     # Extract and return results
     results = []
@@ -807,6 +858,11 @@ async def search_rhea_entity(
 
         return results
 
-    except httpx.HTTPError as e:
-        print(f"Error fetching data from Rhea API: {e}")
-        raise
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(f"Rhea search failed: {type(e).__name__}: {e}")
+        return (
+            f"Error: Rhea REST API request failed ({type(e).__name__}: {e}). "
+            "Usually transient — retry once after a brief delay. If it keeps "
+            "failing, fall back to SPARQL: "
+            "run_sparql(database='rhea', sparql_query=...)."
+        )

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -313,7 +313,23 @@ async def get_MIE_file(
         return "Error: Missing required argument `database` (aliases: `dbname`, `db`)."
     mie_file = Path(MIE_DIR).joinpath(f"{database}.yaml")
     if not mie_file.exists():
-        raise FileNotFoundError(f"MIE file not found for database: '{database}'")
+        # Return a structured error string rather than raising, so the
+        # downstream LLM can read the diagnostic and recover (e.g. retry
+        # with a real database name) instead of seeing an opaque tool
+        # exception that may break the MCP session.
+        valid = ", ".join(sorted(SPARQL_ENDPOINT.keys()))
+        hint = ""
+        if database in ("togoid", "ncbi"):
+            hint = (
+                f" Note: '{database}' is a tool-prefix for a sub-server "
+                "(e.g. togoid_convertId, ncbi_esearch), NOT a SPARQL "
+                "database — it has no MIE file. Use the prefixed tools "
+                "directly."
+            )
+        return (
+            f"Error: No MIE file for '{database}'. Valid database names: "
+            f"{valid}.{hint} Do not retry with the same value."
+        )
     with open(mie_file, encoding="utf-8") as file:
         content = file.read()
     return f"Content-type: application/yaml; charset=utf-8\n{content}"


### PR DESCRIPTION
## Summary

Eliminates two classes of tool exceptions that propagate through fastmcp and, in some configurations, disrupt the MCP session — producing the silent empty-response failures observed during the benchmark sweep on 2026-05-03.

### `get_MIE_file` ([rdf_portal.py](togo_mcp/rdf_portal.py))

- **Before:** raised \`FileNotFoundError\` on unknown database names. Caught when an agent reasonably guessed \`get_MIE_file('togoid')\` from the \`togoid_*\` tool prefix (TogoID is a sub-server with REST tools, not a SPARQL database).
- **After:** returns a structured error string listing valid databases, with a special hint for \`togoid\` and \`ncbi\` (\"sub-server prefixes that legitimately have no MIE file — use the prefixed tools directly\").

### REST search tools ([api_tools.py](togo_mcp/api_tools.py))

All 8 tools previously did:

\`\`\`python
except httpx.HTTPError as e:
    print(f\"Error querying X: {e}\")
    raise
\`\`\`

— catching only network/transport errors (not 4xx/5xx via \`raise_for_status_with_body\`'s \`ValueError\`), logging to stdout (lost under MCP), and re-raising. A transient \`ConnectTimeout\` from any upstream (Reactome, ChEMBL, PDBj, …) propagated up through fastmcp's tool-call handler.

Each site now:

- Catches both \`httpx.HTTPError\` **and** \`ValueError\` (so HTTP errors flow through the same path as transport errors)
- Logs via \`logger.warning\` so the diagnostic shows up in the togomcp container logs (visible to \`podman/docker logs togomcp-main\`) rather than stdout
- Returns an actionable error string with the failure type, a \"usually transient\" note, and a SPARQL-fallback suggestion specific to that database (\`run_sparql(database='reactome', sparql_query=...)\` etc.)

Tools updated: \`search_uniprot_entity\`, \`search_chembl_generic\` (powers \`search_chembl_id_lookup\` / \`search_chembl_target\` / \`search_chembl_molecule\`), \`get_pubchem_compound_id\`, \`get_compound_attributes_from_pubchem\`, \`search_pdb_entity\`, \`search_mesh_descriptor\`, \`search_reactome_entity\`, \`search_rhea_entity\`.

### Why this matters

During a 50-question benchmark run, the togomcp call succeeded for 26/50 questions and \"failed silently\" (empty response from claude-agent-sdk, no exception, no tokens) for the other 24. Container logs showed the actual cause was tool exceptions — including:

\`\`\`
FileNotFoundError: MIE file not found for database: 'togoid'
ConnectTimeout (search_reactome_entity)
\`\`\`

— which propagated up and broke the MCP stream. With this PR the agent now sees a real text response on every tool call, so transient failures stay local to that one tool call instead of cascading into a session-wide silent failure.

## Test plan

- [ ] Rebuild and restart togomcp container: \`docker build -t localhost/togo-mcp:latest . && podman compose up -d --force-recreate togomcp-main\`
- [ ] Confirm \`uv run pytest\` passes (the 8 pre-existing FunctionTool failures in \`tests/test_api_tools.py\` are unrelated)
- [ ] Re-run a 5-question slice of the benchmark and confirm the success rate is materially higher than 52%
- [ ] Trigger a known-bad case (e.g. \`get_MIE_file('togoid')\`) directly and verify the response is a graceful error string, not an exception
- [ ] Watch \`podman logs -f togomcp-main\` during a benchmark run and confirm warnings now appear (\`UniProt search failed:\`, etc.) for any failed REST upstream calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)