### PR TITLE
Harden usage-log collection (IP hashing, session meta, output size, query shape)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,17 @@ TZ=Asia/Tokyo
 # TOGOMCP_STATS_PASSWORD=change-me
 # TOGOMCP_STATS_USER_TEST=admin
 # TOGOMCP_STATS_PASSWORD_TEST=change-me
+
+# Optional: salt for hashing client IPs in the log (IPs are never stored raw).
+# Set a stable value to hash the same IP identically across restarts within a
+# retention window; unset = randomized per process (hashes not linkable across
+# restarts — strictly more private).
+# TOGOMCP_LOG_HASH_SALT=
+# TOGOMCP_LOG_HASH_SALT_TEST=
+
+# Optional: also log full SPARQL query text. Off by default — only the sha256
+# hash and a privacy-safe structural "shape" (literals stripped) are logged.
+# Enable (1/true/yes) only once retention/access policy is agreed; queries may
+# carry user-supplied literals.
+# TOGOMCP_LOG_QUERY_TEXT=0
+# TOGOMCP_LOG_QUERY_TEXT_TEST=0

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,9 @@ services:
       # /stats dashboard HTTP Basic creds — unset = dashboard disabled (503).
       TOGOMCP_STATS_USER: ${TOGOMCP_STATS_USER:-}
       TOGOMCP_STATS_PASSWORD: ${TOGOMCP_STATS_PASSWORD:-}
+      # Log privacy knobs (see .env.example). Salt unset = per-process random.
+      TOGOMCP_LOG_HASH_SALT: ${TOGOMCP_LOG_HASH_SALT:-}
+      TOGOMCP_LOG_QUERY_TEXT: ${TOGOMCP_LOG_QUERY_TEXT:-}
     volumes:
       - ./logs:/var/log/togomcp
     restart: unless-stopped
@@ -27,6 +30,9 @@ services:
       # /stats dashboard HTTP Basic creds — unset = dashboard disabled (503).
       TOGOMCP_STATS_USER: ${TOGOMCP_STATS_USER_TEST:-}
       TOGOMCP_STATS_PASSWORD: ${TOGOMCP_STATS_PASSWORD_TEST:-}
+      # Log privacy knobs (see .env.example). Salt unset = per-process random.
+      TOGOMCP_LOG_HASH_SALT: ${TOGOMCP_LOG_HASH_SALT_TEST:-}
+      TOGOMCP_LOG_QUERY_TEXT: ${TOGOMCP_LOG_QUERY_TEXT_TEST:-}
     volumes:
       - ./logs-test:/var/log/togomcp
     restart: unless-stopped

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,49 @@
+"""Tests for the log-record enrichment helpers in togo_mcp.server.
+
+Covers privacy (IP hashing) and the session-meta / output-size helpers added to
+_ToolCallLogger. The middleware itself is exercised end-to-end via the in-memory
+FastMCP client during development; here we unit-test the pure helpers.
+"""
+import os
+
+# Logging must be disabled during import (no log path) — the middleware reads
+# TOGOMCP_QUERY_LOG at construction time.
+os.environ.pop("TOGOMCP_QUERY_LOG", None)
+
+from togo_mcp import server
+
+
+def test_hash_ip_is_irreversible_and_deterministic():
+    h = server._hash_ip("198.51.100.9")
+    assert h is not None and len(h) == 16
+    assert h == server._hash_ip("198.51.100.9")        # stable within a process
+    assert "198.51.100.9" not in h                      # raw IP never present
+    assert server._hash_ip("203.0.113.1") != h          # different IP -> different hash
+    assert server._hash_ip(None) is None
+    assert server._hash_ip("") is None
+
+
+def test_static_meta_shape():
+    m = server._STATIC_META
+    assert set(m) == {"server_version", "usage_guide_version", "mie_bundle_version"}
+    assert m["usage_guide_version"] == "v5"             # from usage-guide filename
+    assert m["server_version"]                          # importlib.metadata resolved
+    assert m["mie_bundle_version"] and len(m["mie_bundle_version"]) == 12
+
+
+def test_client_info_none_without_context():
+    assert server._client_info(None) is None
+
+
+def test_result_size():
+    assert server._result_size(None) is None
+
+    class _Block:
+        text = "hello"
+
+    class _Result:
+        content = [_Block()]
+
+    assert server._result_size(_Result()) == 5          # len("hello")
+    # objects with neither content nor structured_content fall back to str()
+    assert server._result_size(12345) == len("12345")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -133,6 +133,28 @@ def test_render_html_is_wellformed():
     assert "reactome" in html
 
 
