### PR TITLE
Search-tool return-contract & error-handling hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,15 @@ These conventions were deliberately normalized across tools; preserve them when 
 - **`ids` accepts `str | list[str]`** across NCBI and TogoID tools. Normalize with `_normalize_ids` (ncbi_tools.py) or `_ids_to_csv` (togoid.py).
 - **Search-tool query aliases**: all non-NCBI `search_*` tools accept `query`/`search`/`term`/`keyword`/`keywords`/`search_term`/`name`. Resolve via `_resolve_query_alias` in [api_tools.py](togo_mcp/api_tools.py). NCBI `esearch` uses `db`/`term` aliases specifically.
 
+## Return-shape and error conventions
+
+Two intentional, *different* error conventions coexist — preserve each module's:
+
+- **REST-wrapper tools** in [api_tools.py](togo_mcp/api_tools.py) (`search_uniprot/pdb/mesh/reactome/rhea_entity`, ChEMBL, PubChem) and the catalog tools in [rdf_portal.py](togo_mcp/rdf_portal.py) (`list_databases`, `find_databases`): **raise `ValueError` for bad parameters** (caught early, tells the caller not to retry) but **degrade gracefully on upstream/HTTP failure** by returning a payload carrying an `error` key plus a "fall back to SPARQL" hint. Never raise on a transient HTTP error here.
+- **TogoID tools** in [togoid.py](togo_mcp/togoid.py): **raise on HTTP error** via `raise_for_status_with_body` (with a `client_error_hint`). This is the module's consistent convention; FastMCP surfaces the message to the caller. Don't convert only some togoid tools to the return-JSON style — keep the module uniform.
+
+List-style result tools return a **JSON string of a bare array** (not a Python `list`): empty and non-empty then share one wire shape. Returning a bare `list` makes FastMCP double-represent it (text array + wrapped `{"result": ...}`), so empty vs non-empty diverge for clients. `dict` returns (ChEMBL, `get_sparql_endpoints`) and NCBI `list[TextContent]` returns are exempt — they aren't wrapped.
+
 ## Testing
 
 ```bash

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -200,7 +200,7 @@ class TestSearchPdbEntity:
             result = json.loads(
                 await search_pdb_entity("cc", "", formula="C8 H10 N4 O2")
             )
-        assert result["total"] == -1
+        assert result["total"] is None  # PDBj -1 ("uncounted") -> null
         row = result["results"][0]
         assert row["id"] == "CFF"
         assert row["smiles"] == ["O=C2N(...)C", "Cn1cnc2N(...)c12"]

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -239,6 +239,13 @@ class TestSearchPdbEntity:
         with pytest.raises(ValueError):
             await search_pdb_entity("pdb", "")
 
+    @pytest.mark.asyncio
+    async def test_unknown_method_raises_valueerror(self) -> None:
+        """An out-of-enum method gives a clear ValueError, not a bare KeyError
+        (the schema enum normally blocks this; guard is for drift/direct calls)."""
+        with pytest.raises(ValueError, match="Unknown method"):
+            await search_pdb_entity("pdb", "x", method="cryoem")
+
 
 # ---------------------------------------------------------------------------
 # Reactome

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -248,18 +248,53 @@ class TestSearchPdbEntity:
 class TestSearchReactomeEntity:
     """Tests for search_reactome_entity with mocked HTTP."""
 
+    _REACTOME_URL = "https://reactome.org/ContentService/search/query"
+
     @pytest.mark.asyncio
-    async def test_http_error_returns_error_list(self) -> None:
-        """HTTP errors return a one-element error list, staying type-consistent
-        with the declared `list[dict[str, str]]` return type."""
+    async def test_http_error_returns_error_array(self) -> None:
+        """HTTP errors return a JSON string holding a one-element error array."""
         with respx.mock(using="httpx") as router:
-            router.get(
-                "https://reactome.org/ContentService/search/query"
-            ).mock(return_value=httpx.Response(500, text="Server Error"))
-            result = await search_reactome_entity("apoptosis")
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(500, text="Server Error")
+            )
+            result = json.loads(await search_reactome_entity("apoptosis"))
         assert isinstance(result, list)
-        assert len(result) == 1
         assert "Reactome REST API request failed" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results_same_shape(self) -> None:
+        """Empty results are a bare JSON array, identical in shape to non-empty
+        (Bug 3 regression)."""
+        with respx.mock(using="httpx") as router:
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json={"results": []})
+            )
+            result = json.loads(await search_reactome_entity("apoptosis"))
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_raises(self) -> None:
+        """An unknown / mis-cased `types` value raises rather than silently
+        returning unfiltered results (Bug 2)."""
+        with pytest.raises(ValueError, match="Unknown Reactome type"):
+            await search_reactome_entity("apoptosis", types="NotARealType")
+
+    @pytest.mark.asyncio
+    async def test_type_case_normalized(self) -> None:
+        """A mis-cased but valid type is normalized to canonical case and sent
+        to the API (Bug 2)."""
+        with respx.mock(using="httpx") as router:
+            route = router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json={"results": []})
+            )
+            await search_reactome_entity("apoptosis", types="pathway")
+        assert route.calls.last.request.url.params["types"] == "Pathway"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_query_raises(self) -> None:
+        """A whitespace-only query is treated as empty (Bug 4)."""
+        with pytest.raises(ValueError, match="Missing search string"):
+            await search_reactome_entity("   ")
 
 
 # ---------------------------------------------------------------------------
@@ -282,34 +317,39 @@ class TestSearchRheaEntity:
             router.get("https://www.rhea-db.org/rhea").mock(
                 return_value=httpx.Response(200, text=tsv_body)
             )
-            result = await search_rhea_entity("ATP", limit=5)
+            result = json.loads(await search_rhea_entity("ATP", limit=5))
         assert len(result) == 2
         assert result[0]["rhea_id"] == "RHEA:10000"
         assert "ATP" in result[0]["equation"]
 
     @pytest.mark.asyncio
-    async def test_empty_response(self) -> None:
-        """An empty TSV response (header only) returns an empty list."""
+    async def test_empty_response_same_shape(self) -> None:
+        """An empty TSV response returns a bare JSON array `[]`, identical in
+        shape to the non-empty case (Bug 3 regression)."""
         tsv_body = "Rhea ID\tEquation\n"
         with respx.mock(using="httpx") as router:
             router.get("https://www.rhea-db.org/rhea").mock(
                 return_value=httpx.Response(200, text=tsv_body)
             )
-            result = await search_rhea_entity("nonexistent_compound", limit=5)
+            result = json.loads(
+                await search_rhea_entity("nonexistent_compound", limit=5)
+            )
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_http_error_returns_error_list(self) -> None:
-        """HTTP errors return a one-element error list, not an exception.
+    async def test_negative_limit_raises(self) -> None:
+        """A negative limit is rejected, not forwarded (Bug 1) — otherwise Rhea
+        dumps the entire database."""
+        with pytest.raises(ValueError, match="limit must be >= 0"):
+            await search_rhea_entity("ATP", limit=-1)
 
-        The error path stays type-consistent with the declared
-        `list[dict[str, str]]` return type by wrapping the message in a dict.
-        """
+    @pytest.mark.asyncio
+    async def test_http_error_returns_error_array(self) -> None:
+        """HTTP errors return a JSON string holding a one-element error array."""
         with respx.mock(using="httpx") as router:
             router.get("https://www.rhea-db.org/rhea").mock(
                 return_value=httpx.Response(500, text="Server Error")
             )
-            result = await search_rhea_entity("ATP")
+            result = json.loads(await search_rhea_entity("ATP"))
         assert isinstance(result, list)
-        assert len(result) == 1
         assert "Rhea REST API request failed" in result[0]["error"]

--- a/tests/test_json_string_returns.py
+++ b/tests/test_json_string_returns.py
@@ -1,0 +1,73 @@
+"""Regression tests for the JSON-string return contract (Bug 3).
+
+These tools previously returned bare Python lists, which FastMCP double-
+represents (a text array plus a wrapped ``{"result": [...]}`` structured
+object), so empty vs non-empty results had different client-visible shapes.
+They now return a JSON string of a bare array — empty and non-empty share one
+stable shape. See also the rhea/reactome cases in test_api_tools.py.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from togo_mcp.rdf_portal import find_databases, list_databases
+from togo_mcp.togoid import convertId, getRelation
+
+_TOGOID = "https://api.togoid.dbcls.jp"
+
+
+class TestRdfPortalListReturns:
+    """list_databases / find_databases read a local CSV cache — no network."""
+
+    def test_list_databases_is_json_array_string(self) -> None:
+        result = list_databases()
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert isinstance(parsed, list) and parsed  # catalog is non-empty
+        assert {"database", "title", "description"} <= parsed[0].keys()
+
+    def test_find_databases_hit_and_miss_same_shape(self) -> None:
+        miss = find_databases(keywords=["zzzznotarealdatabasexyz"])
+        assert miss == "[]"  # bare array string, not {"result": []}
+        hit = find_databases(keywords=["protein"])
+        assert isinstance(hit, str)
+        assert isinstance(json.loads(hit), list)
+
+
+class TestTogoidListReturns:
+    @pytest.mark.asyncio
+    async def test_convertid_returns_json_array_string(self) -> None:
+        body = {"results": [["672", "P38398"], ["675", "O15129"]]}
+        with respx.mock(using="httpx") as router:
+            router.get(f"{_TOGOID}/convert").mock(
+                return_value=httpx.Response(200, json=body)
+            )
+            result = await convertId(ids="672,675", route="ncbigene,uniprot")
+        assert isinstance(result, str)
+        assert json.loads(result) == [["672", "P38398"], ["675", "O15129"]]
+
+    @pytest.mark.asyncio
+    async def test_convertid_missing_results_is_empty_array(self) -> None:
+        """When nothing converts, TogoID omits `results` entirely — coalesce to
+        a bare `[]` rather than leaking null."""
+        with respx.mock(using="httpx") as router:
+            router.get(f"{_TOGOID}/convert").mock(
+                return_value=httpx.Response(200, json={})
+            )
+            result = await convertId(ids="999999999", route="ncbigene,uniprot")
+        assert result == "[]"
+
+    @pytest.mark.asyncio
+    async def test_getrelation_returns_json_array_string(self) -> None:
+        body = [{"forward": "encoded by", "reverse": "encodes",
+                 "description": "gene-protein link"}]
+        with respx.mock(using="httpx") as router:
+            router.get(f"{_TOGOID}/config/relation/ncbigene-uniprot").mock(
+                return_value=httpx.Response(200, json=body)
+            )
+            result = await getRelation(source="ncbigene", target="uniprot")
+        assert isinstance(result, str)
+        assert json.loads(result)[0]["forward"] == "encoded by"

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -689,10 +689,10 @@ async def search_pdb_entity(
         are ignored.
 
     Returns:
-        str: JSON string `{"total": int, "results": [ {…named fields…} ]}`.
-            For structured-filter searches PDBj does not compute a count and
-            returns `total: -1` even when `results` is non-empty — rely on
-            `results`, not `total`, in that case.
+        str: JSON string `{"total": int | null, "results": [ {…fields…} ]}`.
+            `total` is `null` when PDBj does not provide a count (typical for
+            structured-filter searches) — it is *not* zero and does not mean
+            "no results"; consult `results` directly in that case.
     """
     query = _resolve_query_alias(
         query,
@@ -745,6 +745,11 @@ async def search_pdb_entity(
             total_results = int(raw_total)
         except (TypeError, ValueError):
             total_results = 0
+        # PDBj returns -1 ("not computed") for structured-filter searches, even
+        # alongside real rows. Surface that as null rather than a nonsensical
+        # negative count.
+        if total_results < 0:
+            total_results = None
         # `limit`/`offset` are honored server-side; the slice is a safety belt.
         result_list = [
             project(entry) for entry in payload.get("results", [])[:limit]

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -707,7 +707,16 @@ async def search_pdb_entity(
     params: dict = {"query": query, "limit": limit, "offset": offset}
     if db == "pdb":
         if method:
-            params["method"] = _PDB_METHOD_CODES[method]
+            # `method` is enum-constrained at the schema layer, but guard the
+            # lookup so a Literal/dict drift (or a direct call) gives a clear
+            # error instead of a bare KeyError.
+            code = _PDB_METHOD_CODES.get(method)
+            if code is None:
+                raise ValueError(
+                    f"Unknown method {method!r}. Valid values: "
+                    f"{sorted(_PDB_METHOD_CODES)}."
+                )
+            params["method"] = code
         if res_min is not None:
             params["res_min"] = res_min
         if res_max is not None:

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -827,6 +827,21 @@ async def search_mesh_descriptor(
 
 
 # DB: Reactome
+#
+# Canonical Reactome search `types` facet values (the API is case-sensitive and
+# silently ignores unknown/mis-cased values, returning UNFILTERED results).
+# Verified against /ContentService/search/facet on 2026-06-24. Keyed by
+# lowercase for case-insensitive validation -> canonical form.
+_REACTOME_TYPES = {
+    t.lower(): t
+    for t in (
+        "Complex", "Protein", "Reaction", "Set", "Pathway",
+        "Genes and Transcripts", "Chemical Compound", "DNA Sequence",
+        "Polymer", "Drug", "RNA Sequence", "OtherEntity", "Cell",
+    )
+}
+
+
 @mcp.tool()
 async def search_reactome_entity(
     query: str = "",
@@ -839,43 +854,41 @@ async def search_reactome_entity(
     keywords: str = "",
     search_term: str = "",
     name: str = "",
-) -> list[dict[str, str]]:
+) -> str:
     """Search the Reactome knowledgebase using keyword search.
 
     Args:
         query: The search query string (e.g., "apoptosis", "TP53", "cell cycle").
             Accepts aliases: `search`, `term`, `keyword`, `keywords`,
-            `search_term`, `name`.
+            `search_term`, `name`. If both `query` and an alias are given with
+            different values, `query` wins silently.
         species: Filter by species. Must be the scientific name
             (e.g., "Homo sapiens", "Mus musculus"). Numeric NCBI taxon
             IDs like "9606" are rejected here (this tool raises ValueError)
             because the Reactome API silently ignores them AND can
             degrade co-occurring filters (e.g. `types`). Accepts a
             single string or a list of strings.
-        types: Filter by entity types. Accepts a single string (e.g.,
+        types: Filter by entity type(s). Accepts a single string (e.g.,
             "Pathway") or a list (e.g., ["Pathway", "Reaction", "Complex"]).
+            Validated case-insensitively against the Reactome type enum;
+            unknown values raise ValueError (the API would otherwise silently
+            ignore them and return unfiltered results). Valid values:
+            Complex, Protein, Reaction, Set, Pathway, Genes and Transcripts,
+            Chemical Compound, DNA Sequence, Polymer, Drug, RNA Sequence,
+            OtherEntity, Cell.
         rows: Per-category result cap. Reactome clusters results by
             entity type (`cluster=true`), so `rows=30` returns up to 30
             hits *per type*, not 30 hits total. To bound the total,
             constrain `types` to a single value.
 
     Returns:
-        List of results with 'id', 'name', and 'type' fields.
-        Example: [
-            {'id': 'R-HSA-109581', 'name': 'Apoptosis', 'type': 'Pathway'},
-            {'id': 'R-HSA-204981', 'name': '14-3-3epsilon...', 'type': 'Reaction'}
-        ]
-
-    Example:
-        >>> results = search_reactome("apoptosis", rows=5)
-        >>> for entry in results:
-        ...     print(f"{entry['type']:10} {entry['id']}: {entry['name']}")
-
-        >>> # Filter by type
-        >>> pathways = [r for r in results if r['type'] == 'Pathway']
+        JSON string: a bare array of results, each with 'id', 'name', and
+        'type' fields. Empty and non-empty results share the same shape.
+        Example: '[{"id": "R-HSA-109581", "name": "Apoptosis",
+        "type": "Pathway"}]'
 
     Raises:
-        httpx.HTTPError: If the API request fails.
+        ValueError: If `query` is blank or `types`/`species` are invalid.
     """
     query = _resolve_query_alias(
         query,
@@ -885,7 +898,7 @@ async def search_reactome_entity(
         keywords=keywords,
         search_term=search_term,
         name=name,
-    )
+    ).strip()
     if not query:
         raise ValueError(
             "Missing search string. Pass it as `query` (canonical) or any of: "
@@ -905,7 +918,19 @@ async def search_reactome_entity(
             )
         params["species"] = ",".join(species_list)
     if types:
-        params["types"] = types if isinstance(types, str) else ",".join(types)
+        types_list = [types] if isinstance(types, str) else list(types)
+        normalized, unknown = [], []
+        for t in types_list:
+            canon = _REACTOME_TYPES.get(t.strip().lower())
+            (normalized if canon else unknown).append(canon or t)
+        if unknown:
+            raise ValueError(
+                f"Unknown Reactome type(s): {unknown}. The search API silently "
+                "ignores invalid/mis-cased types and returns UNFILTERED "
+                f"results. Valid values (case-insensitive): "
+                f"{sorted(set(_REACTOME_TYPES.values()))}."
+            )
+        params["types"] = ",".join(normalized)
 
     # Make API call
     try:
@@ -918,7 +943,7 @@ async def search_reactome_entity(
         data = response.json()
     except (httpx.HTTPError, ValueError) as e:
         logger.warning(f"Reactome search failed: {type(e).__name__}: {e}")
-        return [{
+        return json.dumps([{
             "error": (
                 f"Reactome REST API request failed ({type(e).__name__}: "
                 f"{e}). Reactome's search endpoint can be slow or briefly "
@@ -926,7 +951,7 @@ async def search_reactome_entity(
                 "failing, fall back to SPARQL: "
                 "run_sparql(database='reactome', sparql_query=...)."
             )
-        }]
+        }])
 
     # Extract and return results
     results = []
@@ -945,7 +970,7 @@ async def search_reactome_entity(
                 }
             )
 
-    return results
+    return json.dumps(results)
 
 
 # DB: RhEA
@@ -959,7 +984,7 @@ async def search_rhea_entity(
     keywords: str = "",
     search_term: str = "",
     name: str = "",
-) -> list[dict[str, str]]:
+) -> str:
     """
     Search Rhea database for biochemical reactions using keyword search.
 
@@ -970,18 +995,19 @@ async def search_rhea_entity(
                     - "uniprot:*" - reactions with UniProt annotations
                     - "" - retrieve all reactions
                     Accepts aliases: `search`, `term`, `keyword`, `keywords`,
-                    `search_term`, `name`.
+                    `search_term`, `name`. If both `query` and an alias are
+                    given with different values, `query` wins silently.
         limit (int, optional): Maximum number of results. Defaults to 100.
+            Must be >= 0; a negative limit is rejected (it would make Rhea
+            return the entire database).
 
     Returns:
-        List[Dict[str, str]]: List of reactions, each containing:
-            - 'rhea_id': Reaction identifier (e.g., "RHEA:10000")
-            - 'equation': Reaction equation text
+        JSON string: a bare array of reactions, each with 'rhea_id' and
+        'equation'. Empty and non-empty results share the same shape.
+        Example: '[{"rhea_id": "RHEA:10000", "equation": "ATP + H2O = ..."}]'
 
-    Example:
-        >>> results = search_rhea_entity("ATP", limit=5)
-        >>> for reaction in results:
-        ...     print(f"{reaction['rhea_id']}: {reaction['equation']}")
+    Raises:
+        ValueError: If `limit` is negative.
     """
     # Unlike other search tools, Rhea permits an empty query (returns all
     # reactions). Only coalesce when an alias was provided.
@@ -993,7 +1019,13 @@ async def search_rhea_entity(
         keywords=keywords,
         search_term=search_term,
         name=name,
-    )
+    ).strip()
+
+    if limit is not None and limit < 0:
+        raise ValueError(
+            f"limit must be >= 0 (got {limit}). A negative limit makes Rhea "
+            "return the entire result set (thousands of reactions)."
+        )
 
     params = {
         "query": query,
@@ -1010,7 +1042,7 @@ async def search_rhea_entity(
         lines = response.text.strip().split("\n")
 
         if len(lines) < 2:
-            return []
+            return json.dumps([])
 
         # First line is header, skip it
         results = []
@@ -1020,15 +1052,15 @@ async def search_rhea_entity(
                 if len(parts) >= 2:
                     results.append({"rhea_id": parts[0], "equation": parts[1]})
 
-        return results
+        return json.dumps(results)
 
     except (httpx.HTTPError, ValueError) as e:
         logger.warning(f"Rhea search failed: {type(e).__name__}: {e}")
-        return [{
+        return json.dumps([{
             "error": (
                 f"Rhea REST API request failed ({type(e).__name__}: {e}). "
                 "Usually transient — retry once after a brief delay. If it "
                 "keeps failing, fall back to SPARQL: "
                 "run_sparql(database='rhea', sparql_query=...)."
             )
-        }]
+        }])

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -1,5 +1,6 @@
 import csv as _csv
 import io as _io
+import json
 from pathlib import Path
 import sys
 from typing import Annotated, Any, Literal
@@ -393,7 +394,7 @@ def _load_databases_cache() -> list[dict[str, Any]]:
 
 
 @mcp.tool(name="list_databases")
-def list_databases() -> list[dict[str, Any]]:
+def list_databases() -> str:
     """
     Supplementary: full catalog dump (browse only, no filtering).
 
@@ -406,12 +407,13 @@ def list_databases() -> list[dict[str, Any]]:
     is the canonical entry point. This tool is a supplementary fallback.
 
     Returns:
-        A list of dicts with keys `database`, `title`, `description`.
+        JSON string: a bare array of dicts with keys `database`, `title`,
+        `description`.
     """
-    return [
+    return json.dumps([
         {"database": r["database"], "title": r["title"], "description": r["description"]}
         for r in _load_databases_cache()
-    ]
+    ])
 
 
 def _normalize_terms(value: str | list[str] | None) -> list[str]:
@@ -478,7 +480,7 @@ def find_databases(
             )
         ),
     ] = False,
-) -> list[dict[str, Any]]:
+) -> str:
     """
     Database discovery — REQUIRED first step for any TogoMCP workflow.
 
@@ -500,7 +502,8 @@ def find_databases(
     `list_databases()` — that tool is supplementary, not a substitute for this one.
 
     Returns:
-        List of dicts: `{database, title, matched_keywords, categories, snippet}` (or
+        JSON string: a bare array of dicts
+        `{database, title, matched_keywords, categories, snippet}` (or
         `description` when `verbose=True`). Sorted by number of matched keywords
         descending, then alphabetically by database name.
     """
@@ -508,7 +511,7 @@ def find_databases(
     cat_list = _normalize_terms(category)
 
     if not kw_list and not cat_list:
-        return []
+        return json.dumps([])
 
     results: list[dict[str, Any]] = []
     for r in _load_databases_cache():
@@ -543,7 +546,7 @@ def find_databases(
         })
 
     results.sort(key=lambda x: (-len(x["matched_keywords"]), x["database"]))
-    return results
+    return json.dumps(results)
 
 
 @mcp.tool(name="list_categories")

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import re
 
 import httpx
@@ -78,7 +79,7 @@ async def getAllRelation() -> dict:
 
 
 @togoid_mcp.tool()
-async def getRelation(source: str, target: str) -> list:
+async def getRelation(source: str, target: str) -> str:
     """Check if a specific ID conversion route exists and get its details.
 
     Use this to verify that a particular source→target conversion is available
@@ -90,7 +91,7 @@ async def getRelation(source: str, target: str) -> list:
         target: Target database key (e.g., 'pdb', 'ensembl_gene', 'hgnc')
 
     Returns:
-        List of relationship objects with:
+        JSON string: a bare array of relationship objects with:
         - forward: relationship label from source to target
         - reverse: relationship label from target to source
         - description: explanation of the link
@@ -111,7 +112,7 @@ async def getRelation(source: str, target: str) -> list:
             "to list valid routes."
         ),
     )
-    return response.json()
+    return json.dumps(response.json())
 
 
 @togoid_mcp.tool()
@@ -196,7 +197,7 @@ async def convertId(
     route: str,
     limit: int = 10000,
     offset: int = 0,
-) -> list:
+) -> str:
     """Convert identifiers from one database to another.
 
     Maps IDs between biological databases — e.g., NCBI Gene IDs to UniProt
@@ -227,8 +228,8 @@ async def convertId(
         offset: Pagination offset for large result sets
 
     Returns:
-        List of [source_id, target_id] pairs.
-        Example: [["672", "P38398"], ["675", "O15129"], ...]
+        JSON string: a bare array of [source_id, target_id] pairs.
+        Example: '[["672", "P38398"], ["675", "O15129"]]'
 
     Common use cases:
         - Bridging databases on different SPARQL endpoints
@@ -257,7 +258,9 @@ async def convertId(
             "no direct route between the two datasets."
         ),
     )
-    return response.json().get("results")
+    # `results` is absent (not []) when nothing converts — coalesce so the
+    # return stays a bare array, never null.
+    return json.dumps(response.json().get("results") or [])
 
 
 @togoid_mcp.tool()


### PR DESCRIPTION
Follow-up to #84. A coherent series hardening the return contracts and error handling of the search / list / convert tools, driven by two black-box bug reports plus a systematic error-path sweep.

## Commits

**`5c5ee06` — search_pdb_entity: null instead of -1**
PDBj returns `total: -1` ("uncounted") for structured-filter searches, *alongside* real rows. Surface that as `null` rather than a nonsensical negative; docstring clarified.

**`161165a` — harden search_reactome_entity / search_rhea_entity (5 bugs)**
- rhea negative `limit` → `ValueError` (was dumping the whole DB)
- reactome `types` validated against the canonical enum (mis-cased normalized, unknown rejected) — the API otherwise silently returns unfiltered results
- both now return a JSON string (bare array) so empty and non-empty share one shape (see Bug 3 below)
- reactome whitespace-only query → same "missing search string" error
- documented `query`-wins alias precedence

**`eabeb3c` — Bug-3 JSON-string contract for the remaining list tools**
An output-schema audit found four more bare-`list` returns that FastMCP double-represents (text array + wrapped `{"result": ...}`), so empty vs non-empty diverged client-side: `list_databases`, `find_databases`, `togoid_convertId`, `togoid_getRelation`. All now return a JSON-string bare array. Also fixes a latent `convertId` bug (returned `null` when nothing converts → now `[]`). `dict` and NCBI `list[TextContent]` returns are unaffected.

**`b36de4e` — guard pdb method lookup; document error conventions**
Error-path sweep found an unguarded `_PDB_METHOD_CODES[method]` lookup (bare `KeyError` on Literal/dict drift) → now a clear `ValueError`. Documented the two intentional error conventions in CLAUDE.md (REST wrappers return `{"error": ...}` on HTTP failure; TogoID raises) so neither gets normalized away.

## Notes
- **Return-type contract change**: reactome/rhea/list_databases/find_databases/convertId/getRelation now return a JSON **string** instead of a Python `list`. No internal Python callers depended on the list shape; MCP clients parse JSON either way. This aligns them with the existing str-returning search tools (pdb/uniprot/mesh).
- Error paths now verified: parameter validation raises clean `ValueError`s; HTTP failures degrade to JSON error payloads for the REST wrappers.

**69 tests pass** (new coverage for type validation, negative limit, whitespace query, empty-vs-nonempty shape parity, convertId null-coalesce, and the method guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)