### PR TITLE
docs: document TOGOMCP_QUERY_LOG tool-call logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,10 @@ TEST_PORT=8001
 
 # Optional: timezone for log timestamps (default: Asia/Tokyo)
 TZ=Asia/Tokyo
+
+# Optional: enable tool-call logging (JSONL, one record per MCP tool call).
+# Unset/empty = disabled (default). The compose.yaml bind-mounts ./logs and
+# ./logs-test on the host to /var/log/togomcp inside each container, so set
+# the path to /var/log/togomcp/<file>.jsonl to surface logs as ./logs[-test]/.
+# TOGOMCP_QUERY_LOG=/var/log/togomcp/togomcp.jsonl
+# TOGOMCP_QUERY_LOG_TEST=/var/log/togomcp/togomcp-test.jsonl

--- a/README.md
+++ b/README.md
@@ -114,6 +114,52 @@ docker run -e NCBI_API_KEY="your-key-here" -p 8000:8000 togo-mcp
 
 ---
 
+## Tool-Call Logging (Optional)
+
+TogoMCP can record every MCP tool call as one JSON line per call (timestamp,
+tool name, arguments, status, elapsed_ms, session/request/client IDs, transport,
+client IP). SPARQL calls are enriched with endpoint URL, HTTP code, row/byte
+counts, and a SHA-256 of the query. Useful for benchmarking, MIE iteration,
+and reconstructing multi-tool sequences.
+
+**On/off is a single env var**: `TOGOMCP_QUERY_LOG`. Unset/empty = disabled
+(zero-overhead default). Set to a writable file path to enable.
+Output uses `RotatingFileHandler` (50 MB × 10, ~500 MB cap).
+
+### Docker
+
+`compose.yaml` bind-mounts `./logs` (and `./logs-test`) on the host to
+`/var/log/togomcp` inside each container and passes through `TOGOMCP_QUERY_LOG`
+/ `TOGOMCP_QUERY_LOG_TEST` from `.env`. Opt in:
+
+```bash
+echo 'TOGOMCP_QUERY_LOG=/var/log/togomcp/togomcp.jsonl' >> .env
+mkdir -p logs
+docker compose up -d togomcp-main
+tail -f logs/togomcp.jsonl
+```
+
+The path in the env var is the **container-side** path; the bind mount makes
+the same file visible at `./logs/togomcp.jsonl` on your host. Leaving the var
+unset keeps logging off — no compose changes needed.
+
+### Claude Desktop (local stdio)
+
+Add `TOGOMCP_QUERY_LOG` to the `env` block alongside `NCBI_API_KEY`. Use an
+absolute path (the spawned process's cwd is unpredictable) and ensure the
+parent directory exists:
+
+```json
+"env": {
+    "NCBI_API_KEY": "your-key-here",
+    "TOGOMCP_QUERY_LOG": "/Users/you/togomcp-logs/togomcp.jsonl"
+}
+```
+
+Then `mkdir -p ~/togomcp-logs` once and fully restart Claude Desktop.
+
+---
+
 ## Available Databases & Tools
 
 TogoMCP exposes tools for querying the following (via SPARQL or REST APIs):


### PR DESCRIPTION
## Summary
Follow-up to #68. Documents the JSONL tool-call logging feature so users discover it.

- README gains a **Tool-Call Logging (Optional)** section: on/off env var semantics, Docker bind-mount flow (`./logs` ↔ `/var/log/togomcp`), and a Claude Desktop config snippet.
- `.env.example` lists `TOGOMCP_QUERY_LOG` and `TOGOMCP_QUERY_LOG_TEST` (commented out) so `cp .env.example .env` users see the feature.

No code changes.

## Test plan
- [ ] Reviewer: skim the new README section for accuracy of paths and example commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)