### PR TITLE
Add three TogoMCP workflow skills + ChEBI MIE v2.2 hardening

### DIFF
--- a/.claude/skills/disease-analysis/SKILL.md
+++ b/.claude/skills/disease-analysis/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: disease-analysis
+description: >-
+  Run a multi-scale disease pathophysiology analysis — molecular defects through
+  to clinical symptoms — using TogoMCP (RDF Portal SPARQL), TogoID ID conversion,
+  OLS4, and PubMed. Use whenever the user asks to "analyze a disease", build a
+  disease mechanism model, find disease-associated proteins/pathways/drugs, map a
+  disease across biological scales (molecular → pathway → cellular → tissue →
+  clinical → treatment), or convert disease/protein/drug IDs across databases for
+  a disease. Also triggers on "disease analysis", "pathophysiology of X",
+  "what proteins/pathways/drugs are involved in X". The workflow source is
+  workflows/disease_analysis.md.
+---
+
+# Disease Analysis (multi-scale, TogoMCP-driven)
+
+Systematic analysis of any disease from molecular defect to clinical symptom,
+built from structured queries (not model recall). The real driver is the
+**TogoMCP MCP tools** (`run_sparql`, `togoid_convertId`, `togoid_countId`) plus
+OLS4 and PubMed. The committed harness `smoke.py` is the offline canary that
+proves the workflow's query patterns still resolve before you rely on them.
+
+Paths below are relative to the repo root (`<unit>/`). The full prompt template,
+output format, and per-disease-category customizations live in
+[workflows/disease_analysis.md](workflows/disease_analysis.md) — read it for the
+deliverable structure. This SKILL.md is the *operational* path: verified queries,
+the exact tool calls, and the traps.
+
+## Prerequisites
+
+- A running TogoMCP server. Prefer the **local dev** server (`togomcp-dev` tools)
+  — the remote registry can be stale. From the repo: `uv sync && uv run togo-mcp-local`.
+- For the offline harness: Python 3 only (stdlib `urllib`; no pip install).
+- Network access to `rdfportal.org` and `api.togoid.dbcls.jp`.
+
+## Verify first (agent path — run this before trusting the workflow)
+
+`smoke.py` hits the same SPARQL endpoints and TogoID API the MCP tools wrap, so
+it works even with no MCP server running. Run it to confirm every workflow phase
+still returns data:
+
+```bash
+python3 .claude/skills/disease-analysis/smoke.py
+```
+
+Expected (verified this session, ~30–60s):
+
+```
+PASS  UniProt disease proteins ('osteoarthritis'): 1 rows
+PASS  Reactome pathway search ('collagen degradation'): 10 rows
+PASS  Reactome participants (xsd:string xref): 10 rows
+PASS  TogoID uniprot,ncbigene: 4 rows
+PASS  TogoID uniprot,pdb: 65 rows
+PASS  TogoID mondo,mesh: 1 rows
+PASS  TogoID chembl_compound,pubchem_compound: 2 rows
+
+7/7 checks passed
+```
+
+Point it at any disease keyword (drives only the UniProt full-text check):
+
+```bash
+python3 .claude/skills/disease-analysis/smoke.py --disease "Parkinson disease"
+```
+
+If a check **FAILS**, the corresponding workflow step is broken (endpoint down,
+schema drift, or full-text index changed) — fix that before running the analysis,
+and update the query pattern below + in workflows/disease_analysis.md.
+
+## Run the analysis (the six phases, with verified tool calls)
+
+Drive these with the `togomcp-dev` (preferred) or `togomcp` MCP tools. Each call
+below was run live this session and returned data.
+
+**Phase 1 — Disease ID & ontology cross-refs.** Resolve the disease to MONDO via
+OLS4, then fan out:
+```
+togoid_convertId(ids="MONDO:0005178", route="mondo,mesh")   → [["0005178","D010003"]]
+togoid_convertId(ids="MONDO:0005178", route="mondo,doid")
+togoid_convertId(ids="MONDO:0005178", route="mondo,hp_phenotype")
+togoid_convertId(ids="MONDO:0005178", route="mondo,omim_phenotype")
+```
+
+**Phase 2 — Disease-associated proteins (UniProt SPARQL).** Full-text search over
+disease annotations. `bif:contains` must sit on a *plain variable*, never a
+property path:
+```
+run_sparql(database="uniprot", sparql_query="""
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?protein ?mnemonic ?fullName ?diseaseComment WHERE {
+  ?protein a up:Protein ; up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:mnemonic ?mnemonic ; up:recommendedName ?name ; up:annotation ?annot .
+  ?name up:fullName ?fullName .
+  ?annot a up:Disease_Annotation ; rdfs:comment ?diseaseComment .
+  ?diseaseComment bif:contains "'osteoarthritis'"
+} LIMIT 30""")
+→ Q9BXN1 / ASPN_HUMAN (Asporin), D14 allele association
+```
+
+**Phase 3 — Cross-link proteins (TogoID).** For each UniProt accession:
+```
+togoid_convertId(ids="P45452,P16112,O75173,Q9UNA0", route="uniprot,ncbigene")  → 4 pairs
+togoid_convertId(ids="P45452,P16112,O75173,Q9UNA0", route="uniprot,pdb")       → 65 structures
+togoid_countId(ids="P45452,P16112,O75173", source="uniprot", target="pdb")     → {"source":3,"target":58}
+# also: uniprot,hgnc · uniprot,chembl_target · uniprot,go · uniprot,reactome_pathway
+```
+
+**Phase 4 — Pathway analysis (Reactome SPARQL).** Always include the `FROM` graph;
+score with `bif:contains`. Then get participants — the protein xref **requires
+`"UniProt"^^xsd:string`** (see Gotchas):
+```
+run_sparql(database="reactome", sparql_query="""
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT DISTINCT ?reactionName ?proteinName ?uniprotId
+FROM <http://rdf.ebi.ac.uk/dataset/reactome> WHERE {
+  ?reaction a bp:BiochemicalReaction ; bp:displayName ?reactionName ; bp:left ?entity .
+  FILTER(CONTAINS(?reactionName, "MMP") || CONTAINS(?reactionName, "collagen"))
+  ?entity bp:entityReference ?proteinRef .
+  ?proteinRef bp:xref ?xref .
+  ?xref a bp:UnificationXref ; bp:db "UniProt"^^xsd:string ; bp:id ?uniprotId .
+  OPTIONAL { ?proteinRef bp:name ?proteinName }
+  FILTER(STRLEN(?uniprotId) = 6)
+} LIMIT 50""")
+→ MMP9 (P52176), MMP2 ...
+```
+
+**Phase 5 — Drugs & targets.** `search_chembl_molecule` / `search_chembl_target`
+to find IDs, then:
+```
+togoid_convertId(ids="CHEMBL118,CHEMBL139", route="chembl_compound,pubchem_compound") → [["CHEMBL118","2662"],["CHEMBL139","3033"]]
+togoid_convertId(ids="CHEMBL118,CHEMBL139", route="chembl_compound,drugbank")
+# get_compound_attributes_from_pubchem(...) for properties
+```
+
+**Phase 6 — Literature.** `PubMed:search_articles("<disease> <mechanism> <treatment>")`
+then `get_article_metadata` / `get_full_text_article`.
+
+Read MIE files first when querying a database you haven't this session:
+`get_MIE_file(database="reactome")`, `get_MIE_file(database="uniprot")`. The MIE
+is the authoritative schema/warnings source and is fresher than this doc.
+
+## Gotchas (the traps that silently return zero rows)
+
+- **Reactome xref typing — the #1 silent-fail.** `bp:db "UniProt"^^xsd:string`.
+  A plain `"UniProt"` literal (no `^^xsd:string`) matches nothing and returns an
+  empty result with no error. Same applies to any `VALUES`/literal compared
+  against Reactome string-typed data. Pre-flight every quoted literal against the
+  database's MIE `critical_warnings` before running.
+- **Reactome has two UniProt xref flavors:** `"UniProt"` (~91k) and
+  `"UniProt Isoform"` (~374). Filtering on only one can silently drop proteins
+  (e.g. NPC1L1 / Q9UHC9 is only reachable via the isoform form). For exhaustive
+  coverage match both.
+- **`bif:contains` cannot sit on a property path.** `?p up:recommendedName/up:fullName ?n . ?n bif:contains "..."` → 400. Split into two triples and put `bif:contains` on the terminal variable.
+- **`run_sparql` `database=` vs `endpoint_name=`** are different axes — `database`
+  is a single DB key (`uniprot`, `reactome`); `endpoint_name` is an endpoint group
+  (`sib`, `ebi`). Don't mix; a wrong value fails deterministically — don't retry it.
+- **Reactome needs `FROM <http://rdf.ebi.ac.uk/dataset/reactome>`** or you get
+  wrong/empty results.
+- **Always `up:reviewed 1` + `taxonomy/9606`** on UniProt disease queries, and a
+  `LIMIT` everywhere, or you get TrEMBL noise / timeouts.
+- **TogoID route ordering matters** (`uniprot,ncbigene` ≠ `ncbigene,uniprot`).
+  Use `togoid_countId` as a cheap pre-check before a bulk `convertId`.
+- **Disease keyword matters more than the MONDO ID** for Phase 2 — "osteoarthritis"
+  returns 1 protein, broader keywords return more. Try synonyms if a disease
+  returns nothing.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `smoke.py` Reactome checks FAIL but UniProt passes | EBI endpoint down or schema drift; retry, then check `get_MIE_file(database="reactome")` for changed predicates |
+| MCP `run_sparql` returns empty but `smoke.py` passes | You likely passed an endpoint group to `database=` or dropped `^^xsd:string` / `FROM` — compare against the verified queries above |
+| TogoID convert returns `[]` | Route ordering wrong, or IDs in wrong format — check `togoid_getDataset(dataset="...")` and `togoid_getAllRelation()` |
+| `urllib...timed out` in smoke.py | Endpoints are slow under load; rerun (TIMEOUT is 90s) |
+
+## The harness
+
+[smoke.py](.claude/skills/disease-analysis/smoke.py) — stdlib-only verifier of all
+six phases against the live RDF Portal + TogoID services. Run it before an
+analysis and whenever a query pattern here is edited. The MCP tools are the real
+driver for the analysis itself; smoke.py proves the patterns they send are sound.

