### PR TITLE
Bug 5: raise on conflicting query aliases (centralized)

### DIFF
--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -7,12 +7,39 @@ import pytest
 import respx
 
 from togo_mcp.api_tools import (
+    _resolve_query_alias,
     search_chembl_target,
     search_pdb_entity,
     search_reactome_entity,
     search_rhea_entity,
     search_uniprot_entity,
 )
+
+
+class TestResolveQueryAlias:
+    """Alias precedence is centralized; a conflict raises (surfacing the likely
+    caller mistake) rather than silently dropping a value (Bug 5)."""
+
+    def test_single_value_resolves(self) -> None:
+        assert _resolve_query_alias("ATP") == "ATP"
+
+    def test_duplicate_same_value_ok(self) -> None:
+        # Same value via two aliases is not a conflict.
+        assert _resolve_query_alias("ATP", search="ATP") == "ATP"
+
+    def test_conflict_raises(self) -> None:
+        with pytest.raises(ValueError, match="Multiple distinct search terms"):
+            _resolve_query_alias("ATP", keyword="glucose")
+
+    @pytest.mark.asyncio
+    async def test_conflict_raises_via_tool(self) -> None:
+        """The conflict surfaces through the tool layer, not just the helper."""
+        with pytest.raises(ValueError, match="Multiple distinct search terms"):
+            await search_reactome_entity(query="ATP", keyword="glucose")
+
+    def test_alias_only_resolves(self) -> None:
+        assert _resolve_query_alias("", term="x") == "x"
+        assert _resolve_query_alias("") == ""
 
 # ---------------------------------------------------------------------------
 # UniProt

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -30,8 +30,27 @@ def _resolve_query_alias(
     search_term: str = "",
     name: str = "",
 ) -> str:
-    """Return the first non-empty value among `query` and its accepted aliases."""
-    return query or search or term or keyword or keywords or search_term or name
+    """Return the first non-empty value among `query` and its accepted aliases.
+
+    These are all aliases for the single `query` parameter. Supplying two or
+    more with *different* values is treated as a caller error and raises
+    ValueError. A warning would only land in the server log, never reaching
+    the (often LLM-driven) caller — where this conflict is a likely mistake
+    (e.g. the model fills `query` while a wrapper fills `keyword`); raising
+    surfaces it through the tool result so the caller can retry with one term.
+    Duplicates with the same value, or a single value, resolve normally.
+    """
+    candidates = {
+        "query": query, "search": search, "term": term, "keyword": keyword,
+        "keywords": keywords, "search_term": search_term, "name": name,
+    }
+    provided = {k: v for k, v in candidates.items() if v}
+    if len({*provided.values()}) > 1:
+        raise ValueError(
+            f"Multiple distinct search terms supplied: {provided}; pass only "
+            "one — these are all aliases for the same `query` parameter."
+        )
+    return next(iter(provided.values()), "")
 
 
 ######################################
@@ -660,7 +679,7 @@ async def search_pdb_entity(
         query (str): Free-text keywords. May be empty when at least one
             structured filter is supplied. Accepts aliases: `search`, `term`,
             `keyword`, `keywords`, `search_term`, `name`. If both `query` and
-            an alias are given with different values, `query` wins silently.
+            an alias are given with different values, this raises ValueError (pass only one).
         limit (int): Max results to return, in [0, 500]. Default 20.
         offset (int): Number of leading results to skip (server-side
             pagination). Default 0.
@@ -870,7 +889,7 @@ async def search_reactome_entity(
         query: The search query string (e.g., "apoptosis", "TP53", "cell cycle").
             Accepts aliases: `search`, `term`, `keyword`, `keywords`,
             `search_term`, `name`. If both `query` and an alias are given with
-            different values, `query` wins silently.
+            different values, this raises ValueError (pass only one).
         species: Filter by species. Must be the scientific name
             (e.g., "Homo sapiens", "Mus musculus"). Numeric NCBI taxon
             IDs like "9606" are rejected here (this tool raises ValueError)
@@ -1005,7 +1024,7 @@ async def search_rhea_entity(
                     - "" - retrieve all reactions
                     Accepts aliases: `search`, `term`, `keyword`, `keywords`,
                     `search_term`, `name`. If both `query` and an alias are
-                    given with different values, `query` wins silently.
+                    given with different values, this raises ValueError (pass only one).
         limit (int, optional): Maximum number of results. Defaults to 100.
             Must be >= 0; a negative limit is rejected (it would make Rhea
             return the entire database).


### PR DESCRIPTION
Follow-up to #85, completing the Bug 5 fix from the reactome/rhea report.

## Problem
The earlier pass only *documented* the `query`-wins alias precedence, and only in 3 of the 8 tools that share it — so the behavior stayed silent and the docs were inconsistent.

## Fix
The precedence lives in `_resolve_query_alias`, used by every `search_*` tool (10 call sites). Handle it once, there: when two or more aliases are supplied with **different** values, **raise `ValueError`** naming the conflicting values.

**Why raise, not warn?** A warning only lands in the server log and never reaches the (often LLM-driven) caller — exactly where this conflict is a likely mistake (the model fills `query` while a wrapper fills `keyword`). Raising surfaces it through the tool result so the caller can retry with one term, and matches the documented "raise `ValueError` for bad params" convention (CLAUDE.md).

- Same value via two aliases, or a single value, resolve normally (no false positives).
- All three docstrings updated.

Tests cover single / duplicate-same / conflict (helper + tool layer) / alias-only. **74 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)