+def test_sparql_shape_strips_literals():
+    q = ('SELECT ?x FROM <http://ex/g> WHERE { ?x rdfs:comment ?c . '
+         '?c bif:contains "secret-123" FILTER(?x = "pii-456") } LIMIT 5')
+    s = stats.sparql_shape(q)
+    blob = json.dumps(s)
+    assert "secret-123" not in blob and "pii-456" not in blob  # no literal leakage
+    assert s["form"] == "select"
+    assert s["from"] == ["http://ex/g"]
+    assert "rdfs:comment" in s["predicates"] and "bif:contains" in s["predicates"]
+    assert s["flags"].get("filter") and s["flags"].get("limit") and s["flags"].get("bif_contains")
+
+
+def test_sparql_shape_form_and_no_false_qnames():
+    s = stats.sparql_shape("ASK WHERE { ?s a bp:Pathway }")
+    assert s["form"] == "ask"
+    assert "bp:Pathway" in s["predicates"]
+    # IRIs and bare PREFIX colons must not produce qnames
+    s2 = stats.sparql_shape("PREFIX up: <http://purl.uniprot.org/core/> SELECT ?s WHERE { ?s a up:Protein }")
+    assert "up:Protein" in s2["predicates"]
+    assert not any(p.startswith("http") for p in s2["predicates"])
+
+
 def test_aggregate_empty():
     agg = stats.aggregate([])
     assert agg["months"] == []

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -3,6 +3,8 @@ import hashlib
 import json
 import logging
 import os
+import re
+import secrets
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -217,6 +219,16 @@ async def execute_sparql(
         "endpoint_url": url,
         "query_sha256": hashlib.sha256(sparql_query.strip().encode("utf-8")).hexdigest(),
     }
+    # Privacy-safe structural fingerprint (literals stripped). Full text only
+    # when explicitly opted in via TOGOMCP_LOG_QUERY_TEXT (off by default).
+    try:
+        from togo_mcp import stats as _stats_mod
+
+        extra["query_shape"] = _stats_mod.sparql_shape(sparql_query)
+    except Exception:
+        pass
+    if os.getenv("TOGOMCP_LOG_QUERY_TEXT", "").strip().lower() in ("1", "true", "yes"):
+        extra["query_text"] = sparql_query
     _sparql_extra_var.set(extra)
 
     try:
@@ -314,6 +326,105 @@ class _IgnoreUnknownSearchKwargs(_Middleware):
 mcp.add_middleware(_IgnoreUnknownSearchKwargs())
 
 