--- a/.claude/skills/disease-analysis/smoke.py
+++ b/.claude/skills/disease-analysis/smoke.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Smoke test for the multi-scale disease-analysis workflow.
+
+Exercises the SAME services the TogoMCP tools wrap — the RDF Portal SPARQL
+endpoints and the TogoID REST API — so a future agent can confirm, from a clean
+machine and WITHOUT the MCP server running, that the workflow's core query
+patterns still resolve. Stdlib only (urllib); no pip install needed.
+
+The MCP tools (run_sparql / togoid_convertId) are the real driver when an agent
+runs the workflow. This script is the offline canary: if a SPARQL pattern here
+returns zero rows, the corresponding step in SKILL.md / the workflow is broken.
+
+Usage:
+    python3 .claude/skills/disease-analysis/smoke.py
+    python3 .claude/skills/disease-analysis/smoke.py --disease osteoarthritis
+
+Exit code 0 = every check returned data. Non-zero = at least one check failed.
+"""
+import argparse
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+SIB = "https://rdfportal.org/sib/sparql"        # uniprot
+EBI = "https://rdfportal.org/ebi/sparql"        # reactome, chembl
+TOGOID = "https://api.togoid.dbcls.jp"
+
+TIMEOUT = 90
+
+
+def sparql(endpoint, query):
+    data = urllib.parse.urlencode({"query": query, "format": "json"}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data,
+        headers={"Accept": "application/sparql-results+json",
+                 "User-Agent": "togomcp-disease-analysis-smoke/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return json.loads(r.read())["results"]["bindings"]
+
+
+def togoid_convert(ids, route):
+    params = urllib.parse.urlencode(
+        {"ids": ids, "route": route, "report": "pair", "format": "json"})
+    req = urllib.request.Request(
+        f"{TOGOID}/convert?{params}",
+        headers={"User-Agent": "togomcp-disease-analysis-smoke/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return json.loads(r.read()).get("results", [])
+
+
+def check(name, fn):
+    try:
+        rows = fn()
+        n = len(rows)
+        ok = n > 0
+        print(f"{'PASS' if ok else 'FAIL'}  {name}: {n} rows")
+        return ok
+    except Exception as e:  # noqa: BLE001 - surface any failure as a FAIL line
+        print(f"FAIL  {name}: {type(e).__name__}: {e}")
+        return False
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--disease", default="osteoarthritis",
+                    help="disease keyword for the UniProt full-text check")
+    args = ap.parse_args()
+    kw = args.disease.replace("'", "")
+
+    results = []
+
+    # Phase 2 — UniProt disease-associated proteins (bif:contains full-text)
+    results.append(check(
+        f"UniProt disease proteins ('{kw}')",
+        lambda: sparql(SIB, f"""
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?protein ?mnemonic ?diseaseComment WHERE {{
+  ?protein a up:Protein ; up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:mnemonic ?mnemonic ; up:annotation ?annot .
+  ?annot a up:Disease_Annotation ; rdfs:comment ?diseaseComment .
+  ?diseaseComment bif:contains "'{kw}'"
+}} LIMIT 10""")))
+
+    # Phase 4 — Reactome pathway search (bif:contains + score, FROM graph)
+    results.append(check(
+        "Reactome pathway search ('collagen degradation')",
+        lambda: sparql(EBI, """
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+SELECT DISTINCT ?pathway ?name
+FROM <http://rdf.ebi.ac.uk/dataset/reactome> WHERE {
+  ?pathway a bp:Pathway ; bp:displayName ?name .
+  ?name bif:contains "'collagen degradation'" option (score ?sc)
+} ORDER BY DESC(?sc) LIMIT 10""")))
+
+    # Phase 4 — Reactome participants (the ^^xsd:string xref trap)
+    results.append(check(
+        "Reactome participants (xsd:string xref)",
+        lambda: sparql(EBI, """
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT DISTINCT ?reactionName ?uniprotId
+FROM <http://rdf.ebi.ac.uk/dataset/reactome> WHERE {
+  ?reaction a bp:BiochemicalReaction ; bp:displayName ?reactionName ; bp:left ?e .
+  FILTER(CONTAINS(?reactionName, "MMP"))
+  ?e bp:entityReference ?ref . ?ref bp:xref ?x .
+  ?x a bp:UnificationXref ; bp:db "UniProt"^^xsd:string ; bp:id ?uniprotId .
+} LIMIT 10""")))
+
+    # Phase 3 — TogoID protein cross-linking
+    results.append(check(
+        "TogoID uniprot,ncbigene",
+        lambda: togoid_convert("P45452,P16112,O75173,Q9UNA0", "uniprot,ncbigene")))
+    results.append(check(
+        "TogoID uniprot,pdb",
+        lambda: togoid_convert("P45452,P16112,O75173,Q9UNA0", "uniprot,pdb")))
+
+    # Phase 1 — TogoID disease ontology cross-refs
+    results.append(check(
+        "TogoID mondo,mesh",
+        lambda: togoid_convert("MONDO:0005178", "mondo,mesh")))
+
+    # Phase 5 — TogoID drug cross-linking
+    results.append(check(
+        "TogoID chembl_compound,pubchem_compound",
+        lambda: togoid_convert("CHEMBL118,CHEMBL139", "chembl_compound,pubchem_compound")))
+
+    passed = sum(results)
+    total = len(results)
+    print(f"\n{passed}/{total} checks passed")
+    sys.exit(0 if passed == total else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/prism/SKILL.md
+++ b/.claude/skills/prism/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: prism
+description: >
+  PRISM finds entities (genes, proteins, compounds) at the INTERSECTION of two or more property sets on RDF
+  knowledge graphs via TogoMCP — e.g. "genes common to disease X and druggable pathway Y", "targets both associated
+  with phenotype P and modulated by existing drugs", "compounds both substrate of enzyme A and approved drugs". Use
+  whenever the user asks a set-intersection / overlap / "what is common to" / "is there a gene or target that is both
+  ... and ..." question, a drug-repurposing or target-identification question, or anything combining a
+  DISEASE/PHENOTYPE axis with a FUNCTION axis and/or a DRUGGABILITY axis. Trigger even if the user just says "shared
+  genes between A and B", "druggable targets for disease X", or "intersection of ... and ...". PRISM forces each axis
+  to be a reproducible predicate, expanded over the ontology hierarchy, triangulated across evidence sources, and
+  intersected by stable IDs with a provenance ledger. If you catch yourself listing candidate genes from memory,
+  STOP and use it.
+---
+
+# PRISM — Predicate-defined, Reproducible, Identifier-bridged, Set-intersection Mining
+
+PRISM answers "what entities are common to property set A and property set B?" on linked open data **without relying on recall**. A remembered list of candidates is a *hypothesis*, not a set. PRISM replaces hand-seeded lists with reproducible predicate chains, then triangulates weak axes across multiple evidence sources so the intersection does not silently collapse.
+
+## Before you begin
+
+- Call `TogoMCP_Usage_Guide` (or `TogoMCP-Test:TogoMCP_Usage_Guide`) **first**, and run its GATE 0 classification.
+- Read `references/sparql-templates.md` — parameterized queries for every phase (hierarchy expansion, GO→UniProt, PubTator co-occurrence, ClinVar gene-anchored significance, ChEMBL targets, Reactome membership, TogoID bridging).
+- Read `references/worked-example.md` for a full end-to-end run with a filled-in provenance ledger.
+
+## When to use vs. not
+
+Use PRISM when the question is an **intersection of properties** ("both A and B", "common to", "druggable target for disease", "shared genes", "overlap between"). Do **not** invoke the full machinery for a single-fact lookup ("what is the UniProt ID of CETP?") or a single-axis enumeration ("list genes in pathway X") — those are ordinary TogoMCP queries. The tell for PRISM is two or more *constraints of different kinds* that must be satisfied simultaneously.
+
+---
+
+## The PRISM mnemonic → five phases
+
+```
+P — Pose as sets & Predicate-define each axis   (kill recall)
+R — Reach the full hierarchy                     (transitive closure)
+I — Integrate multi-source evidence              (triangulate weak axes)
+S — Stitch by stable ID & intersect              (set algebra)
+M — Measure actionability & audit provenance     (stratify + ledger)
+```
+
+Do the phases in order. The two most-skipped, most-damaging-to-skip steps are **R** (hierarchy expansion) and **I** (triangulation). Skipping R silently under-covers a set; skipping I lets a single biased source collapse the intersection.
+
+---
+
+## PHASE P — Pose as sets & predicate-define each axis
+
+1. **Write the question as explicit set algebra.** Name the operation (∩, ∪, \) and each operand. Example: `Answer = A ∩ B` where `A = {disease-associated} ∩ {function f}` and `B = {in druggable pathway}`.
+
+2. **Name each set by the PREDICATE that defines it, not by example members.** "Lipid-transport genes" is not a definition; `human reviewed UniProt proteins where up:classifiedWith ∈ descendants(GO:0006869)` is. If you cannot yet name the predicate, that axis is still a hypothesis — resolve it before proceeding.
+
+3. **De-recall.** Any candidate list you produced from memory is a *seed for sanity-checking*, never the set itself. The deliverable set must be derivable from databases by someone who shares none of your priors. Treat "genes I know are associated with X" as a red flag, not an answer.
+
+4. **Map each axis to a database and an anchoring entity:**
+
+| Axis type | Typical source(s) | Anchor |
+|-----------|-------------------|--------|
+| Molecular function | GO (term + descendants) → UniProt `up:classifiedWith` | GO term IRI |
+| Pathway membership | Reactome (BioPAX) | pathway IRI / displayName |
+| Disease / phenotype association | PubTator (literature), NCBI Gene (curation), ClinVar (variant), GWAS Catalog (external) | MeSH / MedGen / disease IRI |
+| Druggability | ChEMBL (target + activity) | target/gene name |
+| Clinical actionability | ClinVar germline classification | gene IRI |
+
+---
+
+## PHASE R — Reach the full hierarchy
+
+Ontology- and keyword-defined axes are **DAGs**. Querying a single term or a single controlled-vocabulary keyword silently misses members annotated only to narrower terms.
+
+- **Always expand to the transitive closure.** For a GO/MONDO/ChEBI axis, fetch descendants with `?term rdfs:subClassOf+ <ROOT>` against the ontology database (e.g. `go`), then feed the resulting term IRIs as `VALUES` into the annotation database (UniProt `up:classifiedWith`, etc.). See `references/sparql-templates.md → Hierarchy expansion`.
+- **Do not trust a single UniProt keyword** (`up:classifiedWith keywords:NNN`) as a complete functional axis — it is one node in a keyword DAG. Prefer the GO-descendant route, or union the relevant child keywords.
+- **Sanity check the expansion** by confirming that a few entities you *expect* (and a few you'd expect to be *absent*) land on the correct side. This is the one place where recall is useful — as a test oracle, not as the set.
+
+> Lesson baked in: a `keyword:Lipid transport`-only axis dropped ABCA1 and ABCA4 (annotated to child terms `cholesterol efflux`, `phospholipid translocation`). Switching to `GO:0006869 + subClassOf+` recovered them. Under-coverage from skipping R is *silent* — you get a plausible-looking but incomplete set.
+
+---
+
+## PHASE I — Integrate multi-source evidence (triangulate weak axes)
+
+Some axes are "hard" (a molecular function is what the annotation says). Others are "soft" — **disease association in particular is recorded differently by every source, each with a different bias.** A naive single-source intersection collapses.
+
+**Define each soft axis as the UNION of bias-distinct sources, and record which source supports each member.**
+
+| Source | Captures | Bias / blind spot |
+|--------|----------|-------------------|
+| PubTator co-occurrence | genes co-mentioned with the disease | **literature-volume bias** — buries GWAS-only loci with few papers |
+| NCBI Gene curation (`esearch gene`) | curated/GeneRIF disease links | broad; surfaces GWAS loci; some non-causal mentions |
+| ClinVar variant–condition | Mendelian / clinically-graded variants | **only Mendelian** — common-variant risk loci appear as "risk factor"/absent |
+| GWAS Catalog (external, outside TogoMCP) | common-variant risk loci with effect sizes | not in TogoMCP — flag as external |
+
+> Lesson baked in: for a disease intersection, PubTator alone kept only `{APOE, ABCA4}`; the curation axis additionally surfaced `CETP, ABCA1, LIPC, APOB, APOC1, SCARB1, ABCG1`; ClinVar pathogenicity flagged `ABCA4` alone (the others' pathogenic variants belong to *other* Mendelian disorders, not the target disease). Each axis was individually misleading; the union was correct. **Always tag provenance per member** so you can see which axis carried each gene.
+
+---
+
+## PHASE S — Stitch by stable ID & intersect
+
+1. **Normalize every set to one stable identifier** (NCBI Gene ID or UniProt accession). Use `togoid_convertId` to bridge (e.g. UniProt ↔ ncbigene). UniProt RDF also carries the GeneID cross-reference directly (`rdfs:seeAlso` → `.../geneid/NNN`).
+2. **Compute the intersection on IDs, not symbols** (symbols are ambiguous; `ABCA1` vs `ABCA4` differ by one character and are easy to confuse).
+3. **Prefer SPARQL-side intersection** via `VALUES` of the smaller set; only fall back to reading two result sets and matching when federation is unavailable (SERVICE is disabled platform-wide on rdfportal — use sequential queries + `VALUES` bridging).
+
+---
+
+## PHASE M — Measure actionability & audit provenance
+
+1. **Stratify the intersection by actionability**, not as a flat list:
+   - Tier 1: directly actionable (e.g. ChEMBL target of an approved/late-stage drug).
+   - Tier 2: on a shared druggable pathway (modulated indirectly).
+   - Tier 3: mechanistically central but only investigational / no direct drug.
+2. **Emit a provenance ledger** (required output). One row per member, columns = each axis + supporting source + verified/inferred. See the template in `references/worked-example.md`.
+3. **Mark DB-verified vs inferred vs out-of-scope.** State plainly which claims came from a database query and which would need an external source (GWAS Catalog for effect sizes, ClinicalTrials.gov for approval/indication status).
+4. **Re-ask "is this comprehensive?"** and name the residual gaps (unscanned pages, axes not yet triangulated, hierarchy levels not expanded).
+
+---
+
+## Operational discipline (query engineering)
+
+These are not optional — they are what made the difference between answers and timeouts:
+
+- **Anchor on the small set.** Put the smaller operand in `VALUES` as the inner anchor (e.g. gene-anchored, not disease-anchored). A disease scan joined against millions of variants times out; the same query gene-anchored returns in seconds.
+- **Prefer single-graph queries.** Cross-graph joins invite namespace mismatches. Known trap: ClinVar stores MedGen refs as `http://ncbi.nlm.nih.gov/medgen/...` (no `www`) while MedGen entities use `http://www.ncbi.nlm.nih.gov/medgen/...` (with `www`). A direct join silently returns 0 rows — convert with `REPLACE(STR(?u), "://ncbi.nlm", "://www.ncbi.nlm")` (or the reverse).
+- **On timeout: reconstruct, don't retry.** Re-anchor, drop a graph, add `LIMIT`, or split into two queries. Never resubmit the identical query.
+- **Respect consecutive-SPARQL limits.** After 2 heavy SPARQL calls in a row, pivot to a non-SPARQL tool (`esearch`, an MIE read, OLS) before the next query.
+- **Read the MIE before querying any database** you have not already characterized this session.
+- **Soft filters can be empty for real reasons.** If a "pathogenic AND disease-named" filter returns nothing, that may be biology (the disease is a complex trait, not Mendelian), not a bug — but verify with a looser single-graph query before concluding.
+
+---
+
+## Anti-patterns (each one bit us; don't repeat them)
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| Seeding the set from memory | a recalled list is a hypothesis, biased and incomplete | Phase P: predicate-define |
+| Single keyword / single GO term as a functional axis | DAG children are silently excluded | Phase R: `subClassOf+` |
+| Single source for disease association | each source's bias collapses the intersection | Phase I: union bias-distinct sources |
+| Intersecting on gene symbols | ambiguous; off-by-one-letter confusions | Phase S: intersect on stable IDs |
+| Disease-anchored heavy join | scans millions of rows → timeout | anchor on the small set |
+| Cross-graph join without namespace fix | `www`/no-`www` mismatch → 0 rows | convert namespaces or go single-graph |
+| Flat result list | hides actionability and provenance | Phase M: stratify + ledger |
+
+---
+
+## Output template
+
+```
+## Answer (set-intersection)
+<yes/no + the intersection, stratified into Tier 1/2/3>
+
+## Provenance ledger
+| member (ID) | function axis | disease axis (source) | druggability | actionability tier | verified? |
+
+## Method (reproducible predicate chain)
+function: <ontology root + subClassOf+ → annotation DB>
+disease : <union of sources, per-member tags>
+intersect: <stable ID>
+
+## Honest limits
+<DB-verified vs inferred; out-of-scope external sources; residual comprehensiveness gaps>
+```

--- a/.claude/skills/prism/references/sparql-templates.md
+++ b/.claude/skills/prism/references/sparql-templates.md
@@ -1,0 +1,216 @@
+# PRISM SPARQL templates
+
+Parameterized, copy-ready queries for each PRISM phase. Replace `«PLACEHOLDERS»`. All target the rdfportal TogoMCP endpoints; run via `run_sparql`. Read the relevant `get_MIE_file` before first use of any database.
+
+## Table of contents
+1. Hierarchy expansion (Phase R) — ontology descendants
+2. Function axis (Phase R) — GO descendants → UniProt members (+ GeneID)
+3. Function axis variant — UniProt keyword (single node; use only when unioning children)
+4. Disease axis A (Phase I) — PubTator co-occurrence
+5. Disease axis B (Phase I) — NCBI Gene curated association (esearch, not SPARQL)
+6. Disease axis C (Phase I) — ClinVar gene-anchored significance × condition (single-graph)
+7. Druggability axis (Phase M) — ChEMBL target check
+8. Pathway membership (Phase P/M) — Reactome participants by UniProt accession
+9. ID bridging (Phase S) — TogoID / UniProt GeneID xref
+
+---
+
+## 1. Hierarchy expansion (Phase R)
+
+Get the transitive closure of an ontology subtree. Run against the ontology DB (`go`, or MONDO/ChEBI equivalents). Feed the result IRIs as `VALUES` into the annotation query (template 2).
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+SELECT DISTINCT ?term
+WHERE {
+  ?term rdfs:subClassOf+ obo:«ROOT_e_g_GO_0006869» .
+  FILTER(STRSTARTS(STR(?term), "http://purl.obolibrary.org/obo/GO_"))
+}
+LIMIT 300
+```
+
+Notes: include the root itself in your downstream `VALUES`. `subClassOf+` is correct for GO subtrees (small); avoid it on pre-flattened lineages like taxonomy. If the ontology DB lacks the hierarchy, use `OLS4:getChildren` iteratively (one level each) or `OLS4:getDescendants` if loaded.
+
+---
+
+## 2. Function axis — GO descendants → UniProt members (Phase R)
+
+Human, reviewed proteins annotated to ANY term in the expanded set, with NCBI GeneID for later bridging.
+
+```sparql
+PREFIX up:   <http://purl.uniprot.org/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo:  <http://purl.obolibrary.org/obo/>
+
+SELECT DISTINCT ?gene ?geneid
+WHERE {
+  VALUES ?goTerm { obo:«ROOT» obo:«CHILD_1» obo:«CHILD_2» «…all descendants from template 1…» }
+  ?protein a up:Protein ;
+           up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:classifiedWith ?goTerm ;
+           up:encodedBy ?g .
+  ?g skos:prefLabel ?gene .
+  OPTIONAL {
+    ?protein rdfs:seeAlso ?xref .
+    ?xref up:database <http://purl.uniprot.org/database/GeneID> .
+    BIND(STRAFTER(STR(?xref), "geneid/") AS ?geneid)
+  }
+}
+ORDER BY ?gene
+LIMIT 400
+```
+
+This is the **memory-independent functional set**. The `OPTIONAL` GeneID block makes Phase S free (no separate TogoID call needed).
+
+---
+
+## 3. Function axis variant — UniProt keyword
+
+Use ONLY if unioning the relevant child keywords; a single keyword under-covers (it is one DAG node).
+
+```sparql
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX keywords: <http://purl.uniprot.org/keywords/>
+
+SELECT DISTINCT ?gene WHERE {
+  VALUES ?kw { keywords:«N1» keywords:«N2» }      # union children, don't use one node
+  ?protein a up:Protein ; up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:classifiedWith ?kw ; up:encodedBy ?g .
+  ?g skos:prefLabel ?gene .
+}
+LIMIT 400
+```
+
+---
+
+## 4. Disease axis A — PubTator co-occurrence (Phase I)
+
+Genes co-mentioned with a disease (MeSH IRI), ranked. Literature-volume biased — pair with templates 5 and 6.
+
+```sparql
+PREFIX oa:     <http://www.w3.org/ns/oa#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX insdc:  <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?gene_symbol (COUNT(DISTINCT ?article) AS ?cooccurrence)
+WHERE {
+  GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+    ?d dcterms:subject "Disease" ; oa:hasBody <http://identifiers.org/mesh/«MESH_e_g_D008268»> ; oa:hasTarget ?article .
+    ?g dcterms:subject "Gene" ;    oa:hasBody ?geneId ; oa:hasTarget ?article .
+  }
+  GRAPH <http://rdfportal.org/dataset/ncbigene> { ?geneId a insdc:Gene ; rdfs:label ?gene_symbol . }
+}
+GROUP BY ?gene_symbol ORDER BY DESC(?cooccurrence) LIMIT 60
+```
+
+To intersect with the functional set inside SPARQL, add `VALUES ?geneId { <ncbigene IRIs…> }` — but if it times out, **anchor on the smaller set** and avoid the unfiltered disease scan; or take the top-N here and intersect by ID on the read side.
+
+---
+
+## 5. Disease axis B — NCBI Gene curated association (Phase I)
+
+Not SPARQL — use `ncbi_esearch` (paginate with `start_index`). Curation-based; de-biases vs literature volume and surfaces GWAS loci.
+
+```
+ncbi_esearch(database="gene",
+  query='("«DISEASE NAME»"[Disease] OR "«DISEASE NAME»") AND Homo sapiens[Organism]',
+  max_results=100, start_index=0)   # then 100, 200, … to cover Total Results
+```
+
+Intersect the returned Gene IDs with the functional set's GeneIDs (Phase S).
+
+---
+
+## 6. Disease axis C — ClinVar gene-anchored significance (Phase I/M)
+
+**Gene-anchored, single-graph** (the disease-anchored / cross-graph forms time out or return 0). Returns clinical-significance × condition-CUI per gene. Anchor `VALUES` = the intersection candidates (small set).
+
+```sparql
+PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?gene_id ?significance ?id (COUNT(DISTINCT ?variant) AS ?n)
+FROM <http://rdfportal.org/dataset/clinvar>
+WHERE {
+  VALUES ?gene_uri { <http://ncbi.nlm.nih.gov/gene/«ID1»> <http://ncbi.nlm.nih.gov/gene/«ID2»> «…» }
+  ?gbn med2rdf:gene ?gene_uri .
+  ?cr sio:SIO_000628 ?gbn .
+  ?variant cvo:classified_record ?cr ;
+           cvo:record_status "current" ;
+           cvo:record_type "classified" ;          # exclude "included" (no classified_record)
+           med2rdf:disease ?dis .
+  ?cr cvo:classifications ?cls .
+  ?cls cvo:germline_classification ?germ .
+  ?germ cvo:description ?significance .
+  ?dis dct:references ?ref .
+  ?ref dct:source "MedGen" ; dct:identifier ?id .
+  BIND(STRAFTER(STR(?gene_uri), "gene/") AS ?gene_id)
+}
+GROUP BY ?gene_id ?significance ?id
+ORDER BY ?gene_id DESC(?n)
+LIMIT 400
+```
+
+Interpretation: macular-degeneration condition CUIs include `C0024437` (Macular Degeneration), `C0242383` (ARMD), `C0854723` (Stargardt). For complex-trait diseases, expect risk loci to show "Uncertain significance"/"Conflicting"/absent rather than "Pathogenic" — Mendelian genes (e.g. ABCA4) carry the pathogenic load. To attach human-readable condition names, join MedGen with the namespace fix: `BIND(IRI(REPLACE(STR(?cv_uri),"://ncbi.nlm","://www.ncbi.nlm")) AS ?mg)`.
+
+---
+
+## 7. Druggability axis — ChEMBL target check (Phase M)
+
+```
+search_chembl_target(query="«gene/protein name»", limit=5)
+```
+
+Confirms a human `SINGLE PROTEIN` target row (e.g. CETP→CHEMBL3572, ABCA1→CHEMBL2362986, HMGCR→CHEMBL402). For approved/late-stage status and indication, ChEMBL gives bioactivity; confirm approval + disease indication via an external source (ClinicalTrials.gov / drug labels) — out of TogoMCP scope.
+
+---
+
+## 8. Pathway membership — Reactome participants by UniProt accession (Phase P/M)
+
+Which of a candidate accession set participate in pathways matching a name (isoform-aware).
+
+```sparql
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?gene ?pathwayName
+FROM <http://rdf.ebi.ac.uk/dataset/reactome>
+WHERE {
+  VALUES (?targetAcc ?gene) { ("«ACC»"^^xsd:string "«SYMBOL»") «…» }
+  ?pathway a bp:Pathway ; bp:displayName ?pathwayName ;
+           bp:organism/bp:name "Homo sapiens"^^xsd:string ;
+           bp:pathwayComponent+ ?reaction .
+  ?pathwayName bif:contains "'«lipoprotein»'" .
+  ?reaction (bp:left|bp:right) ?participant .
+  ?participant bp:component* ?protein .
+  ?protein a bp:Protein ; bp:entityReference/bp:xref ?x .
+  ?x a bp:UnificationXref ; bp:db ?db ; bp:id ?xid .
+  VALUES ?db { "UniProt"^^xsd:string "UniProt Isoform"^^xsd:string }
+  FILTER(?xid = ?targetAcc || STRSTARTS(STR(?xid), CONCAT(STR(?targetAcc), "-")))
+}
+ORDER BY ?pathwayName ?gene
+```
+
+To enumerate a whole pathway's membership instead, drop the `VALUES` accession anchor and select `?uniprotId` from the xref.
+
+---
+
+## 9. ID bridging (Phase S)
+
+Preferred: pull GeneID directly in the UniProt query (template 2's `OPTIONAL`). Otherwise:
+
+```
+togoid_countId(...)        # check convertibility first
+togoid_convertId(route="uniprot → ncbigene", ids=[...])
+```
+
+Intersection is computed on the normalized IDs. When SPARQL federation is needed but unavailable (SERVICE disabled on rdfportal), run sequential queries and bridge with `VALUES`.

--- a/.claude/skills/prism/references/worked-example.md
+++ b/.claude/skills/prism/references/worked-example.md
@@ -1,0 +1,79 @@
+# PRISM worked example — dry AMD lipid-transport ∩ druggable pathways
+
+A full run illustrating all five phases, the failure modes encountered, and the required provenance ledger. The question:
+
+> *Are there genes common to (lipid-transport dysfunction in dry AMD) and (pathways controllable by existing drugs)?*
+
+## Phase P — pose as sets
+
+```
+Answer = A ∩ B
+A = {dAMD-associated} ∩ {lipid transport}     # disease axis ∩ function axis
+B = {druggable / in a drug-modulated pathway} # druggability axis
+```
+
+Predicate definitions chosen:
+- function axis = `human reviewed UniProt where up:classifiedWith ∈ descendants(GO:0006869 "lipid transport")`
+- disease axis = `UNION of {PubTator co-occurrence with MeSH D008268}, {NCBI Gene curated "macular degeneration"}, {ClinVar variant→condition}`
+- druggability axis = `ChEMBL human SINGLE PROTEIN target` and/or `Reactome lipoprotein-metabolism membership`
+
+The first-pass answer (CETP, ABCA1, APOE, LIPC) was **recall-seeded** and, as Phase R/I later showed, *missed ABCA4* — the gene most faithful to "lipid transport dysfunction" in dAMD. That miss is the entire reason PRISM exists.
+
+## Phase R — reach the full hierarchy
+
+- A keyword-only function axis (`keywords:445 "Lipid transport"`) returned ~180 genes but **silently dropped ABCA1, ABCA4, LCAT, LIPC** (annotated only to child terms like `cholesterol efflux`, `phospholipid translocation`).
+- Fix: `GO:0006869 subClassOf+` → 107 descendant terms → fed as `VALUES` into UniProt `up:classifiedWith` → ~270 genes, now **including ABCA1, ABCA4, LCAT, LIPC, SCARB1, NPC1L1, STRA6, CLU**. (templates 1 → 2)
+
+## Phase I — integrate (triangulate the disease axis)
+
+| Source | What survived ∩ function set | Bias exposed |
+|--------|------------------------------|--------------|
+| PubTator (D008268) | APOE, ABCA4 only | literature volume — buried CETP/ABCA1/LIPC |
+| NCBI Gene curation | + CETP, ABCA1, LIPC, APOB, APOC1, SCARB1, ABCG1, CD36, PLTP, VLDLR | broad; a few peripheral (ACE, SLC2A1) |
+| ClinVar pathogenicity | ABCA4 only (Stargardt/AMD CUIs) | Mendelian-only; risk loci absent |
+
+The single-source intersection collapsed to `{APOE}` (PubTator) — proof that one axis is not enough. The union recovered the real set.
+
+## Phase S — stitch by ID
+
+Normalized all sets to NCBI Gene ID (UniProt GeneID xref + esearch IDs), intersected on IDs.
+
+## Phase M — measure & audit
+
+### Provenance ledger
+
+| Gene (NCBI ID) | Function (GO:0006869+desc) | Disease axis (source) | Druggability | Tier | Verified |
+|----------------|---------------------------|------------------------|--------------|------|----------|
+| ABCA4 (24)  | ✓ phospholipid translocation | PubTator + NCBI + **ClinVar pathogenic** (Stargardt/AMD) | visual-cycle modulators (emixustat, ALK-001) — investigational | 3 (mechanistic core) | DB-verified; drug status external |
+| CETP (1071) | ✓ cholesteryl ester transfer | NCBI curation (GWAS locus) | CETP inhibitors — ChEMBL3572 | 1 | DB-verified |
+| ABCA1 (19)  | ✓ cholesterol efflux | NCBI curation (GWAS locus) | LXR agonists (indirect) — ChEMBL2362986 | 1 | DB-verified |
+| APOE (348)  | ✓ lipoprotein transport | PubTator + NCBI | pathway-level only | 2 | DB-verified |
+| LIPC (3990) | ✓ lipid metabolism/transport | NCBI curation (GWAS locus) | fibrate/PPARA (indirect) | 2 | DB-verified |
+| APOB (338)  | ✓ | NCBI curation | mipomersen/lomitapide | 2 | DB-verified |
+| APOC1 (341) | ✓ | NCBI curation | pathway-level | 2 | DB-verified |
+| SCARB1 (949)| ✓ | NCBI curation | pathway-level | 2 | DB-verified |
+| ABCG1 (9619)| ✓ | NCBI curation | pathway-level | 2 | DB-verified |
+| PLTP (5360) | ✓ | NCBI curation | pathway-level | 2 | DB-verified |
+| VLDLR (7436)| ✓ | NCBI curation | pathway-level | 2 | DB-verified |
+| CD36 (948)  | ✓ | PubTator + NCBI | pathway-level | 2 | DB-verified |
+| NPC1L1*     | ✓ | (pathway node) | ezetimibe | 2 | function/drug verified; AMD link weak |
+
+\* shared-pathway druggable node; included as a drug-modulation lever, not a confirmed AMD locus.
+
+### Stratified answer
+- **Tier 1 (AMD lipid locus × direct existing drug):** CETP, ABCA1.
+- **Tier 2 (AMD lipid locus on a drug-modulated lipoprotein pathway):** APOE, LIPC, APOB, APOC1, SCARB1, ABCG1, PLTP, VLDLR, CD36 (+ pathway levers NPC1L1, LDLR/PCSK9/HMGCR).
+- **Tier 3 (mechanistic core; drug investigational):** ABCA4 — the gene most faithful to "lipid-transport dysfunction" in dAMD.
+
+### Honest limits (always state)
+- Druggability (ChEMBL) and pathway membership (Reactome) and function (GO/UniProt) and disease links (PubTator/NCBI/ClinVar) are **DB-verified**.
+- **AMD effect sizes** require the GWAS Catalog (outside TogoMCP).
+- **Drug approval + AMD indication** require ClinicalTrials.gov / labels (outside TogoMCP).
+
+## Failure log (what timed out / returned empty, and the fix)
+
+| Symptom | Cause | Fix that worked |
+|---------|-------|-----------------|
+| Disease-anchored PubTator×functional-set join timed out | scanned all gene annotations for a high-frequency disease | take top-N disease genes, intersect by ID on read side |
+| ClinVar MedGen-name cross-graph join → 0 rows | `www`/no-`www` namespace mismatch | single-graph by condition CUI; or `REPLACE` namespace |
+| ClinVar "pathogenic AND macular" → 0 rows | complex-trait risk loci aren't "Pathogenic"; ABCA4 pathogenic load is under "Stargardt" (no "macular" in name) | drop significance filter; read full distribution per gene |

--- a/.claude/skills/research-article-analysis/SKILL.md
+++ b/.claude/skills/research-article-analysis/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: research-article-analysis
+description: >-
+  Systematically validate a research article's claims against TogoMCP RDF
+  databases — molecular formulas, reaction equations, pathways, protein function,
+  GO definitions — instead of trusting the paper's text or keyword-search
+  snippets. Use whenever the user asks to "analyze this paper/article", fact-check
+  or validate a study's biology, verify claimed metabolites/reactions/pathways/
+  proteins/processes against databases, score the evidence for a paper's claims,
+  or build a cross-database evidence chain (ChEBI → Rhea → UniProt → Reactome →
+  GO). Triggers on "article analysis", "validate this study", "check this paper's
+  claims". Workflow source: workflows/research_article_analysis.md.
+---
+
+# Research Article Analysis (claim validation via TogoMCP SPARQL)
+
+Validate a paper claim-by-claim by running structured SPARQL against five RDF
+databases — **ChEBI, Rhea, Reactome, UniProt, GO** — and citing the query
+results (exact formulas, equations, EC numbers, GO definitions), not the paper's
+prose or keyword-search text. The real driver is the **TogoMCP MCP tools**
+(`run_sparql`, the `search_*` tools, `get_MIE_file`). The committed harness
+`smoke.py` is the offline canary that proves all 10 query types still resolve.
+
+Paths below are relative to the repo root. The full phased checklist, ID-tracking
+templates, scoring rubric, and anti-skipping safeguards live in
+[workflows/research_article_analysis.md](workflows/research_article_analysis.md)
+— read it for the deliverable structure and discipline. **This SKILL.md is the
+operational path: the SPARQL that actually works (the printed templates have two
+bugs — see Gotchas), the verified tool calls, and the traps.**
+
+## Prerequisites
+
+- A running TogoMCP server. Prefer the **local dev** server (`togomcp-dev` tools)
+  — the remote registry can be stale. From the repo: `uv sync && uv run togo-mcp-local`.
+- For the offline harness: Python 3 only (stdlib `urllib`; no pip install).
+- Network access to `rdfportal.org`.
+
+## Verify first (agent path — run before trusting the templates)
+
+`smoke.py` runs the *corrected* form of all 10 query types (2 per database)
+against the live RDF Portal endpoints `run_sparql` routes to, so it works with no
+MCP server running. Run it to confirm every database still answers:
+
+```bash
+python3 .claude/skills/research-article-analysis/smoke.py
+```
+
+Expected (verified this session, ~30–90s; the bile-acid example from the workflow):
+
+```
+PASS  chebi: structure (chemrof namespace!): 1 rows
+PASS  chebi: hierarchy: 6 rows
+PASS  rhea: equation search: 10 rows
+PASS  rhea: participants + chebi xref: 5 rows
+PASS  reactome: pathway structure: 20 rows
+PASS  reactome: complex: 15 rows
+PASS  uniprot: function (name/EC, NO classifiedWith join): 1 rows
+PASS  uniprot: GO terms (localization/function): 10 rows
+PASS  go: definitions: 2 rows
+PASS  go: hierarchy: 2 rows
+
+10/10 checks passed
+```
+
+A **FAIL** means that database's query type is broken (endpoint down or schema
+drift) — fix the pattern below and in the workflow before relying on it.
+
+## Run the analysis (phases, with verified queries)
+
+Follow the phase discipline in the workflow doc: **2A** select databases (5
+rules), **2B** `get_MIE_file(database=...)` for each, **2C** keyword-search to
+get IDs, **2D** run 2+ SPARQL per database using those IDs, **3** synthesize, **4**
+score. Drive 2D with `togomcp-dev` `run_sparql`. The query types below were all
+run live this session (bile-acid example) and returned data — copy these, not the
+workflow's printed templates.
+
+**ChEBI — structure (⚠ uses `chemrof:`, NOT `chebi:`):**
+```
+run_sparql(database="chebi", sparql_query="""
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX chemrof: <https://w3id.org/chemrof/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?formula ?mass ?smiles ?inchikey
+FROM <http://rdf.ebi.ac.uk/dataset/chebi> WHERE {
+  obo:CHEBI_16359 rdfs:label ?label ;
+    chemrof:generalized_empirical_formula ?formula ; chemrof:mass ?mass .
+  OPTIONAL { obo:CHEBI_16359 chemrof:smiles_string ?smiles }
+  OPTIONAL { obo:CHEBI_16359 chemrof:inchi_key_string ?inchikey }
+}""")
+→ cholic acid, C24H40O5, 408.579, SMILES, InChIKey BHQCQFFYRZLCQQ-OELDTZBJSA-N
+```
+ChEBI hierarchy uses `rdfs:subClassOf` + the `obo/CHEBI_` filter (works as printed
+in the workflow). Definition is `obo:IAO_0000115`; monoisotopic mass is
+`chemrof:monoisotopic_mass`; InChI string is `chemrof:inchi_string`.
+
+**Rhea — equation search & participants (work as printed):**
+```
+run_sparql(database="rhea", sparql_query="""
+PREFIX rhea: <http://rdf.rhea-db.org/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?reaction ?equation ?status ?ec WHERE {
+  ?reaction rdfs:subClassOf rhea:Reaction ; rhea:equation ?equation ; rhea:status ?status .
+  FILTER(CONTAINS(LCASE(?equation), "cholate"))
+  OPTIONAL { ?reaction rhea:ec ?ec }
+} LIMIT 10""")
+→ RHEA:14541 "choloyl-CoA + H2O = cholate + CoA + H(+)", EC 3.1.2.27
+```
+Participants: `VALUES ?reaction { <http://rdf.rhea-db.org/14541> }` then
+`rhea:side → rhea:contains → rhea:compound → rhea:chebi` → links to ChEBI IDs.
+
+**Reactome — pathway structure & complex (work as printed):** always
+`FROM <http://rdf.ebi.ac.uk/dataset/reactome>`; `FILTER(CONTAINS(LCASE(?displayName), "bile acid"))`
+for pathways, `?complex a bp:Complex` + `bp:component` for complexes (e.g.
+"GPBAR1: Bile acids"). For UniProt xrefs inside Reactome use `bp:db "UniProt"^^xsd:string`.
+
+**UniProt — function & GO (⚠ split into TWO queries):**
+```
+# Query A: name + EC. Do NOT add up:classifiedWith here — the join TIMES OUT.
+run_sparql(database="uniprot", sparql_query="""
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+SELECT ?mnemonic ?fullName ?ecNumber WHERE {
+  uniprot:Q8TDU6 up:reviewed 1 ; up:mnemonic ?mnemonic ; up:recommendedName ?name .
+  ?name up:fullName ?fullName .
+  OPTIONAL { uniprot:Q8TDU6 up:enzyme ?ecNumber }
+} LIMIT 10""")
+→ GPBAR_HUMAN, "G-protein coupled bile acid receptor 1"
+
+# Query B: GO terms in a separate query (fast on its own).
+run_sparql(database="uniprot", sparql_query="""
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+SELECT DISTINCT ?goTerm WHERE {
+  uniprot:Q8TDU6 up:classifiedWith ?goTerm .
+  FILTER(STRSTARTS(STR(?goTerm), "http://purl.obolibrary.org/obo/GO_"))
+} LIMIT 50""")
+→ GO_0005886, GO_0038182, GO_0097009, ...
+```
+
+**GO — definitions & hierarchy (work as printed):** always
+`FROM <http://rdfportal.org/ontology/go>`, `DISTINCT`, and the `obo/GO_` filter.
+Definitions via `obo:IAO_0000115`; hierarchy via `rdfs:subClassOf`.
+
+**Cross-database evidence chain** (the workflow's required deliverable) is real
+and reproducible: ChEBI cholate (`CHEBI_15378`) appears as a `rhea:chebi`
+participant of RHEA:14541, whose EC links to a UniProt enzyme, which appears in
+the Reactome "GPBAR1: Bile acids" complex, annotated with GO terms.
+
+Read MIE files first for any database you haven't queried this session:
+`get_MIE_file(database="chebi")`, etc. The MIE is the authoritative, freshest
+schema source.
+
+## Gotchas (the template bugs and silent-fail traps)
+
+- **ChEBI: the workflow's printed structure query returns ZERO rows.** It uses
+  `chebi:formula` / `chebi:mass` / `chebi:smiles` / `chebi:inchikey`
+  (`http://purl.obolibrary.org/obo/chebi/`). RDF Portal's ChEBI stores those under
+  the **chemrof** namespace instead: `chemrof:generalized_empirical_formula`,
+  `chemrof:mass`, `chemrof:smiles_string`, `chemrof:inchi_key_string`
+  (`https://w3id.org/chemrof/`). Use the corrected query above. The hierarchy
+  query is fine because it only uses `rdfs:subClassOf`.
+- **UniProt: combining `up:recommendedName` + `up:classifiedWith` in one query
+  TIMES OUT** (60s) on the SIB endpoint even with a single bound accession. Split:
+  name/EC in one query, GO terms (`classifiedWith`) in another. The workflow's
+  "Query Type 1" template combines them — don't.
+- **`run_sparql` `database=` vs `endpoint_name=`** are different axes (single DB
+  key vs endpoint group); a wrong value fails deterministically — don't retry.
+- **`FROM` graph is mandatory** and differs per DB: ChEBI/Reactome →
+  `http://rdf.ebi.ac.uk/dataset/{chebi,reactome}`; GO → `http://rdfportal.org/ontology/go`.
+  Rhea and UniProt take no `FROM`. Wrong/missing graph → empty results, no error.
+- **Reactome string xref needs `^^xsd:string`** (`bp:db "UniProt"^^xsd:string`);
+  a plain literal silently matches nothing.
+- **UniProt: always `up:reviewed 1`**; never put `bif:contains` on a property
+  path (split it). **Rhea/Reactome/GO: always `LIMIT`** on exploratory queries.
+- **Keyword search ≠ validation.** The whole point of the workflow: every ID from
+  a `search_*` call must be fed back into a SPARQL query, and you cite the SPARQL
+  result, not the search snippet.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `smoke.py` ChEBI structure FAILS | Confirm chemrof predicates with `SELECT ?p ?o { obo:CHEBI_16359 ?p ?o FILTER(isLiteral(?o)) }`; namespace may have changed again |
+| UniProt query `ReadTimeout` | You joined `recommendedName` with `classifiedWith` — split into two queries (see above) |
+| `run_sparql` returns empty but smoke.py passes | Missing/wrong `FROM` graph, dropped `^^xsd:string`, or `chebi:` instead of `chemrof:` — diff against the verified queries here |
+| `go: definitions` returns 0 | GO uses the `primary` endpoint and `FROM <http://rdfportal.org/ontology/go>` — not the ebi graph |
+
+## The harness
+
+[smoke.py](.claude/skills/research-article-analysis/smoke.py) — stdlib-only
+verifier of all 10 query types (5 databases × 2) against the live RDF Portal
+endpoints, with the chemrof and UniProt-split corrections baked in. Run it before
+an analysis and whenever a query pattern here is edited. The MCP tools are the
+real driver for the analysis itself; smoke.py proves the patterns are sound.

--- a/.claude/skills/research-article-analysis/smoke.py
+++ b/.claude/skills/research-article-analysis/smoke.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Smoke test for the research-article-analysis workflow.
+
+The workflow (workflows/research_article_analysis.md) validates a paper's claims
+by running 2 SPARQL query types against each of 5 RDF databases — ChEBI, Rhea,
+Reactome, UniProt, GO — then building a cross-database evidence chain. This
+script runs the *corrected* form of all 10 query types against the live RDF
+Portal endpoints (the same ones the TogoMCP run_sparql tool routes to), so a
+future agent can confirm, offline and without the MCP server, that every query
+type still resolves.
+
+Two corrections are baked in vs. the workflow's printed templates (see SKILL.md
+Gotchas): ChEBI uses the `chemrof:` namespace (not `chebi:`) for formula/mass/
+smiles, and the UniProt function query must NOT join recommendedName with
+classifiedWith (it times out) — they go in separate queries.
+
+Stdlib only (urllib); no pip install. Exit 0 = all checks returned data.
+
+    python3 .claude/skills/research-article-analysis/smoke.py
+"""
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+# database -> endpoint URL (from togo_mcp/data/resources/endpoints.csv)
+EP = {
+    "uniprot":  "https://rdfportal.org/sib/sparql",
+    "rhea":     "https://rdfportal.org/sib/sparql",
+    "chebi":    "https://rdfportal.org/ebi/sparql",
+    "reactome": "https://rdfportal.org/ebi/sparql",
+    "go":       "https://rdfportal.org/primary/sparql",
+}
+TIMEOUT = 90
+
+Q = {}
+
+# --- ChEBI (CHEBI_16359 cholic acid) -------------------------------------
+Q["chebi: structure (chemrof namespace!)"] = ("chebi", """
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX chemrof: <https://w3id.org/chemrof/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?formula ?mass ?smiles ?inchikey
+FROM <http://rdf.ebi.ac.uk/dataset/chebi> WHERE {
+  obo:CHEBI_16359 rdfs:label ?label ;
+    chemrof:generalized_empirical_formula ?formula ; chemrof:mass ?mass .
+  OPTIONAL { obo:CHEBI_16359 chemrof:smiles_string ?smiles }
+  OPTIONAL { obo:CHEBI_16359 chemrof:inchi_key_string ?inchikey }
+}""")
+
+Q["chebi: hierarchy"] = ("chebi", """
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?parent ?parentLabel
+FROM <http://rdf.ebi.ac.uk/dataset/chebi> WHERE {
+  obo:CHEBI_16359 rdfs:label ?label ; rdfs:subClassOf ?parent .
+  ?parent rdfs:label ?parentLabel .
+  FILTER(STRSTARTS(STR(?parent), "http://purl.obolibrary.org/obo/CHEBI_"))
+} LIMIT 20""")
+
+# --- Rhea (equation search + participants of RHEA:14541) ------------------
+Q["rhea: equation search"] = ("rhea", """
+PREFIX rhea: <http://rdf.rhea-db.org/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?reaction ?equation ?status ?ec WHERE {
+  ?reaction rdfs:subClassOf rhea:Reaction ;
+    rhea:equation ?equation ; rhea:status ?status .
+  FILTER(CONTAINS(LCASE(?equation), "cholate"))
+  OPTIONAL { ?reaction rhea:ec ?ec }
+} LIMIT 10""")
+
+Q["rhea: participants + chebi xref"] = ("rhea", """
+PREFIX rhea: <http://rdf.rhea-db.org/>
+SELECT ?equation ?side ?compound ?chebi WHERE {
+  VALUES ?reaction { <http://rdf.rhea-db.org/14541> }
+  ?reaction rhea:equation ?equation .
+  OPTIONAL { ?reaction rhea:side ?side . ?side rhea:contains ?p .
+    ?p rhea:compound ?compound . ?compound rhea:chebi ?chebi . }
+} LIMIT 30""")
+
+# --- Reactome (pathway structure + protein-ligand complex) ----------------
+Q["reactome: pathway structure"] = ("reactome", """
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+SELECT DISTINCT ?pathway ?displayName ?component ?componentName
+FROM <http://rdf.ebi.ac.uk/dataset/reactome> WHERE {
+  ?pathway a bp:Pathway ; bp:displayName ?displayName .
+  FILTER(CONTAINS(LCASE(?displayName), "bile acid"))
+  OPTIONAL { ?pathway bp:pathwayComponent ?component .
+    ?component bp:displayName ?componentName . }
+} LIMIT 20""")
+
+Q["reactome: complex"] = ("reactome", """
+PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+SELECT DISTINCT ?complex ?displayName ?component ?componentName
+FROM <http://rdf.ebi.ac.uk/dataset/reactome> WHERE {
+  ?complex a bp:Complex ; bp:displayName ?displayName .
+  FILTER(CONTAINS(?displayName, "GPBAR1"))
+  OPTIONAL { ?complex bp:component ?component .
+    ?component bp:displayName ?componentName . }
+} LIMIT 15""")
+
+# --- UniProt (Q8TDU6 GPBAR1) — function and GO terms in SEPARATE queries --
+Q["uniprot: function (name/EC, NO classifiedWith join)"] = ("uniprot", """
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+SELECT ?mnemonic ?fullName ?ecNumber WHERE {
+  uniprot:Q8TDU6 up:reviewed 1 ; up:mnemonic ?mnemonic ; up:recommendedName ?name .
+  ?name up:fullName ?fullName .
+  OPTIONAL { uniprot:Q8TDU6 up:enzyme ?ecNumber }
+} LIMIT 10""")
+
+Q["uniprot: GO terms (localization/function)"] = ("uniprot", """
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+SELECT DISTINCT ?goTerm WHERE {
+  uniprot:Q8TDU6 up:classifiedWith ?goTerm .
+  FILTER(STRSTARTS(STR(?goTerm), "http://purl.obolibrary.org/obo/GO_"))
+} LIMIT 50""")
+
+# --- GO (definitions + hierarchy) -----------------------------------------
+Q["go: definitions"] = ("go", """
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?term ?label ?definition
+FROM <http://rdfportal.org/ontology/go> WHERE {
+  VALUES ?term { obo:GO_0006954 obo:GO_0014732 }
+  ?term rdfs:label ?label .
+  OPTIONAL { ?term obo:IAO_0000115 ?definition }
+}""")
+
+Q["go: hierarchy"] = ("go", """
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?label ?parent ?parentLabel
+FROM <http://rdfportal.org/ontology/go> WHERE {
+  obo:GO_0014732 rdfs:label ?label ; rdfs:subClassOf ?parent .
+  ?parent rdfs:label ?parentLabel .
+  FILTER(STRSTARTS(STR(?parent), "http://purl.obolibrary.org/obo/GO_"))
+} LIMIT 20""")
+
+
+def sparql(endpoint, query):
+    data = urllib.parse.urlencode({"query": query, "format": "json"}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data,
+        headers={"Accept": "application/sparql-results+json",
+                 "User-Agent": "togomcp-article-analysis-smoke/1.0"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        return json.loads(r.read())["results"]["bindings"]
+
+
+def main():
+    passed = 0
+    for name, (db, q) in Q.items():
+        try:
+            n = len(sparql(EP[db], q))
+            ok = n > 0
+            print(f"{'PASS' if ok else 'FAIL'}  {name}: {n} rows")
+            passed += ok
+        except Exception as e:  # noqa: BLE001
+            print(f"FAIL  {name}: {type(e).__name__}: {e}")
+    total = len(Q)
+    print(f"\n{passed}/{total} checks passed")
+    sys.exit(0 if passed == total else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/togo_mcp/data/mie/chebi.yaml
+++ b/togo_mcp/data/mie/chebi.yaml
@@ -33,8 +33,9 @@ schema_info:
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_updated: "2026-06-19"
     data_version: "Release 2025"
     update_frequency: "Monthly"
   access:
@@ -55,17 +56,20 @@ critical_warnings: |
 
   - RELATIONSHIP NAMESPACE MIGRATION (CRITICAL): Chemical relationship properties migrated
     from chebi# namespace to OBO RO_ IRIs. Old predicates return 0 results silently.
+    Counts below are owl:Restriction triples (= relationship assertions), NOT distinct
+    entities — relationships are multi-valued, so one entity may carry several. E.g.
+    has_role spans 45,268 restrictions across only 25,508 distinct entities (verified 2026-06-19).
     CORRECT mappings:
-      chebi#:has_role              → obo:RO_0000087  (45,268 entities)
-      chebi#:is_conjugate_acid_of  → obo:RO_0018034  (8,660 entities)
-      chebi#:is_conjugate_base_of  → obo:RO_0018033  (8,713 entities)
-      chebi#:is_tautomer_of        → obo:RO_0018036  (1,949 entities)
-      chebi#:is_enantiomer_of      → obo:RO_0018039  (2,783 entities)
+      chebi#:has_role              → obo:RO_0000087  (45,268 restrictions)
+      chebi#:is_conjugate_acid_of  → obo:RO_0018034  (8,660 restrictions / 8,541 entities)
+      chebi#:is_conjugate_base_of  → obo:RO_0018033  (8,713 restrictions)
+      chebi#:is_tautomer_of        → obo:RO_0018036  (1,949 restrictions)
+      chebi#:is_enantiomer_of      → obo:RO_0018039  (2,783 restrictions)
     New relationships (no old equivalent):
-      obo:RO_0018038 has_functional_parent (20,167 entities)
-      obo:BFO_0000051 has_part            (4,107 entities)
-      obo:RO_0018040 has_parent_hydride   (1,823 entities)
-      obo:RO_0018037 is_substituent_group_from (1,302 entities)
+      obo:RO_0018038 has_functional_parent (20,167 restrictions)
+      obo:BFO_0000051 has_part            (4,107 restrictions)
+      obo:RO_0018040 has_parent_hydride   (1,823 restrictions)
+      obo:RO_0018037 is_substituent_group_from (1,302 restrictions)
 
   - XREF PREFIX FORMAT CHANGE (CRITICAL): Cross-reference literal prefixes are now lowercase
     and use dot notation. Old STRSTARTS filters silently return 0 results.
@@ -85,7 +89,7 @@ shape_expressions: |
   PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
   PREFIX obo: <http://purl.obolibrary.org/obo/>
 
-  # Total owl:Class entities with CHEBI_ IRI: 224,523 (verified 2025-04-21)
+  # Total owl:Class entities with CHEBI_ IRI: 224,523 (verified 2026-06-19)
   # Abstract classes (e.g. "amino acid", "lipid") lack chemrof: properties — use OPTIONAL
   <ChemicalEntityShape> {
     a [ owl:Class ] ;
@@ -109,19 +113,21 @@ shape_expressions: |
   }
 
   # OWL Restriction pattern — ONLY way to access chemical relationships and roles
-  # Never asserted directly; always via rdfs:subClassOf blank node
+  # Never asserted directly; always via rdfs:subClassOf blank node.
+  # Counts are restriction triples (relationship assertions), not distinct entities
+  # (multi-valued: has_role = 45,268 restrictions across 25,508 entities). Verified 2026-06-19.
   <ChemicalRelationshipShape> {
     a [ owl:Restriction ] ;
     owl:onProperty [
-      obo:RO_0000087 |   # has role            — 45,268 entities
-      obo:RO_0018034 |   # is conjugate acid of —  8,660 entities
-      obo:RO_0018033 |   # is conjugate base of —  8,713 entities
-      obo:RO_0018036 |   # is tautomer of       —  1,949 entities
-      obo:RO_0018039 |   # is enantiomer of     —  2,783 entities
-      obo:RO_0018038 |   # has functional parent — 20,167 entities
-      obo:BFO_0000051 |  # has part             —  4,107 entities
-      obo:RO_0018040 |   # has parent hydride   —  1,823 entities
-      obo:RO_0018037     # is substituent group from — 1,302 entities
+      obo:RO_0000087 |   # has role            — 45,268 restrictions
+      obo:RO_0018034 |   # is conjugate acid of —  8,660 restrictions
+      obo:RO_0018033 |   # is conjugate base of —  8,713 restrictions
+      obo:RO_0018036 |   # is tautomer of       —  1,949 restrictions
+      obo:RO_0018039 |   # is enantiomer of     —  2,783 restrictions
+      obo:RO_0018038 |   # has functional parent — 20,167 restrictions
+      obo:BFO_0000051 |  # has part             —  4,107 restrictions
+      obo:RO_0018040 |   # has parent hydride   —  1,823 restrictions
+      obo:RO_0018037     # is substituent group from — 1,302 restrictions
     ] ;
     owl:someValuesFrom IRI
   }
@@ -381,59 +387,67 @@ cross_database_queries:
     - ensembl
     - amrportal
   examples:
-    - title: "ChEBI–ChEMBL Integration via skos:exactMatch"
+    - title: "ChEBI–ChEMBL Integration via InChIKey (structure match)"
       description: |
         Link ChEBI chemical entities to ChEMBL drug molecules to enrich compounds
-        with bioactivity data and development phases. ChEMBL references ChEBI via
-        skos:exactMatch for seamless integration.
+        with development phase / bioactivity context. ChEMBL SmallMolecules do NOT
+        carry skos:exactMatch to ChEBI IRIs (verified 2026-06-19 — that join returns
+        0 rows); the reliable cross-link is the standard InChIKey.
 
-        Linking strategy:
-        - ChEMBL: skos:exactMatch links SmallMolecule to CHEBI_ IRI directly
-        - ChEBI: IRI matched as owl:Class; chemrof: properties queried
-        - Direct IRI matching; no text search or URI conversion required
+        Linking strategy (anchor on specific ChEMBL molecule IRIs to stay bounded):
+        - ChEMBL: ?molecule sio:SIO_000008 ?node . ?node a sio:CHEMINF_000059 ;
+          sio:SIO_000300 ?inchikey  (CHEMINF_000059 = "standard InChIKey" descriptor)
+        - ChEBI:  ?chebi chemrof:inchi_key_string ?inchikey  (join on the literal)
+        - InChIKey is the canonical structure key shared across both databases
       databases_used:
         - chembl
         - chebi
       complexity: intermediate
       sparql: |
         PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+        PREFIX sio: <http://semanticscience.org/resource/>
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
-        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX chemrof: <https://w3id.org/chemrof/>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-        SELECT DISTINCT ?drugName ?chebiLabel ?formula ?mass ?developmentPhase
+        SELECT DISTINCT ?molecule ?drugName ?inchikey ?chebi ?chebiLabel ?formula
         WHERE {
           GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> {
-            ?molecule a cco:SmallMolecule ;
-                      rdfs:label ?drugName ;
-                      skos:exactMatch ?chebiId ;
-                      cco:highestDevelopmentPhase ?developmentPhase .
-            FILTER(?developmentPhase >= 3)
+            VALUES ?molecule {
+              <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25>    # aspirin
+              <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL192>   # sildenafil
+              <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL521>   # ibuprofen
+            }
+            ?molecule rdfs:label ?drugName ;
+                      sio:SIO_000008 ?ikNode .
+            ?ikNode a sio:CHEMINF_000059 ;
+                    sio:SIO_000300 ?inchikey .
           }
           GRAPH <http://rdf.ebi.ac.uk/dataset/chebi> {
-            ?chebiId a owl:Class ;
-                     rdfs:label ?chebiLabel .
-            OPTIONAL { ?chebiId chemrof:generalized_empirical_formula ?formula }
-            OPTIONAL { ?chebiId chemrof:mass ?mass }
+            ?chebi a owl:Class ;
+                   chemrof:inchi_key_string ?inchikey ;
+                   rdfs:label ?chebiLabel .
+            OPTIONAL { ?chebi chemrof:generalized_empirical_formula ?formula }
           }
         }
-        ORDER BY DESC(?developmentPhase)
         LIMIT 50
       notes: |
-        - Linking via: skos:exactMatch → direct CHEBI_ IRI match
-        - Pre-filter FILTER(?developmentPhase >= 3) reduces 2.4M → ~10k before join
-        - Performance: ~1-2s (Tier 1)
+        - Linking via: standard InChIKey (ChEMBL CHEMINF_000059/SIO_000300 ↔ ChEBI chemrof:inchi_key_string)
+        - skos:exactMatch does NOT link ChEMBL molecules to ChEBI — verified 0 rows (do not use)
+        - Anchor on specific molecule IRIs (VALUES); a full unanchored InChIKey scan of ChEMBL is heavy
+        - Verified 2026-06-19: aspirin→CHEBI_15365, sildenafil→CHEBI_9139, ibuprofen→CHEBI_5855
         - MIE files checked: chebi, chembl
 
-    - title: "ChEBI–Reactome Pathway Integration"
+    - title: "ChEBI–Reactome Cross-Reference (small-molecule identity)"
       description: |
-        Connect ChEBI molecules to Reactome pathways. Reactome uses bp:UnificationXref
-        with bp:db="ChEBI" and bp:id in "CHEBI:NNNNN" format, requiring URI conversion.
+        Resolve Reactome small-molecule participants to their ChEBI identity (label +
+        formula). Reactome links to ChEBI via bp:UnificationXref with
+        bp:db "ChEBI"^^xsd:string and bp:id "CHEBI:NNNNN"^^xsd:string.
 
-        Linking strategy:
-        - Reactome: bp:xref → bp:UnificationXref with bp:db "ChEBI"^^xsd:string
-        - URI conversion: "CHEBI:15422" → CHEBI_15422 IRI via SUBSTR + IRI(CONCAT(...))
-        - ^^xsd:string CRITICAL for bp:db filter — omitting it returns 0 results
+        Linking strategy (anchor on the ChEBI ids of interest to stay bounded):
+        - Provide target ids as ^^xsd:string-typed VALUES (see TWO traps in notes)
+        - Reactome: ?xref bp:db "ChEBI"^^xsd:string ; bp:id ?fullChebiId
+        - Convert "CHEBI:NNNNN" → CHEBI_NNNNN IRI to join the ChEBI graph for properties
       databases_used:
         - reactome
         - chebi
@@ -444,20 +458,21 @@ cross_database_queries:
         PREFIX chemrof: <https://w3id.org/chemrof/>
         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-        SELECT DISTINCT ?reactomeName ?chebiLabel ?formula ?pathwayName
+        SELECT DISTINCT ?reactomeName ?fullChebiId ?chebiLabel ?formula
         WHERE {
           GRAPH <http://rdf.ebi.ac.uk/dataset/reactome> {
-            ?molecule a bp:SmallMolecule ;
-                      bp:displayName ?reactomeName ;
-                      bp:entityReference/bp:xref ?xref .
+            VALUES ?fullChebiId {
+              "CHEBI:16469"^^xsd:string    # 17beta-estradiol
+              "CHEBI:16480"^^xsd:string    # nitric oxide
+            }
             ?xref a bp:UnificationXref ;
                   bp:db "ChEBI"^^xsd:string ;
                   bp:id ?fullChebiId .
-            FILTER(STRSTARTS(?fullChebiId, "CHEBI:"))
-            BIND(SUBSTR(?fullChebiId, 7) AS ?chebiNum)
-            ?pathway a bp:Pathway ;
-                     bp:displayName ?pathwayName .
-            FILTER(CONTAINS(LCASE(?pathwayName), "metabolism"))
+            ?ref bp:xref ?xref .
+            ?molecule a bp:SmallMolecule ;
+                      bp:entityReference ?ref ;
+                      bp:displayName ?reactomeName .
+            BIND(SUBSTR(STR(?fullChebiId), 7) AS ?chebiNum)
           }
           BIND(IRI(CONCAT("http://purl.obolibrary.org/obo/CHEBI_", ?chebiNum)) AS ?chebiUri)
           GRAPH <http://rdf.ebi.ac.uk/dataset/chebi> {
@@ -466,11 +481,16 @@ cross_database_queries:
             OPTIONAL { ?chebiUri chemrof:generalized_empirical_formula ?formula }
           }
         }
