### PR TITLE
Make find_databases canonical to restore No-Instr discovery

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,11 @@
   "permissions": {
     "allow": [
       "mcp__togomcp-dev__run_sparql",
-      "mcp__togomcp-dev__get_graph_list"
+      "mcp__togomcp-dev__get_graph_list",
+      "Bash(python3)",
+      "Bash(python3 -c ' *)",
+      "Read(//tmp/**)",
+      "Read(//private/tmp/**)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "mcp__togomcp-dev__run_sparql",
-      "mcp__togomcp-dev__get_graph_list",
-      "Bash(python3)",
-      "Bash(python3 -c ' *)",
-      "Read(//tmp/**)",
-      "Read(//private/tmp/**)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -208,10 +208,6 @@ __marimo__/
 
 # Others
 .DS_Store
-evaluation/scripts/evaluation_dashboard.html
-evaluation/scripts/evaluation_results_intermediate.csv
-# evaluation/results/
-# evaluation/questions/
 .vscode/
 
 # Claude Code — keep project-level skills, ignore per-user state

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -400,19 +400,15 @@ def _load_databases_cache() -> list[dict[str, Any]]:
 @mcp.tool(name="list_databases")
 def list_databases() -> list[dict[str, Any]]:
     """
-    Database Discovery & Selection — full catalog browse.
+    Supplementary: full catalog dump (browse only, no filtering).
 
-    Returns every available RDF database with `{database, title, description}`. Use this
-    when you want to see the entire catalog. For token-efficient lookup when you already
-    have search terms in mind, prefer `find_databases(keywords=...)`.
+    Returns every available RDF database with `{database, title, description}`. Use
+    this only when you need the entire catalog with no filter — for example, to
+    enumerate all databases or to discover what kinds of data exist before you
+    have specific search terms.
 
-    Common keywords-in-descriptions to watch for: "MANE" (Ensembl), "drug targets" (ChEMBL),
-    "clinical variants" (ClinVar), "pathways" (Reactome).
-
-    Workflow:
-    1. (Optional) call list_databases() or find_databases() to identify 1–3 relevant DBs.
-    2. get_MIE_file(database) for each.
-    3. run_sparql() with discovered structured properties.
+    For every normal workflow, call `find_databases(keywords=[...])` first — that
+    is the canonical entry point. This tool is a supplementary fallback.
 
     Returns:
         A list of dicts with keys `database`, `title`, `description`.
@@ -490,13 +486,24 @@ def find_databases(
     ] = False,
 ) -> list[dict[str, Any]]:
     """
-    Token-efficient database discovery — alternative to list_databases().
+    Database discovery — REQUIRED first step for any TogoMCP workflow.
 
-    Filters the RDF database catalog by keywords and/or category, returning only matching
-    entries. Use this when you already have specific search terms (gene, pathway, drug
-    target, variant, etc.) and want a focused candidate list before calling get_MIE_file().
+    Always call this BEFORE `get_MIE_file()` or `run_sparql()`. Pass any search
+    terms you have (gene, pathway, drug target, variant, organism, disease,
+    enzyme class, etc.) as `keywords`. Returns 1–3 candidate databases scoped
+    to your terms — much more efficient than browsing the full catalog.
 
-    Use list_databases() instead when you want to browse the full catalog.
+    Workflow:
+    1. find_databases(keywords=[...]) — identify 1–3 relevant databases.
+    2. get_MIE_file(database) — learn each candidate's schema and SPARQL idioms.
+    3. run_sparql() — query with the discovered structured properties.
+
+    Common keywords to try: "MANE" (Ensembl), "drug targets" (ChEMBL),
+    "clinical variants" (ClinVar), "pathways" (Reactome), "variants" (gnomAD),
+    "ortholog" (OMA), "expression" (Bgee).
+
+    If you have no search terms and want to browse the full catalog instead, see
+    `list_databases()` — that tool is supplementary, not a substitute for this one.
 
     Returns:
         List of dicts: `{database, title, matched_keywords, categories, snippet}` (or


### PR DESCRIPTION
## Summary

- **Primary:** rework `find_databases` and `list_databases` docstrings in [togo_mcp/rdf_portal.py](togo_mcp/rdf_portal.py) so `find_databases` is the canonical, required first step of every workflow and `list_databases` is supplementary. The 3-step workflow text (`find_databases → get_MIE_file → run_sparql`) now lives on `find_databases`. Removed `(Optional)` framing and the circular cross-references that made the two tools read as interchangeable alternatives.
- **Why:** the 2026-05-04 benchmark surfaced a regression — spontaneous discovery in the No-Instr (ng2) condition collapsed from `list_databases` at 36 % (rev0, Feb–Mar 2026) to `find_databases` at 0 % today. Tracing it back: when `find_databases` was added in `65f5266`, both tools' docstrings were softened ("Optional", "alternative to"), and without an explicit Usage Guide instruction the model now skips discovery entirely and goes straight to `run_sparql`. Downstream `get_MIE_file` calls dropped from 59 to 9 in matched 50-q ng2 runs.
- **Side cleanup:** drop dead `evaluation/*` `.gitignore` rules (the directory is now `benchmark/`); clear two stale `mcp__togomcp-dev__*` entries from the tracked `.claude/settings.json` allowlist.
- **Note:** this only takes effect for the benchmark once the change is deployed to `togomcp.rdfportal.org` — local edits don't affect the in-flight or future runs against the production endpoint.

## Test plan

- [ ] Read the updated docstrings — confirm `find_databases` reads as imperative ("REQUIRED first step", "Always call BEFORE …") and `list_databases` reads as supplementary
- [ ] Deploy to the staging/production HTTP MCP endpoint
- [ ] Rerun No-Instr (ng2) on the 50-question benchmark and verify `find_databases` usage rate jumps from 0 % back toward the rev0 36 %, with a corresponding bounce in spontaneous `get_MIE_file` calls
- [ ] Spot-check the With-Guide (WG) condition — it should be unchanged (it was already at 94 % `find_databases`, driven by an explicit system prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)