+# --- Session/static metadata for log records --------------------------------
+# Computed once at import: what the server was running. Client (LLM) info is
+# read per-call from the MCP context. None values are tolerated downstream.
+def _detect_server_version() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("togo-mcp")
+        except PackageNotFoundError:
+            return None
+    except Exception:
+        return None
+
+
+def _detect_usage_guide_version() -> str | None:
+    m = re.search(r"_v(\d+)", os.path.basename(TOGOMCP_USAGE_GUIDE))
+    return f"v{m.group(1)}" if m else None
+
+
+def _detect_mie_bundle_version() -> str | None:
+    """sha256[:12] over sorted '<file>=<mie_version>' lines — changes whenever
+    any MIE file's mie_version changes. Regex-parsed, no YAML dependency."""
+    items: list[str] = []
+    try:
+        paths = sorted(Path(MIE_DIR).glob("*.yaml"))
+    except OSError:
+        return None
+    for path in paths:
+        ver = None
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    m = re.search(r'mie_version:\s*"?([^"\n]+)"?', line)
+                    if m:
+                        ver = m.group(1).strip()
+                        break
+        except OSError:
+            continue
+        items.append(f"{path.name}={ver}")
+    if not items:
+        return None
+    return hashlib.sha256("\n".join(items).encode("utf-8")).hexdigest()[:12]
+
+
+_STATIC_META: dict[str, Any] = {
+    "server_version": _detect_server_version(),
+    "usage_guide_version": _detect_usage_guide_version(),
+    "mie_bundle_version": _detect_mie_bundle_version(),
+}
+
+# Salt for hashing client IPs (PII). A stable salt (set TOGOMCP_LOG_HASH_SALT)
+# hashes the same IP identically across restarts within a retention window; an
+# unset salt is randomized per process, so hashes are not linkable across
+# restarts — strictly more private. Raw IPs are never written to the log.
+_IP_SALT = os.getenv("TOGOMCP_LOG_HASH_SALT", "").strip() or secrets.token_hex(16)
+
+
+def _hash_ip(ip: str | None) -> str | None:
+    if not ip:
+        return None
+    return hashlib.sha256(f"{_IP_SALT}:{ip}".encode("utf-8")).hexdigest()[:16]
+
+
+def _client_info(fctx: Any) -> dict[str, str | None] | None:
+    """LLM client (name/version) from the MCP initialize handshake, if present."""
+    try:
+        params = fctx.session.client_params if fctx else None
+        info = getattr(params, "clientInfo", None) if params else None
+        if info is None:
+            return None
+        return {
+            "name": getattr(info, "name", None),
+            "version": getattr(info, "version", None),
+        }
+    except Exception:
+        return None
+
+
+def _result_size(result: Any) -> int | None:
+    """Best-effort serialized byte size of a tool result (output-size stats)."""
+    if result is None:
+        return None
+    try:
+        content = getattr(result, "content", None)
+        if content is not None:
+            total = 0
+            for block in content:
+                text = getattr(block, "text", None)
+                total += len((text if text is not None else str(block)).encode("utf-8"))
+            return total
+        sc = getattr(result, "structured_content", None)
+        if sc is not None:
+            return len(json.dumps(sc, default=str).encode("utf-8"))
+        return len(str(result).encode("utf-8"))
+    except Exception:
+        return None
+
+
 class _ToolCallLogger(_Middleware):
     """Emit one JSONL record per MCP tool call.
 
@@ -357,8 +468,10 @@ class _ToolCallLogger(_Middleware):
         status = "ok"
         error_class: str | None = None
         error_message: str | None = None
+        result = None
         try:
-            return await call_next(context)
+            result = await call_next(context)
+            return result
         except BaseException as exc:
             status = "error"
             error_class = exc.__class__.__name__
@@ -375,6 +488,7 @@ class _ToolCallLogger(_Middleware):
                 "args": context.message.arguments or {},
                 "status": status,
                 "elapsed_ms": elapsed_ms,
+                "output_bytes": _result_size(result),
                 "session_id": getattr(fctx, "session_id", None) if fctx else None,
                 "request_id": getattr(fctx, "request_id", None) if fctx else None,
                 "origin_request_id": (
@@ -382,7 +496,8 @@ class _ToolCallLogger(_Middleware):
                 ),
                 "client_id": getattr(fctx, "client_id", None) if fctx else None,
                 "transport": getattr(fctx, "transport", None) if fctx else None,
-                "ip": self._client_ip(),
+                "ip_hash": _hash_ip(self._client_ip()),
+                "meta": {**_STATIC_META, "client": _client_info(fctx)},
             }
             if error_class is not None:
                 record["error_class"] = error_class

--- a/togo_mcp/stats.py
+++ b/togo_mcp/stats.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import csv
 import json
 import os
+import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -57,6 +58,59 @@ _SEARCH_TOOL_DB = {
     "search_chembl_molecule": "chembl",
     "search_chembl_target": "chembl",
 }
+
+
+# --------------------------------------------------------------------------- #
+# SPARQL query shape (privacy-safe structural fingerprint)
+# --------------------------------------------------------------------------- #
+# Matches string literals (triple-quoted, double, single) so their CONTENTS can
+# be stripped before any feature extraction — user literals never leak into the
+# shape. IRIs live in <...> and are handled separately (only FROM graphs kept).
+_LITERAL_RE = re.compile(
+    r'"""(?:.|\n)*?"""|\'\'\'(?:.|\n)*?\'\'\'|"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\''
+)
+# prefix:local — schema terms (predicates/classes), e.g. up:reviewed, bp:db,
+# xsd:string, bif:contains. The local part requirement (`:[A-Za-z_]`) means bare
+# "up:" in a PREFIX decl and "http://" inside an IRI do NOT match.
+_QNAME_RE = re.compile(r"\b[A-Za-z][\w.-]*:[A-Za-z_]\w*")
+_FROM_RE = re.compile(r"\bfrom\s+(?:named\s+)?<([^>]+)>", re.IGNORECASE)
+_FLAG_WORDS = (
+    "filter", "optional", "union", "values", "service",
+    "limit", "offset", "order", "group", "minus", "having",
+)
+
+
+def sparql_shape(query: str) -> dict[str, Any]:
+    """Privacy-safe structural fingerprint of a SPARQL query.
+
+    String-literal CONTENTS are stripped first, so no user-supplied text can
+    leak. What remains is schema-level: query form, FROM graphs, the set of
+    qname predicates/classes used, structural flags, and length. This is the
+    signal MIE-improvement analysis needs ("reactome queries using bp:db but
+    not xsd:string return 0 rows") without storing the raw query.
+    """
+    q = query or ""
+    stripped = _LITERAL_RE.sub('""', q)
+    low = stripped.lower()
+
+    form = "other"
+    for f in ("select", "ask", "construct", "describe"):
+        if re.search(rf"\b{f}\b", low):
+            form = f
+            break
+
+    qnames = sorted(set(_QNAME_RE.findall(stripped)))
+    flags = {w: bool(re.search(rf"\b{w}\b", low)) for w in _FLAG_WORDS}
+    flags["bif_contains"] = "bif:contains" in low
+
+    return {
+        "form": form,
+        "from": sorted(set(_FROM_RE.findall(stripped)))[:20],
+        "predicates": qnames[:60],
+        "n_predicates": len(qnames),
+        "flags": {k: v for k, v in flags.items() if v},  # only present flags
+        "len": len(q),
+    }
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes the four collection-layer gaps left by the analysis iteration (#74). All validated end-to-end via an in-memory MCP client.

## Changes

1. **IP hashing** — the raw `ip` field becomes **`ip_hash`** (salted SHA-256, 16 hex). Salt from `TOGOMCP_LOG_HASH_SALT`, else randomized per process. Raw IPs are never written → satisfies the spec's no-PII / irreversible-hash requirement.
2. **Session meta** — each record gains a `meta` block: `server_version` (importlib.metadata), `usage_guide_version` (from the guide filename), `mie_bundle_version` (sha256[:12] over all MIE `mie_version` fields), and `client` (LLM client name/version from the MCP initialize handshake).
3. **Tool-call output size** — new **`output_bytes`** on every record (all tools, not just SPARQL).
4. **SPARQL query shape** — `execute_sparql` records `extra.query_shape`: a privacy-safe structural fingerprint (form, FROM graphs, predicate qnames, flags) with **all string literals stripped** (verified no leakage). Full `query_text` only when `TOGOMCP_LOG_QUERY_TEXT` is opted in (off by default), pending DBCLS retention/access policy.

## Privacy
Raw IP gone; query literals never enter the shape; full query text gated behind an explicit env flag. The analysis engine ignores unknown fields, so `/stats` is unaffected — the new fields are available in `/stats.json` for future per-tool output-size and version breakdowns.

## Tests / config
`stats.py` gains `sparql_shape()` (pure, testable); +2 shape tests and a new `test_logging.py` (4) — all pass. `compose.yaml` + `.env.example` document and pass through `TOGOMCP_LOG_HASH_SALT` and `TOGOMCP_LOG_QUERY_TEXT` (+ `_TEST`).

Note: the 2 pre-existing `test_api_tools.py` failures (Rhea/UniProt search error handling) are unrelated and reproduce on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)