### PR TITLE
Fix search_pdb_entity cc-filter crash; remove dead inchi filter

### DIFF
--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -155,8 +155,8 @@ class TestSearchPdbEntity:
         assert result["results"][1]["ligands"] is None      # empty -> None
 
     @pytest.mark.asyncio
-    async def test_cc_projection_smiles_list(self) -> None:
-        """CC rows expose formula/SMILES (split on ';')/InChI."""
+    async def test_cc_projection_string_shape(self) -> None:
+        """Free-text query: PDBj returns SMILES/InChI as ';'-separated str."""
         body = {
             "total": "1",
             "results": [[
@@ -174,7 +174,51 @@ class TestSearchPdbEntity:
         assert row["id"] == "CFF"
         assert row["formula"] == "C8 H10 N4 O2"
         assert row["smiles"] == ["Cn1cnc2c1...", "O=C2N..."]
+        assert row["inchi"] == "InChI=1S/C8H10N4O2/..."
         assert row["iupac_name"] == "1,3,7-trimethyl..."
+
+    @pytest.mark.asyncio
+    async def test_cc_projection_list_shape(self) -> None:
+        """Structured-filter searches make PDBj return SMILES/InChI columns as
+        JSON lists (not ';'-strings). Projecting them must not crash and must
+        yield the same normalized shape. Regression for the formula/smiles
+        'list object has no attribute split' bug."""
+        body = {
+            "total": -1,  # PDBj returns -1 (uncounted) for filter searches
+            "results": [[
+                "CFF", "CAFFEINE", "C8 H10 N4 O2",
+                ["O=C2N(...)C", "Cn1cnc2N(...)c12"],          # smiles as list
+                ["InChI=1S/C8H10N4O2/c1-10-..."],             # inchi as list
+                ["3,7-DIHYDRO-..."],                          # syn as list
+                "2000-05-16", "2020-06-17", "1,3,7-trimethyl...", None,
+            ]],
+        }
+        with respx.mock(using="httpx") as router:
+            router.get("https://pdbj.org/rest/newweb/search/cc").mock(
+                return_value=httpx.Response(200, json=body)
+            )
+            result = json.loads(
+                await search_pdb_entity("cc", "", formula="C8 H10 N4 O2")
+            )
+        assert result["total"] == -1
+        row = result["results"][0]
+        assert row["id"] == "CFF"
+        assert row["smiles"] == ["O=C2N(...)C", "Cn1cnc2N(...)c12"]
+        assert row["inchi"] == "InChI=1S/C8H10N4O2/c1-10-..."  # first of list
+
+    @pytest.mark.asyncio
+    async def test_cc_filter_forwarded(self) -> None:
+        """formula/smiles filters reach PDBj; inchi is no longer accepted."""
+        body = {"total": -1, "results": []}
+        with respx.mock(using="httpx") as router:
+            route = router.get("https://pdbj.org/rest/newweb/search/cc").mock(
+                return_value=httpx.Response(200, json=body)
+            )
+            await search_pdb_entity("cc", "", formula="C8 H10 N4 O2")
+        request = route.calls.last.request
+        assert request.url.params["formula"] == "C8 H10 N4 O2"
+        with pytest.raises(TypeError):  # inchi removed from the signature
+            await search_pdb_entity("cc", "", inchi="InChI=1S/C8H10N4O2")
 
     @pytest.mark.asyncio
     async def test_filter_only_search_allowed(self) -> None:

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -525,8 +525,10 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
 #   pdb: 0 id · 1 title · 2 authors · 3 citation · 4 journal · 5 year ·
 #        6 volume · 7 pmid · 8 doi · 9 release · 10 deposit · 11 modify ·
 #        12 method · 13 resolution · 14 ligands
-#   cc:  0 code · 1 name · 2 formula · 3 smiles(;-sep) · 4 inchi ·
+#   cc:  0 code · 1 name · 2 formula · 3 smiles · 4 inchi ·
 #        5 systematic_name · 6 release · 7 modified · 8 iupac_name · 9 synonym
+#        (cols 3/4/5 are ';'-strings for free-text query, JSON lists for
+#        structured-filter searches — normalized in _project_cc_row)
 #   prd: 0 id · 1 (empty) · 2 release · 3 modified · 4 name · 5 formula ·
 #        6 description
 
@@ -563,15 +565,35 @@ def _project_pdb_row(row: list) -> dict:
     }
 
 
+def _cc_smiles_list(val) -> list:
+    """Normalize PDBj's polymorphic cc SMILES column to list[str].
+
+    Free-text `query` searches return it as a ';'-separated string; structured
+    filter searches (formula/smiles) return it as a JSON list. Handle both.
+    """
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return [s for s in val if s]
+    return [s for s in str(val).split(";") if s]
+
+
+def _cc_first(val):
+    """Return a single scalar from a cc column that PDBj may deliver as a
+    scalar string (free-text query) or a one-element list (filter query)."""
+    if isinstance(val, list):
+        return val[0] if val else None
+    return val or None
+
+
 def _project_cc_row(row: list) -> dict:
     g = lambda i: row[i] if len(row) > i else None
-    smiles = g(3) or ""
     return {
         "id": g(0),
         "name": g(1),
         "formula": g(2),
-        "smiles": [s for s in smiles.split(";") if s],
-        "inchi": g(4) or None,
+        "smiles": _cc_smiles_list(g(3)),
+        "inchi": _cc_first(g(4)),
         "iupac_name": g(8) or None,
     }
 
@@ -615,7 +637,6 @@ async def search_pdb_entity(
     ligand: str = "",
     formula: str = "",
     smiles: str = "",
-    inchi: str = "",
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -638,7 +659,8 @@ async def search_pdb_entity(
               Dictionary, mostly peptides).
         query (str): Free-text keywords. May be empty when at least one
             structured filter is supplied. Accepts aliases: `search`, `term`,
-            `keyword`, `keywords`, `search_term`, `name`.
+            `keyword`, `keywords`, `search_term`, `name`. If both `query` and
+            an alias are given with different values, `query` wins silently.
         limit (int): Max results to return, in [0, 500]. Default 20.
         offset (int): Number of leading results to skip (server-side
             pagination). Default 0.
@@ -649,12 +671,15 @@ async def search_pdb_entity(
                 "solid-state-nmr".
             res_min / res_max (float): Resolution bounds in Å.
             source (str): Source organism (e.g. "Homo sapiens").
-            ligand (str): Restrict to entries containing this ligand.
+            ligand (str): Keep entries whose ligand list contains this string.
+                Matching is a substring, not an exact CCD code — `ATP` also
+                matches `dATP`. Pass the exact ligand name for precision.
 
         Structured filters for db="cc" (chemical search):
-            formula (str): Molecular formula (e.g. "C8 H10 N4 O2").
-            smiles (str): SMILES substructure/exact query.
-            inchi (str): InChI query.
+            formula (str): Molecular formula in the canonical spaced,
+                element-counted form (e.g. "C8 H10 N4 O2"). The unspaced form
+                ("C8H10N4O2") is not matched by PDBj.
+            smiles (str): SMILES substructure query.
 
     Note:
         PDBj search hits multiple fields (title, authors, keywords,
@@ -665,7 +690,9 @@ async def search_pdb_entity(
 
     Returns:
         str: JSON string `{"total": int, "results": [ {…named fields…} ]}`.
-            A `total` of -1 means PDBj rejected the filter combination.
+            For structured-filter searches PDBj does not compute a count and
+            returns `total: -1` even when `results` is non-empty — rely on
+            `results`, not `total`, in that case.
     """
     query = _resolve_query_alias(
         query,
@@ -694,8 +721,6 @@ async def search_pdb_entity(
             params["formula"] = formula
         if smiles:
             params["smiles"] = smiles
-        if inchi:
-            params["inchi"] = inchi
 
     # A search needs either free text or at least one structured filter.
     has_filter = any(
@@ -705,7 +730,7 @@ async def search_pdb_entity(
         raise ValueError(
             "Missing search criteria. Pass `query` (or an alias: search, term, "
             "keyword, keywords, search_term, name) and/or a structured filter "
-            "(pdb: method/res_min/res_max/source/ligand; cc: formula/smiles/inchi)."
+            "(pdb: method/res_min/res_max/source/ligand; cc: formula/smiles)."
         )
 
     project = _PDB_ROW_PROJECTORS[db]


### PR DESCRIPTION
Follow-up to #83, fixing bugs found in the `cc` structured-filter path of `search_pdb_entity`.

## The bug

`formula` and `smiles` filters on `db="cc"` crashed with `'list' object has no attribute 'split'`. Root cause was **not** input coercion but the response projector: PDBj returns the `cc` smiles/inchi columns as `;`-separated **strings** for free-text `query` searches but as **JSON lists** for structured-filter searches, and `_project_cc_row` called `.split(";")` unconditionally. The filters actually succeed upstream — only projection failed.

## Fixes

- **`_project_cc_row`** now normalizes both shapes (`_cc_smiles_list`, `_cc_first`), so `formula`/`smiles` searches return rich rows. Verified live: `formula="C8 H10 N4 O2"` → `CFF` (caffeine) with 3 SMILES.
- **Removed the `inchi` filter** — PDBj's `cc` endpoint returns HTTP 500 for every InChI form (full, truncated, InChIKey). Don't advertise a dead parameter. `inchi` is still returned in result rows.
- **Corrected the `total: -1` docstring** — it means "uncounted" (typical for filter searches) and ships alongside real rows, not "rejected." The earlier "rejected" wording was a misdiagnosis.
- **Documented** `ligand` substring matching (`ATP` matches `dATP`) and `query`-wins alias precedence.

## Tests

Regression coverage for the list-shaped `cc` columns (the crash), the string shape, filter forwarding, and `inchi` removal. **58 pass.**

Credit: bug report by Akira Kinjo (reproductions all accurate; root cause turned out to be projection, not input coercion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)