-        LIMIT 50
+        LIMIT 30
       notes: |
-        - Linking via: URI conversion "CHEBI:15422" → "http://purl.obolibrary.org/obo/CHEBI_15422"
-        - ^^xsd:string on bp:db is MANDATORY — bare string literal returns 0 results
-        - Performance: ~3-5s (Tier 2) due to property paths in Reactome
+        - TWO ^^xsd:string traps in Reactome: BOTH bp:db AND bp:id are xsd:string-typed.
+          A bare/untyped literal — including one produced by CONCAT — matches 0 rows.
+          Hence anchoring via ^^xsd:string-typed VALUES on ?fullChebiId, not via an
+          untyped CONCAT'd id (that direction silently returns nothing).
+        - To link molecule → PATHWAY (not just identity) you must traverse
+          bp:pathwayComponent recursively: reactions nest under sub-pathways, so a
+          direct ?pathway bp:pathwayComponent ?reaction misses most participants.
+        - Verified 2026-06-19: EST17b→17beta-estradiol (C18H24O2), NO→nitric oxide
         - MIE files checked: chebi, reactome
 
 cross_references:
@@ -479,14 +499,23 @@ cross_references:
       Cross-references to external databases as literal strings with lowercase "prefix:id"
       format (migrated from old uppercase format). 73% of ChEBI entities (164,779) have
       at least one cross-reference. Parse with STRBEFORE(?xref, ":") to extract prefix.
+      Top prefixes by entity coverage (verified 2026-06-19): chemspider 53,225,
+      lincs.smallmolecule 41,390, pubmed 33,274, cas 29,826, hmdb 19,790, reaxys 17,597,
+      kegg.compound 17,362, lipidmaps 12,638, glytoucan 10,578, glygen 9,871,
+      metacyc.compound 7,132, wikipedia.en 6,753, beilstein 5,572, pdb-ccd 4,956,
+      knapsack 4,920, kegg.drug 4,484, drugcentral 3,832, drugbank 3,602, gmelin 3,354,
+      patent 2,613, ppdb 1,141.
     databases:
       chemical:
+        - "chemspider: ChemSpider (largest single xref source — 53,225 entities)"
         - "cas: Chemical Abstracts Service registry numbers"
         - "reaxys: Reaxys chemical database"
+        - "beilstein: Beilstein registry numbers"
         - "gmelin: Gmelin database"
         - "ppdb: Pesticide Properties DataBase"
         - "knapsack: KNApSAcK metabolite database"
       biological:
+        - "lincs.smallmolecule: LINCS small molecules (41,390 entities)"
         - "kegg.compound: KEGG Compound"
         - "kegg.drug: KEGG Drug"
         - "hmdb: Human Metabolome Database"
@@ -494,6 +523,9 @@ cross_references:
         - "drugcentral: Drug Central"
         - "metacyc.compound: MetaCyc metabolic pathways"
         - "lipidmaps: LIPID MAPS"
+      glycan:
+        - "glytoucan: GlyTouCan glycan accessions (10,578 entities)"
+        - "glygen: GlyGen (9,871 entities)"
       structure:
         - "pdb-ccd: PDB Chemical Component Dictionary"
       literature:
@@ -565,19 +597,20 @@ architectural_notes:
 
 data_statistics:
   total_entities: 224523
-  verified_date: "2025-04-21"
+  verified_date: "2026-06-19"
   verification_method: "COUNT DISTINCT owl:Class with CHEBI_ IRI filter"
 
   coverage:
-    with_formula: "87%"
-    with_smiles: "86%"
-    with_inchi_inchikey: "81%"
-    with_dbxrefs: "73%"
+    with_formula: "87%"          # 195,316 / 224,523
+    with_smiles: "86%"           # 194,123 / 224,523
+    with_inchi_inchikey: "81%"   # 182,605 / 224,523
+    with_dbxrefs: "73%"          # 164,779 / 224,523
     amino_acid_subclasses: 1577
     antimicrobial_agents: 425
-    conjugate_acid_pairs: 8660
-    has_role_entities: 45268
-    verified_date: "2025-04-21"
+    conjugate_acid_restrictions: 8660   # owl:Restriction triples (8,541 distinct entities)
+    has_role_restrictions: 45268        # owl:Restriction triples
+    has_role_entities: 25508            # distinct entities carrying >=1 has_role restriction
+    verified_date: "2026-06-19"
     calculation: "COUNT DISTINCT with property present / total 224,523"
 
   staleness_warning: "Monthly updates — re-verify counts after each release"
@@ -633,7 +666,7 @@ anti_patterns:
     correct_sparql: |
       # CORRECT: use the role restriction IRI discovered during exploration (CHEBI:33281 = antimicrobial agent)
       SELECT (COUNT(DISTINCT ?entity) AS ?count)
-      FROM <http://rdfportal.org/dataset/chebi>
+      FROM <http://rdf.ebi.ac.uk/dataset/chebi>
       WHERE {
         ?entity rdfs:subClassOf ?r .
         ?r a owl:Restriction ;


### PR DESCRIPTION
Adds three workflow-driven skills under `.claude/skills/` and hardens the ChEBI MIE file. All SPARQL/TogoID queries in every deliverable were validated live against the dev RDF Portal endpoints (2026-06-19).

## Skills

- **disease-analysis** — multi-scale disease pathophysiology (molecular → clinical) over UniProt/Reactome/TogoID/OLS4/PubMed. Ships `smoke.py`, a stdlib-only harness verifying all 6 phases (7/7 checks).
- **research-article-analysis** — claim validation against 5 databases (ChEBI, Rhea, Reactome, UniProt, GO), 2 query types each. Ships `smoke.py` running all 10 query types (10/10). Bakes in two corrections vs. the source template: ChEBI uses the `chemrof:` namespace (not `chebi:`), and the UniProt function query must split `recommendedName` from `classifiedWith` (the join times out).
- **prism** — predicate-defined set-intersection mining (drug-repurposing / target-ID / "common to A and B"). All 9 SPARQL/tool templates validated live; no fixes needed.

## ChEBI MIE v2.2

Live re-verification of v2.1 surfaced and fixed four defects:
- ChEBI–ChEMBL cross-DB query joined on `skos:exactMatch`, which doesn't exist on ChEMBL molecules (0 rows) → replaced with a validated InChIKey structure match.
- ChEBI–Reactome cross-DB query was a cartesian product → replaced with a genuinely-joined version; documents that `bp:id` (not just `bp:db`) is `^^xsd:string`-typed.
- "Circular Reasoning" anti-pattern used the wrong graph URI (returned 0) → corrected.
- Relationship counts were mislabeled "entities" but are restriction triples (has_role: 45,268 restrictions / 25,508 entities) → relabeled.
- Plus: corrected a `verified_date` typo and added the two largest missing cross-reference prefixes (chemspider, lincs.smallmolecule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)