### PR TITLE
Benchmark: agent-SDK baseline, Opus judge, model centralization, and the qa-generator skill

### DIFF
--- a/.claude/skills/qa-generator/SKILL.md
+++ b/.claude/skills/qa-generator/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: qa-generator
+description: Generate new benchmark questions for the TogoMCP evaluation set (benchmark/questions/question_XXX.yaml). Use this skill whenever the user asks to create, write, add, or extend benchmark questions / the QA set / the evaluation dataset for TogoMCP — e.g. "add a few benchmark questions", "extend the QA set", "we need more list-type questions", "write a new question about <topic/database>", "grow the benchmark past 50", or anything mentioning benchmark/questions, coverage_tracker.yaml, the QA creation guide, or question YAML files. Each question is produced end-to-end against live RDF databases (SPARQL, OLS4, PubMed) following the v5.5.0 type-first protocol, then presented for approval before it is written.
+---
+
+# TogoMCP Benchmark QA Generator
+
+This skill produces new, fully-validated benchmark questions one at a time, enforcing the type-first creation protocol and the 25-category QA review that the existing 50 questions passed. A question is only useful if it **requires live RDF access to answer** and is **arithmetically self-consistent**; this skill exists to guarantee both, not just to emit plausible-looking YAML.
+
+It runs in a Claude Code environment with the **TogoMCP MCP server** (SPARQL + REST wrappers + TogoID), **OLS4** (ontology lookup), and **PubMed/NCBI** tools connected, plus filesystem access. Use those tools freely — that is the normal mode here. Prefer the local `togomcp-dev` server if both it and the remote `togomcp` are present (its registry is fresher).
+
+## The Three Hard Rules
+
+**1. Nothing is invented.** Every SPARQL query in `sparql_queries` must execute successfully against the real endpoint before it is written. Every `result_count`, every triple in `rdf_triples`, and every fact in `ideal_answer` must come from an actual query result you ran this session. A fabricated count or triple is worse than a missing one — it silently poisons the benchmark.
+
+**2. Question scope = query scope (no sampling).** If exploration discovers N ontology terms (GO/MONDO/ChEBI/EC/MeSH), the SPARQL `VALUES` clause must use **all N**, including all `getDescendants()`. A "which/how many/list all" question must query the entire set, never a subset. This is the single most common way a question silently becomes wrong — see [references/coverage-gaps.md](references/coverage-gaps.md).
+
+**3. Every `GROUP BY` gets an arithmetic-verification query.** Run a separate `COUNT(DISTINCT ?entity)` over the same criteria and confirm `sum of category counts == total`. If `sum < total` → a coverage gap exists, STOP and fix it. If `sum > total` → the overlap must be explained in `ideal_answer`.
+
+## Workflow — one question, then checkpoint
+
+Generate **one** question through all phases, then **stop and present it for the user's approval** (the YAML + the `verify_questions.py` result + your C01–C25 self-review). Only after approval do you write the file and update the tracker. For a "generate N" request, loop this — pause on each. Never batch-write.
+
+### Phase 0 — Pick the type (type-first; non-negotiable)
+Read `benchmark/questions/coverage_tracker.yaml`. Choose the **most under-represented** `type` (target ≈ total/5 per type; the five types are `yes_no`, `factoid`, `list`, `summary`, `choice`). If the user named a type/topic/database, honor it but still record the coverage rationale. Type is chosen **before** databases and keywords — not fitted to a keyword afterward.
+
+### Phase 1 — Pick databases (type-compatible, under-used)
+From the tracker's `databases` counts, prefer under-used databases. Call `list_databases()`; pick **2–3** with complementary domains and a real cross-reference path (e.g. UniProt→PDB, ChEMBL→ChEBI), compatible with the type (`summary` needs ≥3). Call `get_MIE_file()` for each chosen database before writing any SPARQL. Avoid pushing UniProt past 70% of the set.
+
+### Phase 2 — Pick a keyword
+Read `benchmark/keywords.tsv` (columns: `Keyword ID`, `Name`, `Category`). Filter by the type and the chosen databases, drop any already in the tracker's `keywords_used`, and pick **randomly** from what remains (do not browse for an appealing topic — that inverts the workflow). Avoid famous entities (BRCA1, TP53, insulin, aspirin, glycolysis, E. coli K-12, …).
+
+### Phase 3 — Structured vocabulary discovery
+Before any SPARQL, resolve every concept to a structured identifier via the hierarchy in [references/vocabulary-discovery.md](references/vocabulary-discovery.md): ontology IRIs (OLS4 `searchClasses` for GO/MONDO/ChEBI/UBERON; `search_mesh_descriptor`; EC via Rhea) **before** any text search. For every ontology term found, call `OLS4:getDescendants()` and record the full term set. Free-text `bif:contains` is a last resort and must be justified in the file.
+
+### Phase 4 — Explore & formulate SPARQL (live)
+Run real queries via `run_sparql` (and `search_*`/`ncbi_*` wrappers) to find the answer. **No blind retry loops** — if a query fails twice, diagnose (wrong predicate/graph/IRI) before retrying; consult the MIE file. Keep `VALUES` exhaustive (Rule 2).
+
+### Phase 5 — Arithmetic verification
+For every `GROUP BY`, run the verification query (Rule 3) and record the check.
+
+### Phase 6 — Necessity gates (both must pass)
+- **Training test:** the answer must depend on *current* database state, not recallable from memory.
+- **PubMed test:** actually try to *answer* the specific question from PubMed (≥2 queries, read abstracts) and fail. Confirming the topic exists is not enough. The `pubmed_test.conclusion` must contain `PASS`.
+
+### Phase 7 — Assemble the YAML
+Fill every required field per [references/question-schema.md](references/question-schema.md) and [references/template.yaml](references/template.yaml): correct `exact_answer` format for the type; `rdf_triples` with a `# Database: X | Query: N | Comment: ...` line after **every** triple; a `verification_score` that honestly totals ≥9 with no zero dimension; a synthesized `ideal_answer` (single paragraph for `summary`; no meta-references like "according to UniProt"). The question `body` must be self-contained and must **not** name a database.
+
+### Phase 8 — Self-review against C01–C25
+Walk the full checklist in [references/qa-checklist.md](references/qa-checklist.md). Any CRITICAL (C01–C06, C22, C23) or MAJOR finding means fix it before presenting — do not present a question you know is flawed. Produce a short verdict (PASS / MINOR / MAJOR) with the triggered codes.
+
+### Phase 9 — Machine validation
+Write the candidate to a scratch path and run:
+```bash
+python benchmark/scripts/verify_questions.py /path/to/candidate.yaml   # single-file mode
+```
+Fix every ❌ error. (Single-file mode checks structure/format only; the aggregate balance is already guaranteed by Phase 0–1.)
+
+### Phase 10 — CHECKPOINT: present for approval
+Show the user: the rendered YAML, the verify result, and the C01–C25 verdict. **Wait.** Do not write into `benchmark/questions/` or touch the tracker until they approve.
+
+### Phase 11 — Commit the question (after approval only)
+- Assign the next id: `question_0NN.yaml` where NN = (current highest + 1), `id` field matching the filename.
+- Write it into `benchmark/questions/`.
+- Update `benchmark/questions/coverage_tracker.yaml`: `total_questions`; the chosen type's `count`/`questions`; each database's `count`/`questions`; `multi_database_metrics` (2+/3+ counts and percentages); append the keyword to `keywords_used`.
+- Append a row to the progress tracker in `benchmark/togomcp_qa_prompt.md` (`| 0NN | P | — |`) and bump its summary line.
+- Run the **full** `python benchmark/scripts/verify_questions.py` (no args) to confirm the whole set, including the new question, still passes with 0 errors.
+
+## Scope boundary
+This skill stops at **approved, validated questions + updated tracker**. It does **not** run `automated_test_runner.py` or `add_llm_evaluation.py` — collecting answers and scoring the new questions is a separate, explicitly-triggered step (it incurs billed API runs).
+
+## Source of truth
+The canonical, full protocol lives in the repo and overrides anything distilled here if they ever disagree:
+- `benchmark/QA_CREATION_GUIDE.md` — the v5.5.0 protocol
+- `benchmark/QUESTION_FORMAT.md` — the YAML schema
+- `benchmark/togomcp_qa_prompt.md` — the QA review prompt (C01–C25) + progress tracker
+
+The `references/` files here are the distilled, in-loop actionable versions; read the canonical doc when a detail is ambiguous.
+
+## File & tool map
+
+| Asset | Path | How |
+|---|---|---|
+| Question files | `benchmark/questions/question_XXX.yaml` | Read/Write |
+| Coverage tracker | `benchmark/questions/coverage_tracker.yaml` | Read/Edit |
+| Keyword pool | `benchmark/keywords.tsv` | Read |
+| Validator | `benchmark/scripts/verify_questions.py` | Bash (file arg = checkpoint; no arg = full set) |
+| QA progress tracker | `benchmark/togomcp_qa_prompt.md` | Edit (Phase 11) |
+| Databases / schema | — | `list_databases`, `get_MIE_file`, `run_sparql`, `search_*`, `ncbi_*` (TogoMCP MCP) |
+| Ontology terms | — | OLS4 `searchClasses` / `getDescendants`; `search_mesh_descriptor` |
+| Literature gate | — | PubMed / `ncbi_esearch` + `ncbi_efetch` |

--- a/.claude/skills/qa-generator/SKILL.md
+++ b/.claude/skills/qa-generator/SKILL.md
@@ -7,7 +7,7 @@ description: Generate new benchmark questions for the TogoMCP evaluation set (be
 
 This skill produces new, fully-validated benchmark questions one at a time, enforcing the type-first creation protocol and the 25-category QA review that the existing 50 questions passed. A question is only useful if it **requires live RDF access to answer** and is **arithmetically self-consistent**; this skill exists to guarantee both, not just to emit plausible-looking YAML.
 
-It runs in a Claude Code environment with the **TogoMCP MCP server** (SPARQL + REST wrappers + TogoID), **OLS4** (ontology lookup), and **PubMed/NCBI** tools connected, plus filesystem access. Use those tools freely — that is the normal mode here. Prefer the local `togomcp-dev` server if both it and the remote `togomcp` are present (its registry is fresher).
+It runs in a Claude Code environment with the **TogoMCP MCP server** (SPARQL + REST wrappers + TogoID), **OLS4** (ontology lookup), and **PubMed/NCBI** tools connected, plus filesystem access. Use those tools freely — that is the normal mode here. **Either TogoMCP server works** — they expose the identical tool surface, differing only in the tool prefix (`mcp__togomcp-dev__*` vs `mcp__togomcp__*`). Prefer the local `togomcp-dev` when present because its registry is fresher (it picks up new `endpoints.csv` rows immediately); the remote `togomcp` is a fine fallback for the established databases, with the one caveat that its registry can lag, so a *recently added* database may not be available there yet. OLS4 and PubMed are separate servers, unaffected by which TogoMCP you use.
 
 ## The Three Hard Rules
 

--- a/.claude/skills/qa-generator/SKILL.md
+++ b/.claude/skills/qa-generator/SKILL.md
@@ -24,6 +24,8 @@ Generate **one** question through all phases, then **stop and present it for the
 ### Phase 0 — Pick the type (type-first; non-negotiable)
 Read `benchmark/questions/coverage_tracker.yaml`. Choose the **most under-represented** `type` (target ≈ total/5 per type; the five types are `yes_no`, `factoid`, `list`, `summary`, `choice`). If the user named a type/topic/database, honor it but still record the coverage rationale. Type is chosen **before** databases and keywords — not fitted to a keyword afterward.
 
+> **Shortcut:** `python benchmark/scripts/verify_questions.py` (full run, no args) prints a **Next-Question Guidance** block that does Phase 0–1's bookkeeping for you — the per-type shortfall to the next balanced milestone, the most under-used databases to prefer, and how much UniProt headroom remains under the 70% cap. Use it to make the type/database picks unambiguous rather than eyeballing the tracker.
+
 ### Phase 1 — Pick databases (type-compatible, under-used)
 From the tracker's `databases` counts, prefer under-used databases. Call `list_databases()`; pick **2–3** with complementary domains and a real cross-reference path (e.g. UniProt→PDB, ChEMBL→ChEBI), compatible with the type (`summary` needs ≥3). Call `get_MIE_file()` for each chosen database before writing any SPARQL. Avoid pushing UniProt past 70% of the set.
 

--- a/.claude/skills/qa-generator/SKILL.md
+++ b/.claude/skills/qa-generator/SKILL.md
@@ -19,7 +19,7 @@ It runs in a Claude Code environment with the **TogoMCP MCP server** (SPARQL + R
 
 ## Workflow — one question, then checkpoint
 
-Generate **one** question through all phases, then **stop and present it for the user's approval** (the YAML + the `verify_questions.py` result + your C01–C25 self-review). Only after approval do you write the file and update the tracker. For a "generate N" request, loop this — pause on each. Never batch-write.
+Generate **one** question through all phases, then **stop and present it for the user's approval** (the YAML + the `verify_questions.py` result + your C01–C26 self-review). Only after approval do you write the file and update the tracker. For a "generate N" request, loop this — pause on each. Never batch-write.
 
 ### Phase 0 — Pick the type (type-first; non-negotiable)
 Read `benchmark/questions/coverage_tracker.yaml`. Choose the **most under-represented** `type` (target ≈ total/5 per type; the five types are `yes_no`, `factoid`, `list`, `summary`, `choice`). If the user named a type/topic/database, honor it but still record the coverage rationale. Type is chosen **before** databases and keywords — not fitted to a keyword afterward.
@@ -46,25 +46,25 @@ For every `GROUP BY`, run the verification query (Rule 3) and record the check.
 ### Phase 7 — Assemble the YAML
 Fill every required field per [references/question-schema.md](references/question-schema.md) and [references/template.yaml](references/template.yaml): correct `exact_answer` format for the type; `rdf_triples` with a `# Database: X | Query: N | Comment: ...` line after **every** triple; a `verification_score` that honestly totals ≥9 with no zero dimension; a synthesized `ideal_answer` (single paragraph for `summary`; no meta-references like "according to UniProt"). The question `body` must be self-contained and must **not** name a database.
 
-### Phase 8 — Self-review against C01–C25
-Walk the full checklist in [references/qa-checklist.md](references/qa-checklist.md). Any CRITICAL (C01–C06, C22, C23) or MAJOR finding means fix it before presenting — do not present a question you know is flawed. Produce a short verdict (PASS / MINOR / MAJOR) with the triggered codes.
+### Phase 8 — Self-review against C01–C26
+Walk the full checklist in [references/qa-checklist.md](references/qa-checklist.md). Any CRITICAL (C01–C06, C22, C23) or MAJOR finding means fix it before presenting — do not present a question you know is flawed. **For C26 (structural near-duplicate), actively scan the existing questions that share this candidate's `type` and database set** — read their `body` and `sparql_queries` and confirm the candidate uses a genuinely different query pattern/predicate path, not the same shape with a new keyword. This is the one check the machine validator can't fully make at the checkpoint (single-file mode sees only this file), so it's on you here. Produce a short verdict (PASS / MINOR / MAJOR) with the triggered codes.
 
 ### Phase 9 — Machine validation
 Write the candidate to a scratch path and run:
 ```bash
 python benchmark/scripts/verify_questions.py /path/to/candidate.yaml   # single-file mode
 ```
-Fix every ❌ error. (Single-file mode checks structure/format only; the aggregate balance is already guaranteed by Phase 0–1.)
+Fix every ❌ error. (Single-file mode checks structure/format only — it does **not** see the rest of the set, so the aggregate gates and the structural near-duplicate guard run later, in the full Phase-11 validation. Phase 0–1 *biases* toward balance; the full run is what *enforces* the coverage caps and surfaces signature/keyword collisions.)
 
 ### Phase 10 — CHECKPOINT: present for approval
-Show the user: the rendered YAML, the verify result, and the C01–C25 verdict. **Wait.** Do not write into `benchmark/questions/` or touch the tracker until they approve.
+Show the user: the rendered YAML, the verify result, and the C01–C26 verdict. **Wait.** Do not write into `benchmark/questions/` or touch the tracker until they approve.
 
 ### Phase 11 — Commit the question (after approval only)
 - Assign the next id: `question_0NN.yaml` where NN = (current highest + 1), `id` field matching the filename.
 - Write it into `benchmark/questions/`.
 - Update `benchmark/questions/coverage_tracker.yaml`: `total_questions`; the chosen type's `count`/`questions`; each database's `count`/`questions`; `multi_database_metrics` (2+/3+ counts and percentages); append the keyword to `keywords_used`.
 - Append a row to the progress tracker in `benchmark/togomcp_qa_prompt.md` (`| 0NN | P | — |`) and bump its summary line.
-- Run the **full** `python benchmark/scripts/verify_questions.py` (no args) to confirm the whole set, including the new question, still passes with 0 errors.
+- Run the **full** `python benchmark/scripts/verify_questions.py` (no args) to confirm the whole set, including the new question, still passes with 0 errors. **Read the "Structural Near-Duplicate Guard" section** — those are warnings (a reused keyword, an identical `(type, databases, template)` signature, or a 3+ cluster sharing a `(type, database-pair)`); they don't block, but any hit means you should re-examine C26 before considering the question final.
 
 ## Scope boundary
 This skill stops at **approved, validated questions + updated tracker**. It does **not** run `automated_test_runner.py` or `add_llm_evaluation.py` — collecting answers and scoring the new questions is a separate, explicitly-triggered step (it incurs billed API runs).
@@ -73,7 +73,7 @@ This skill stops at **approved, validated questions + updated tracker**. It does
 The canonical, full protocol lives in the repo and overrides anything distilled here if they ever disagree:
 - `benchmark/QA_CREATION_GUIDE.md` — the v5.5.0 protocol
 - `benchmark/QUESTION_FORMAT.md` — the YAML schema
-- `benchmark/togomcp_qa_prompt.md` — the QA review prompt (C01–C25) + progress tracker
+- `benchmark/togomcp_qa_prompt.md` — the QA review prompt (C01–C26) + progress tracker
 
 The `references/` files here are the distilled, in-loop actionable versions; read the canonical doc when a detail is ambiguous.
 

--- a/.claude/skills/qa-generator/references/coverage-gaps.md
+++ b/.claude/skills/qa-generator/references/coverage-gaps.md
@@ -1,0 +1,51 @@
+# Coverage gaps, arithmetic verification & banned entities
+
+The two ways a question silently becomes wrong are **sampling** (querying less than the question claims) and **bad arithmetic** (counts that don't reconcile). These are the CRITICAL categories C02–C06. Treat this file as the gate for Phases 4–5.
+
+## Valid exploration vs. sampling — decision tree
+
+```
+Did you discover entities during exploration?
+├─ NO  → no coverage-gap risk, proceed.
+└─ YES → What does the question ask about?
+         ├─ a SPECIFIC entity you discovered (e.g. "TLR7")
+         │    → query returns ALL of that entity's data  → ✅ VALID
+         └─ ALL / WHICH / HOW MANY entities
+              ├─ query processes ALL discovered entities  → ✅ VALID (comprehensive)
+              └─ query processes a SUBSET                 → ❌ COVERAGE GAP
+```
+
+Rule of thumb: **question scope must equal query scope.** "Which order has the most X" requires checking *every* order, not the few you happened to see.
+
+## The 6 coverage-gap types (C02/C04/C05/C06)
+
+1. **Vocabulary sampling** — using 8 of 36 discovered GO terms (missing 33% of data).
+2. **Entity pre-filtering** — filtering entities without a verification count, then categorizing the incomplete set.
+3. **Database post-selection** — choosing databases because results appeared there during exploration.
+4. **Filter targeting** — filters tuned to match the entities you already found.
+5. **Cross-DB sampling** — `VALUES ?id { <specific IDs from exploration> }` inside a query that claims to be comprehensive.
+6. **Reverse engineering** — question scope wider than query scope (asks about 5 SLE genes, queries 1).
+
+## Arithmetic verification (mandatory for every GROUP BY)
+
+**Checkpoint A — pre-filter count** (when filtering entities):
+```
+COUNT(*) before filter            = A
+COUNT(*) after filter + remainder = B
+A must equal B — if not, the filter dropped entities silently.
+```
+
+**Checkpoint B — post-aggregation** (UNIVERSAL for every GROUP BY):
+```
+Aggregation: SELECT ?cat (COUNT(?e) AS ?n) WHERE {…} GROUP BY ?cat
+Verification: SELECT (COUNT(DISTINCT ?e) AS ?total) WHERE {…same criteria, no GROUP BY…}
+
+sum(?n) == ?total  → ✅ mutually exclusive categories
+sum(?n) >  ?total  → ⚠️  overlap — VALID only if explained in ideal_answer (C20)
+sum(?n) <  ?total  → ❌ COVERAGE GAP — STOP, find the missing entities, fix
+```
+Record the checkpoint (numbers and the verdict) in the question file so a reviewer can re-derive it.
+
+## Banned: famous entities (C07)
+
+Do not build questions around canonically famous examples — they're likely memorized and fail the training test. Explicitly prohibited examples include: **BRCA1, TP53, insulin, aspirin, glycolysis, E. coli K-12**, and obvious peers (hemoglobin, p53 pathway, the lac operon, penicillin, etc.). Prefer less-trodden entities where the answer genuinely depends on current database state.

--- a/.claude/skills/qa-generator/references/qa-checklist.md
+++ b/.claude/skills/qa-generator/references/qa-checklist.md
@@ -27,6 +27,7 @@ Run this as Phase 8 on every candidate, in the voice of a strict reviewer trying
 - **C16 SPARQL fields** — A `sparql_queries` entry missing `query_number`/`database`/`description`/`query`/`result_count`.
 - **C19 Inventory question** — Asks about database structure/metadata ("how many entries does UniProt have…") rather than biology.
 - **C21 Unbounded scope** — `list`/`summary` not 5–100 members and no stated top-N justification.
+- **C26 Structural near-duplicate** — Does this question share its *structure* with an existing one, even under a different keyword? Before presenting, scan the existing questions that share this candidate's `type` and database set, and compare the **query pattern / predicate path / `question_template_used`**, not just the topic. The recurring real failure is "proteins annotated with X → their Rhea reactions" or "pathway enzymes that are ChEMBL drug targets" reused with a new keyword. If a structural twin exists, either change the query shape (different predicate path, different aggregation axis, different databases) or state explicitly in the file how this question differs. The full `verify_questions.py` run flags identical `(type, databases, template)` signatures and duplicate keywords mechanically — this check catches the same-shape/different-words cases a signature can't.
 
 ## 🟡 MINOR — fix or note
 

--- a/.claude/skills/qa-generator/references/qa-checklist.md
+++ b/.claude/skills/qa-generator/references/qa-checklist.md
@@ -1,0 +1,37 @@
+# QA self-review checklist (C01–C25)
+
+Run this as Phase 8 on every candidate, in the voice of a strict reviewer trying to *reject* it. A CRITICAL or MAJOR finding must be fixed before the checkpoint — never present a question you know trips one. Output a verdict: `PASS` | `MINOR` | `MAJOR`, with the triggered codes. (Canonical wording: `benchmark/togomcp_qa_prompt.md`.)
+
+## 🔴 CRITICAL — fix before presenting
+
+- **C01 Circular logic** — Is `ideal_answer` only obtainable by re-running the exact exploration query that built the question? Self-fulfilling questions are invalid.
+- **C02 Coverage gap (scope)** — For "which/how many/list all/yes-no/summary": does the SPARQL cover **all** discovered terms/entities, or only a sampled subset? Question scope must equal query scope.
+- **C03 Arithmetic verification** — Every `GROUP BY`/categorical count needs a `COUNT(DISTINCT)` verification query. `sum == total` (or `sum > total` with overlap explained in `ideal_answer`). Missing verification = fail.
+- **C04 Vocabulary sampling** — Were GO/MONDO/ChEBI/MeSH/EC terms (and their `getDescendants()`) discovered but only *some* placed in `VALUES`? Use all of them.
+- **C05 Unverified filter heuristic** — Entities filtered by taxonomy-ID ranges / name patterns / eyeballing without a `(before) = (filtered) + (remaining)` count check.
+- **C06 Reverse engineering** — Question scope ("SLE-associated genes") broader than what was actually queried (one of several).
+- **C22 Literature-recoverable** — Could PubMed + abstracts fully answer it? Then `rdf_necessity` must be ≥2; flag if 0–1.
+- **C23 Biological insight = 0/1** — Mere inventory of database contents with no mechanistic/functional/evolutionary insight.
+
+## 🟠 MAJOR — fix before presenting
+
+- **C07 Famous entity** — BRCA1, TP53, insulin, aspirin, glycolysis, E. coli K-12, or similar canonical examples (see [coverage-gaps.md](coverage-gaps.md)).
+- **C08 Wrong type** — `type` label doesn't match the actual structure (see schema's type↔structure table).
+- **C09 Type distribution** — Type over the balanced cap (≈ total/5 + 2), or created while another type is under-represented.
+- **C10 Structured-vocab skipped** — `bif:contains`/free-text used where a GO/MONDO/ChEBI/EC/MeSH IRI exists, with no note explaining why no IRI was available.
+- **C11 Descendants not fetched** — Ontology term found but `getDescendants()` not called / descendants not included.
+- **C12 PubMed test invalid** — The test only confirmed the topic exists; it must attempt and fail to retrieve the *specific* answer.
+- **C13 Single database** — Only one DB in `togomcp_databases_used` without documented justification.
+- **C14 Database post-selection** — DBs chosen because results showed up during exploration, not pre-planned for complementarity.
+- **C15 `exact_answer` format** — Wrong shape for the type (see schema).
+- **C16 SPARQL fields** — A `sparql_queries` entry missing `query_number`/`database`/`description`/`query`/`result_count`.
+- **C19 Inventory question** — Asks about database structure/metadata ("how many entries does UniProt have…") rather than biology.
+- **C21 Unbounded scope** — `list`/`summary` not 5–100 members and no stated top-N justification.
+
+## 🟡 MINOR — fix or note
+
+- **C17 RDF triple comments** — A triple without its `# Database: X | Query: N | Comment: ...` annotation.
+- **C18 Vague wording** — `body` uses bind/contain/have/associated-with/interact-with without a qualifier.
+- **C20 Undocumented overlap** — `sum > total` not explained in `ideal_answer`.
+- **C24 Keyword-workflow inversion** — The type feels force-fitted to the keyword (keyword chosen before type/DB).
+- **C25 UniProt cap** — UniProt usage pushed past 70% of the set.

--- a/.claude/skills/qa-generator/references/question-schema.md
+++ b/.claude/skills/qa-generator/references/question-schema.md
@@ -1,0 +1,55 @@
+# Question YAML schema (distilled from QUESTION_FORMAT.md)
+
+`benchmark/scripts/verify_questions.py` enforces all of the structural rules below — run it. The judgment rules (insight, scope, non-circularity) it cannot check; those are in [qa-checklist.md](qa-checklist.md).
+
+## Required top-level fields (every question)
+
+| Field | Type | Rule |
+|---|---|---|
+| `id` | str | `question_XXX`, zero-padded, **must equal the filename stem** |
+| `type` | enum | one of `yes_no`, `factoid`, `list`, `summary`, `choice` |
+| `body` | str | self-contained; specific named entities + qualifiers; **must NOT name a database**; avoid vague verbs ("bind/contain/have/associated with") without a qualifier ("annotated with", "co-crystallized with") |
+| `choices` | list | **only for `type: choice`**; 2–10 items; ≥1 correct |
+| `inspiration_keyword` | map | `keyword_id` (KW-XXXX), `name`, `category` — from `keywords.tsv` |
+| `togomcp_databases_used` | list | ≥1 (≥2 strongly preferred); **every entry must appear as a `database` in `sparql_queries`** |
+| `verification_score` | map | see rubric below |
+| `pubmed_test` | map | `time_spent`, `method`, `result`, `conclusion` (must contain `PASS`) |
+| `sparql_queries` | list | ≥1; each: `query_number` (sequential from 1), `database`, `description`, `query`, `result_count` (int ≥0, the **real** count) |
+| `rdf_triples` | str | Turtle; **every triple line followed by** `# Database: X \| Query: N \| Comment: ...` |
+| `exact_answer` | varies | format by type (below) |
+| `ideal_answer` | str | synthesized expert prose; **no meta-references** ("according to UniProt", "the query", "the database shows"); single paragraph (no blank lines) for `summary` |
+| `question_template_used` | str | name of the template/pattern used |
+| `time_spent` | map | `exploration`, `formulation`, `verification`, `pubmed_test`, `extraction`, `documentation`, `total` |
+
+**Optional:** `documents` (`{pmid, title, url}`), `snippets` (`{text, document, offsetInBeginSection, offsetInEndSection}`) — only if literature is referenced.
+
+## `exact_answer` format by type (validator-enforced)
+
+| Type | Format |
+|---|---|
+| `yes_no` | the string `"yes"` or `"no"` |
+| `factoid` | a single string or number (e.g. `127` or `"JAK2 (UniProt:O60674)"`) |
+| `list` | a YAML array (even for one item) |
+| `choice` | a YAML array; **every item must appear in `choices`** |
+| `summary` | empty string `""` (or null) |
+
+## `verification_score` rubric — must total ≥9 AND no dimension = 0
+
+Each dimension is an integer 0–3; `total` must equal the sum; `passed: true`.
+
+| Dimension | 0 | 1 | 2 | 3 |
+|---|---|---|---|---|
+| `biological_insight` | inventory only | basic | function/properties | mechanism/evolution |
+| `multi_database` | search only | single/weak | 2 databases | 3+ databases |
+| `verifiability` | unbounded | loosely bounded | 6–10 items | ≤5 items or single answer |
+| `rdf_necessity` | PubMed suffices | helpful | significantly enhances | impossible without RDF |
+
+Score honestly from the actual question — do not inflate to clear the gate. A question that can't legitimately reach 9 with no zeros is not a good question; pick a better angle.
+
+## Type ↔ structure compatibility
+
+- `yes_no` — binary existence/property; no enumeration.
+- `factoid` — one retrievable value or count.
+- `list` — an enumerable set, **5–100 members** (or a stated top-N).
+- `summary` — multi-dimensional aggregation across **3+ databases**, answered as **one paragraph**.
+- `choice` — comparison/count among the bounded `choices` options.

--- a/.claude/skills/qa-generator/references/template.yaml
+++ b/.claude/skills/qa-generator/references/template.yaml
@@ -1,0 +1,76 @@
+# Skeleton for a new benchmark question. Fill every field from REAL query
+# results (Hard Rule 1). Delete the inline guidance comments before saving.
+# Validate with: python benchmark/scripts/verify_questions.py <this-file>
+---
+id: question_0NN            # must equal the filename stem
+type: summary              # yes_no | factoid | list | summary | choice
+body: >-                   # self-contained; NO database names; specific entities + qualifiers
+  <the question>
+
+# choices: only for type: choice (2-10 items; >=1 correct)
+# choices:
+#   - "Option A"
+#   - "Option B"
+
+inspiration_keyword:
+  keyword_id: KW-XXXX      # from keywords.tsv, not already in coverage_tracker
+  name: <keyword name>
+  category: <keyword category>
+
+togomcp_databases_used:    # every entry MUST appear as a `database` in sparql_queries
+  - uniprot
+  - go
+
+verification_score:        # each dimension 0-3; total = sum; total >= 9; no zeros; passed: true
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: <e.g. 15 minutes>
+  method: <queries you ran to try to ANSWER the question>
+  result: |
+    <what PubMed returned; why it cannot produce the specific answer>
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# Optional vocabulary-discovery audit block (recommended):
+# STRUCTURED VOCABULARY DISCOVERY — DESCENDANTS CHECKED (OLS4:getDescendants)
+# GO:XXXXXXX (<label>): <N> descendants — all included in VALUES
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: <what this query retrieves>
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      SELECT ... WHERE { ... }
+    result_count: 0          # the REAL count from running it
+
+  # For every GROUP BY query, include its arithmetic-verification query as a
+  # separate entry (Checkpoint B): COUNT(DISTINCT ?entity) over the same
+  # criteria; confirm sum == total in the ideal_answer / a comment.
+
+rdf_triples: |              # Turtle; EVERY triple line followed by a comment
+  @prefix up: <http://purl.uniprot.org/core/> .
+
+  <http://purl.uniprot.org/uniprot/XXXXXX> a up:Protein .
+  # Database: UniProt | Query: 1 | Comment: <what this triple shows>
+
+exact_answer: ""           # yes_no: "yes"/"no" | factoid: value | list/choice: [array] | summary: ""
+
+ideal_answer: |            # synthesized expert prose; NO meta-references;
+  <the answer>            # single paragraph (no blank lines) for summary
+
+question_template_used: <template/pattern name>
+
+time_spent:
+  exploration: <min>
+  formulation: <min>
+  verification: <min>
+  pubmed_test: <min>
+  extraction: <min>
+  documentation: <min>
+  total: <min>

--- a/.claude/skills/qa-generator/references/vocabulary-discovery.md
+++ b/.claude/skills/qa-generator/references/vocabulary-discovery.md
@@ -1,0 +1,39 @@
+# Structured vocabulary discovery (Phase 3)
+
+Resolve every biological concept in the question to a **structured identifier** before writing SPARQL. Free-text matching (`bif:contains`, `regex`, `CONTAINS`) is the last resort and must be justified in the file (C10). This is what makes a question reproducible and its `VALUES` clause exhaustive.
+
+## Resolution hierarchy (try in order)
+
+1. **Ontology IRI** (GO, MONDO, ChEBI, UBERON) via OLS4
+2. **Typed predicate** in the database's MIE file
+3. **Classification code** (EC number, taxon ID)
+4. **Graph navigation** (follow cross-references)
+5. **Text search** — last resort only
+
+## Concept → tool map
+
+| Concept | Source | Tool | Example |
+|---|---|---|---|
+| Molecular function | GO | `OLS4:searchClasses(ontologyId=go)` | "kinase activity" → GO:0016301 |
+| Biological process | GO | `OLS4:searchClasses(ontologyId=go)` | "apoptosis" → GO:0006915 |
+| Cellular component | GO | `OLS4:searchClasses(ontologyId=go)` | "nucleus" → GO:0005634 |
+| Enzyme | EC, GO | `search_rhea_entity`, `OLS4` | "nitrogenase" → EC 1.18.6.1 |
+| Disease | MONDO, MeSH | `OLS4:searchClasses(ontologyId=mondo)`, `search_mesh_descriptor` | "Noonan syndrome" → MONDO:0018955 |
+| Chemical / drug | ChEBI, ChEMBL | `OLS4:searchClasses(ontologyId=chebi)`, `search_chembl_molecule` | "aspirin" → CHEBI:15365 |
+| Pathway | Reactome, GO | `search_reactome_entity` | "glycolysis" → R-HSA-70171 |
+| Anatomy | UBERON | `OLS4:searchClasses(ontologyId=uberon)` | "heart" → UBERON:0000948 |
+| Organism | NCBI Taxonomy | `ncbi_esearch(db=taxonomy)` / TogoID | "E. coli" → taxon:562 |
+
+## Mandatory checkpoint (record in the question file)
+
+For every ontology term used:
+1. Call `OLS4:getDescendants()` (and `getAncestors()` if you need the right level).
+2. Put **all** discovered terms — parent + every descendant — in the SPARQL `VALUES` clause. Using a subset is **C04 (vocabulary sampling)** and silently undercounts.
+3. Document it, e.g. as a comment block in the YAML:
+   ```
+   # STRUCTURED VOCABULARY DISCOVERY — DESCENDANTS CHECKED (OLS4:getDescendants)
+   # GO:0030187 (melatonin biosynthetic process): 0 descendants — leaf, comprehensive
+   # GO:0004059 (aralkylamine N-acetyltransferase activity): 0 descendants
+   ```
+
+If a concept genuinely has no structured IRI (rare), say so explicitly in the file and only then fall back to a justified text search.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,7 +24,7 @@ benchmark/
 │   └── ... (question_001–question_050.yaml)
 ├── scripts/
 │   ├── automated_test_runner.py  # Collects answers from baseline and TogoMCP agents
-│   ├── add_llm_evaluation.py     # Scores collected answers using an LLM judge
+│   ├── add_llm_evaluation.py     # Scores collected answers using Claude Opus as judge
 │   ├── results_analyzer.py       # Statistical analysis of evaluation results
 │   ├── generate_dashboard.py     # Generates HTML evaluation dashboard
 │   ├── verify_questions.py       # Validates question YAML files
@@ -122,14 +122,9 @@ The script runs each question in an isolated session (no conversation history) a
 
 ### Step 4 — LLM Evaluation (initial, llama3.2)
 
-Initial scoring was done with `scripts/add_llm_evaluation.py` using `llama3.2` as the judge:
+> **Note (provenance vs. current tooling):** for the paper, initial scoring used `scripts/add_llm_evaluation.py` with a local `llama3.2` model (Ollama), and those scores were then superseded by a manual Claude Opus re-evaluation on the platform (Step 5). The script has **since been rewritten** to call Claude Opus directly via the Claude API, which collapses Steps 4–5 into one command — see Step 5 for current usage. The `llama3.2` / Ollama path described here is historical.
 
-```bash
-python add_llm_evaluation.py ../results/with_guide-2026-05-04.csv \
-    --llm-model llama3.2
-```
-
-Each answer is scored on four criteria (1–5 each, total 4–20):
+Initial scoring was originally done with a local `llama3.2` judge, scoring each answer on four criteria (1–5 each, total 4–20):
 - **Recall** — completeness relative to the `ideal_answer`
 - **Precision** — relevance of provided information
 - **Non-redundancy** (repetition) — avoidance of repeated content
@@ -140,6 +135,17 @@ These initial scores (`with_guide-2026-05-04.csv`, `ng1-2026-05-04.csv`, `ng2-20
 ### Step 5 — Re-evaluation with Claude Opus
 
 Because the llama3.2 scores were insufficiently reliable, all four conditions were re-evaluated five times each using **Claude Opus** as the judge (250 question–run pairs per condition). The current canonical re-evaluation is the 2026-05-04 batch judged by **Opus 4.7**; the earlier 2026-02–03 batch (judged by Opus 4.6) is preserved under `results/rev0/`.
+
+The paper's Opus re-evaluation was performed manually on the platform (see `results/reevaluation.md`). That process is now automated — `add_llm_evaluation.py` calls Claude Opus through the Claude API with the same four-criteria rubric and forced tool use, producing the same 12 score columns. To reproduce the five-run batch for one condition:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...          # required by the anthropic SDK
+python add_llm_evaluation.py ../results/with_guide-2026-05-04.csv \
+    -o ../results/with_guide-2026-05-04-Opus.csv \
+    --model claude-opus-4-8 --runs 5         # writes ...-Opus-v1.csv … -v5.csv
+```
+
+Use `--model claude-opus-4-7` to match the model used for the paper's canonical batch.
 
 **Current batch — 2026-05-04, judge: Opus 4.7** (results reported in the paper)
 
@@ -186,17 +192,19 @@ See `scripts/CONFIG_FORMAT.md` for the full specification and YAML formatting gu
 | `questions/coverage_tracker.yaml` | Running tally of question type and database usage during creation |
 | `scripts/automated_test_runner.py` | Answer collection script using `claude-agent-sdk` |
 | `scripts/run_all_conditions.sh` | Sequential orchestrator that runs all four conditions for a given date and skips existing outputs |
-| `scripts/add_llm_evaluation.py` | LLM-based scoring using Ollama (initial pass) |
+| `scripts/add_llm_evaluation.py` | Answer scoring with Claude Opus as judge, via the Claude API (forced tool use) |
 
 ---
 
 ## Requirements
 
 ```bash
-pip install 'claude-agent-sdk>=0.1.70' pyyaml pandas ollama
+pip install 'claude-agent-sdk>=0.1.70' anthropic pyyaml pandas
 ```
 
-Both the baseline and TogoMCP conditions now run through the `claude-agent-sdk` (Claude Code CLI), so authentication comes from the CLI: an `ANTHROPIC_API_KEY` environment variable if set, otherwise the CLI's stored login (`claude login` — OAuth/keychain). Setting `ANTHROPIC_API_KEY` is therefore optional but recommended for reproducible, uniformly-billed runs (it forces both conditions onto the same API-billed credential). The `automated_test_runner.py` script requires access to the TogoMCP MCP server at `https://togomcp.rdfportal.org/mcp` (or the staging endpoint at `https://test-togomcp.rdfportal.org/mcp`).
+Both the baseline and TogoMCP conditions now run through the `claude-agent-sdk` (Claude Code CLI), so authentication for `automated_test_runner.py` comes from the CLI: an `ANTHROPIC_API_KEY` environment variable if set, otherwise the CLI's stored login (`claude login` — OAuth/keychain). Setting `ANTHROPIC_API_KEY` is therefore optional but recommended for reproducible, uniformly-billed runs (it forces both conditions onto the same API-billed credential). The `automated_test_runner.py` script requires access to the TogoMCP MCP server at `https://togomcp.rdfportal.org/mcp` (or the staging endpoint at `https://test-togomcp.rdfportal.org/mcp`).
+
+`add_llm_evaluation.py` (the Opus judge) uses the plain `anthropic` SDK instead, which **requires** `ANTHROPIC_API_KEY` (or `ANTHROPIC_AUTH_TOKEN` / an `ant auth login` profile) — it does not read the `claude login` keychain. `ollama` is no longer required: the judge now calls the Claude API directly.
 
 > The baseline previously used the standalone `anthropic` SDK with an explicit `temperature`/`max_tokens`; it now uses the agent SDK like the TogoMCP path so both conditions share identical (CLI-fixed) sampling and differ only in tool availability. The `anthropic` package is no longer required.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -193,10 +193,12 @@ See `scripts/CONFIG_FORMAT.md` for the full specification and YAML formatting gu
 ## Requirements
 
 ```bash
-pip install anthropic 'claude-agent-sdk>=0.1.70' pyyaml pandas ollama
+pip install 'claude-agent-sdk>=0.1.70' pyyaml pandas ollama
 ```
 
-An `ANTHROPIC_API_KEY` environment variable must be set. The `automated_test_runner.py` script requires access to the TogoMCP MCP server at `https://togomcp.rdfportal.org/mcp` (or the staging endpoint at `https://test-togomcp.rdfportal.org/mcp`).
+Both the baseline and TogoMCP conditions now run through the `claude-agent-sdk` (Claude Code CLI), so authentication comes from the CLI: an `ANTHROPIC_API_KEY` environment variable if set, otherwise the CLI's stored login (`claude login` — OAuth/keychain). Setting `ANTHROPIC_API_KEY` is therefore optional but recommended for reproducible, uniformly-billed runs (it forces both conditions onto the same API-billed credential). The `automated_test_runner.py` script requires access to the TogoMCP MCP server at `https://togomcp.rdfportal.org/mcp` (or the staging endpoint at `https://test-togomcp.rdfportal.org/mcp`).
+
+> The baseline previously used the standalone `anthropic` SDK with an explicit `temperature`/`max_tokens`; it now uses the agent SDK like the TogoMCP path so both conditions share identical (CLI-fixed) sampling and differ only in tool availability. The `anthropic` package is no longer required.
 
 > **Pin `claude-agent-sdk>=0.1.70`.** Older versions ship a stale bundled `claude` CLI that silently returns empty responses against the current Anthropic API — the test runner records these as failures with the marker `"Empty response from claude-agent-sdk (no ResultMessage text)"`. If you see that error pattern at high frequency, upgrade with `pip install -U claude-agent-sdk` and verify with `echo "What is 2+2?" | <site-packages>/claude_agent_sdk/_bundled/claude --print`.
 

--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,7 +96,7 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 50
+total_questions: 51
 
 question_types:
   yes_no:
@@ -120,9 +120,9 @@ question_types:
     status: 'at_capacity'  # 10 uses - AT TARGET
 
   choice:
-    count: 10
-    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050']
-    status: 'at_capacity'  # 10 uses - AT TARGET
+    count: 11
+    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051']
+    status: 'ok'  # 11 uses - extending past 50 (target ~total/5)
 
 databases:
   uniprot:
@@ -131,8 +131,8 @@ databases:
     status: 'ok'  # At 44.0%, below 70% cap
 
   rhea:
-    count: 9
-    questions: ['003', '011', '024', '026', '027', '031', '041', '043', '045']
+    count: 10
+    questions: ['003', '011', '024', '026', '027', '031', '041', '043', '045', '051']
     status: 'ok'
 
   pubchem:
@@ -151,8 +151,8 @@ databases:
     status: 'ok'
 
   chebi:
-    count: 5
-    questions: ['004', '011', '024', '043', '045']
+    count: 6
+    questions: ['004', '011', '024', '043', '045', '051']
     status: 'ok'
 
   reactome:
@@ -242,15 +242,15 @@ databases:
 
 multi_database_metrics:
   two_plus_databases:
-    count: 50
-    percentage: 100.0  # 50/50
+    count: 51
+    percentage: 100.0  # 51/51 (Q051 is 2-DB: chebi + rhea)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
     count: 20
     questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049']
-    percentage: 40.0  # 20/50
+    percentage: 39.2  # 20/51 (Q051 is 2-DB, does not add to 3+)
     target: '>= 20%'
     status: 'excellent'
 
@@ -305,6 +305,7 @@ keywords_used:
   - 'KW-0077'  # Bacteriochlorophyll biosynthesis (Q048)
   - 'KW-0147'  # Coenzyme A biosynthesis (Q049)
   - 'KW-0044'  # Antibiotic (Q050)
+  - 'KW-0846'  # Cobalamin (Q051)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_051.yaml
+++ b/benchmark/questions/question_051.yaml
@@ -1,0 +1,231 @@
+id: question_051
+type: choice
+body: >-
+  Cobalamin (vitamin B12) and its derivatives — including cob(I)alamin,
+  cob(II)alamin, adenosylcobalamin, and methylcobalamin — appear as explicit
+  participants in some approved, enzyme-catalysed biochemical reactions. Among
+  approved reactions that carry an Enzyme Commission (EC) number and include a
+  cobalamin species as a reaction participant, which EC top-level enzyme class
+  accounts for the greatest number of distinct reactions?
+
+choices:
+  - "Oxidoreductases (EC 1)"
+  - "Transferases (EC 2)"
+  - "Hydrolases (EC 3)"
+  - "Lyases (EC 4)"
+  - "Isomerases (EC 5)"
+  - "Ligases (EC 6)"
+  - "Translocases (EC 7)"
+
+inspiration_keyword:
+  keyword_id: KW-0846
+  name: Cobalamin
+  category: Ligand
+
+togomcp_databases_used:
+  - chebi
+  - rhea
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 15 minutes
+  method: >-
+    Searched "cobalamin vitamin B12 enzyme EC class distribution reactions"
+    (0 results) and "cobalamin-dependent enzymes reactions review" (12 review
+    articles, e.g. PMIDs 35726326, 30079906, 28167430) to try to determine which
+    EC class accounts for the most cobalamin-participant reactions.
+  result: |
+    The review literature characterises the catalytic uses of vitamin B12 —
+    methylcobalamin-dependent methionine synthase and the adenosylcobalamin-
+    dependent isomerases/mutases (EC 5.4.99.-, e.g. methylmalonyl-CoA mutase).
+    None enumerate, across a reaction database, the EC-class distribution of
+    reactions in which a cobalamin species is an explicit reaction participant.
+    The literature emphasis on mutases would in fact mislead a reader toward
+    isomerases (EC 5), which is the opposite of the database result, because
+    enzyme-bound cobalamin cofactors are regenerated within the catalytic cycle
+    and therefore omitted from those reaction equations.
+  conclusion: PASS (cannot answer from literature - requires RDF reaction-participant modeling)
+
+# STRUCTURED VOCABULARY DISCOVERY — DESCENDANTS CHECKED (OLS4:searchClasses + ChEBI rdfs:subClassOf*)
+# Concept "cobalamin (vitamin B12) cofactor" resolved to the ChEBI class
+# "cobalamins" (CHEBI:23334). Its full subClassOf* closure (Query 1) yields 15
+# distinct entities, ALL of which are used in the Rhea VALUES clause (no sampling):
+#   CHEBI:23334 cobalamins, 30411 cobalamin, 23333 cob(III)alamins,
+#   15982 cob(I)alamin, 16304 cob(II)alamin, 28911 cob(III)alamin,
+#   18408 cobamamide (adenosylcobalamin), 28115 methylcobalamin,
+#   27786 hydroxocobalamin, 15852 aquacob(III)alamin, 17439 cyanocob(III)alamin,
+#   30529 nitritocobalamin, 24339 glutathionylcobalamin, 140785 R-cob(III)alamin,
+#   60493 adenosylcobalamin 5'-phosphate(2-)
+
+# ARITHMETIC VERIFICATION (Checkpoint B — GROUP BY reconciliation)
+#   Query 2 GROUP BY EC top-level class (COUNT DISTINCT reaction):
+#     EC 2 (transferases) = 7; EC 1 = 1; EC 3 = 1; EC 7 = 1; EC 4/5/6 = 0
+#     Sum = 7 + 1 + 1 + 1 = 10
+#   Query 3 independent total: COUNT(DISTINCT ?reaction) = 10
+#   10 = 10 -> mutually exclusive (each reaction carries exactly one EC, all in
+#   distinct classes; no reaction double-counted across classes)
+
+sparql_queries:
+  - query_number: 1
+    database: chebi
+    description: >-
+      Enumerate the full ChEBI "cobalamins" family (CHEBI:23334 and all
+      subclasses) used to define the cobalamin cofactor set.
+    query: |
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?entity ?label
+      FROM <http://rdf.ebi.ac.uk/dataset/chebi>
+      WHERE {
+        ?entity rdfs:subClassOf* obo:CHEBI_23334 ;
+                rdfs:label ?label .
+        FILTER(STRSTARTS(STR(?entity), "http://purl.obolibrary.org/obo/CHEBI_"))
+      }
+      ORDER BY ?label
+    result_count: 15
+
+  - query_number: 2
+    database: rhea
+    description: >-
+      Count distinct approved reactions that carry an EC number and contain a
+      cobalamin species as a participant, grouped by EC top-level class.
+    query: |
+      PREFIX rhea: <http://rdf.rhea-db.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?ecClass (COUNT(DISTINCT ?reaction) AS ?n)
+      WHERE {
+        VALUES ?chebi {
+          obo:CHEBI_140785 obo:CHEBI_60493 obo:CHEBI_15852 obo:CHEBI_15982
+          obo:CHEBI_16304 obo:CHEBI_28911 obo:CHEBI_23333 obo:CHEBI_30411
+          obo:CHEBI_23334 obo:CHEBI_18408 obo:CHEBI_17439 obo:CHEBI_24339
+          obo:CHEBI_27786 obo:CHEBI_28115 obo:CHEBI_30529
+        }
+        ?reaction rdfs:subClassOf rhea:Reaction ;
+                  rhea:status <http://rdf.rhea-db.org/Approved> ;
+                  rhea:ec ?ec ;
+                  rhea:side ?side .
+        ?side rhea:contains ?participant .
+        ?participant rhea:compound ?compound .
+        ?compound rdfs:subClassOf rhea:SmallMolecule ;
+                  rhea:chebi ?chebi .
+        BIND(STRBEFORE(STRAFTER(STR(?ec), "enzyme/"), ".") AS ?ecClass)
+      }
+      GROUP BY ?ecClass
+      ORDER BY DESC(?n)
+    result_count: 4
+
+  - query_number: 3
+    database: rhea
+    description: >-
+      Arithmetic verification (Checkpoint B): total distinct approved
+      EC-annotated reactions containing a cobalamin participant, computed
+      independently of the GROUP BY.
+    query: |
+      PREFIX rhea: <http://rdf.rhea-db.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT (COUNT(DISTINCT ?reaction) AS ?total)
+      WHERE {
+        VALUES ?chebi {
+          obo:CHEBI_140785 obo:CHEBI_60493 obo:CHEBI_15852 obo:CHEBI_15982
+          obo:CHEBI_16304 obo:CHEBI_28911 obo:CHEBI_23333 obo:CHEBI_30411
+          obo:CHEBI_23334 obo:CHEBI_18408 obo:CHEBI_17439 obo:CHEBI_24339
+          obo:CHEBI_27786 obo:CHEBI_28115 obo:CHEBI_30529
+        }
+        ?reaction rdfs:subClassOf rhea:Reaction ;
+                  rhea:status <http://rdf.rhea-db.org/Approved> ;
+                  rhea:ec ?ec ;
+                  rhea:side ?side .
+        ?side rhea:contains ?participant .
+        ?participant rhea:compound ?compound .
+        ?compound rhea:chebi ?chebi .
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix rhea: <http://rdf.rhea-db.org/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix enz: <http://purl.uniprot.org/enzyme/> .
+
+  obo:CHEBI_30411 rdfs:subClassOf obo:CHEBI_23334 .
+  # Database: ChEBI | Query: 1 | Comment: cobalamin is a subclass of the cobalamins family (the cofactor set root)
+
+  obo:CHEBI_18408 rdfs:label "cobamamide" .
+  # Database: ChEBI | Query: 1 | Comment: cobamamide = adenosylcobalamin (CHEBI:18408), a catalytically active B12 form
+
+  obo:CHEBI_28115 rdfs:label "methylcobalamin" .
+  # Database: ChEBI | Query: 1 | Comment: methylcobalamin (CHEBI:28115), the methyl-transfer-active B12 form
+
+  rhea:28671 rdfs:subClassOf rhea:Reaction .
+  # Database: Rhea | Query: 2 | Comment: an approved master (undirected) reaction, counted once
+
+  rhea:28671 rhea:status <http://rdf.rhea-db.org/Approved> .
+  # Database: Rhea | Query: 2 | Comment: only Approved reactions are counted
+
+  rhea:28671 rhea:ec enz:2.5.1.17 .
+  # Database: Rhea | Query: 2 | Comment: EC 2.5.1.17 (cob(II)alamin adenosyltransferase) -> EC class 2 (transferases)
+
+  rhea:28671 rhea:side _:side_28671 .
+  # Database: Rhea | Query: 2 | Comment: reaction->side->contains->compound->chebi is the mandatory participant path
+
+  obo:CHEBI_16304 rdfs:label "cob(II)alamin" .
+  # Database: ChEBI | Query: 1 | Comment: cob(II)alamin (CHEBI:16304) is the cobalamin participant of RHEA:28671
+
+  rhea:16049 rhea:ec enz:2.7.8.26 .
+  # Database: Rhea | Query: 2 | Comment: cobalamin synthase (EC 2.7.8.26, transferase) builds adenosylcobalamin - cofactor biosynthesis
+
+  rhea:16113 rhea:ec enz:1.16.1.6 .
+  # Database: Rhea | Query: 2 | Comment: cyanocobalamin reductase (EC 1.16.1.6) - the single oxidoreductase (EC 1) reaction
+
+  rhea:30367 rhea:ec enz:3.1.3.73 .
+  # Database: Rhea | Query: 2 | Comment: adenosylcobalamin 5'-phosphatase (EC 3.1.3.73) - the single hydrolase (EC 3) reaction
+
+  rhea:17873 rhea:ec enz:7.6.2.8 .
+  # Database: Rhea | Query: 2 | Comment: cobalamin ABC transporter (EC 7.6.2.8) - the single translocase (EC 7) reaction
+
+exact_answer:
+  - "Transferases (EC 2)"
+
+ideal_answer: |
+  Transferases (EC 2) account for the most distinct approved, EC-annotated
+  reactions in which a cobalamin species is an explicit participant: 7 of the 10
+  such reactions, compared with one each for oxidoreductases (EC 1), hydrolases
+  (EC 3), and translocases (EC 7), and none for lyases (EC 4), isomerases
+  (EC 5), or ligases (EC 6). The seven transferase reactions concern the
+  biosynthesis and processing of the cofactor rather than its catalytic use:
+  cob(II)alamin adenosyltransferases (EC 2.5.1.17 and EC 2.5.1.154) that form
+  adenosylcobalamin, adenosylcobinamide-GDP:alpha-ribazole cobalamin synthase
+  (EC 2.7.8.26), and glutathione-dependent alkylcobalamin reductase
+  (EC 2.5.1.151). The most informative result is the complete absence of
+  isomerases: the textbook adenosylcobalamin-dependent mutases (EC 5.4.99.-,
+  such as methylmalonyl-CoA mutase) and the methylcobalamin-dependent methionine
+  synthase do not list a cobalamin as a reaction participant, because the
+  enzyme-bound cofactor shuttles a radical or methyl group and is regenerated
+  within the catalytic cycle rather than consumed. Cobalamin therefore appears in
+  the reaction record chiefly where the cofactor itself is synthesised, reduced
+  (EC 1.16.1.6), dephosphorylated (EC 3.1.3.73), or transported (EC 7.6.2.8), so
+  the enzyme class with the most cobalamin-participant reactions reflects the
+  metabolism of the cofactor, not its catalytic deployment.
+
+question_template_used: Cross-database categorical comparison (which EC class has the most reactions)
+
+time_spent:
+  exploration: 40 minutes
+  formulation: 20 minutes
+  verification: 30 minutes
+  pubmed_test: 15 minutes
+  extraction: 20 minutes
+  documentation: 20 minutes
+  total: 145 minutes

--- a/benchmark/scripts/add_llm_evaluation.py
+++ b/benchmark/scripts/add_llm_evaluation.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Add LLM-Based Evaluation to Test Results
+Add Opus-Based Evaluation to Test Results
 
-This script reads the CSV output from automated_test_runner.py and evaluates
-both baseline and TogoMCP answers against the ideal answer using four criteria:
+Reads the CSV output from automated_test_runner.py and scores both the baseline
+and TogoMCP answers against the ideal answer using four criteria:
     1. Information recall (1-5): Does the answer contain all necessary information?
     2. Information precision (1-5): Does the answer contain only relevant information?
     3. Information repetition (1-5): Does the answer avoid repeating the same information?
@@ -12,20 +12,34 @@ both baseline and TogoMCP answers against the ideal answer using four criteria:
 Each criterion uses a 1-5 scale (1 = very poor, 5 = excellent).
 The total score is the sum of all four criteria (4-20).
 
+This is the automated form of the evaluation previously done by hand on the
+platform (see results/reevaluation.md). It calls the Claude Messages API with
+Claude Opus as the judge and forces a single tool call, so scores come back as
+a validated JSON object — no free-text parsing, no Ollama, no local model.
+
 Usage:
     python add_llm_evaluation.py test_results.csv
     python add_llm_evaluation.py test_results.csv -o evaluated_results.csv
-    python add_llm_evaluation.py test_results.csv --llm-model llama3.2
+    python add_llm_evaluation.py test_results.csv --model claude-opus-4-7
+    # Five independent runs (-> results-v1.csv ... results-v5.csv):
+    python add_llm_evaluation.py test_results.csv -o results.csv --runs 5
+
+Auth: this uses the `anthropic` Python SDK, which requires an ANTHROPIC_API_KEY
+(or ANTHROPIC_AUTH_TOKEN, or an `ant auth login` profile). Note this differs
+from automated_test_runner.py, whose bundled Claude Code CLI can also use the
+`claude login` keychain — the plain SDK does NOT read that keychain, so an API
+key is required here.
 
 Requirements:
-    pip install ollama pandas
+    pip install anthropic pandas
 """
 
 import argparse
+import os
 import sys
+import time
 from pathlib import Path
-from typing import Dict, Optional, Any
-import re
+from typing import Any, Dict, List
 
 try:
     import pandas as pd
@@ -34,88 +48,36 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import ollama
+    import anthropic
+    from pydantic import BaseModel
 except ImportError:
-    print("Error: ollama not installed. Install with: pip install ollama")
+    print("Error: anthropic not installed. Install with: pip install anthropic")
     sys.exit(1)
 
-DEFAULT_MODEL = "llama3.2"
+# Default judge model. claude-opus-4-8 is the current Opus; override with
+# --model (e.g. claude-opus-4-7) to reproduce an earlier evaluation batch.
+DEFAULT_MODEL = "claude-opus-4-8"
 
-class AnswerEvaluator:
-    """Evaluates answer quality using LLM with four criteria."""
-    
-    def __init__(self, model: str = DEFAULT_MODEL):
-        """
-        Initialize answer evaluator.
-        
-        Args:
-            model: Ollama model name for evaluation
-        """
-        self.model = model
-        print(f"Initializing LLM evaluator with model: {model}")
-    
-    def evaluate_answer(
-        self, 
-        answer: str, 
-        ideal_answer: str,
-        question: str = ""
-    ) -> Dict[str, Any]:
-        """
-        Evaluate an answer against the ideal answer using four criteria.
-        
-        Args:
-            answer: The answer to evaluate
-            ideal_answer: The ideal/reference answer
-            question: The original question (for context)
-            
-        Returns:
-            Dict with:
-                - recall_score: int (1-5)
-                - precision_score: int (1-5)
-                - repetition_score: int (1-5)
-                - readability_score: int (1-5)
-                - total_score: int (4-20)
-                - explanation: str (brief explanation)
-                - error: Optional[str]
-        """
-        result = {
-            "recall_score": 1,
-            "precision_score": 1,
-            "repetition_score": 1,
-            "readability_score": 1,
-            "total_score": 4,
-            "explanation": "",
-            "error": None
-        }
-        
-        # Handle empty or error answers
-        if not answer or not ideal_answer:
-            result["error"] = "Empty answer or ideal answer"
-            result["explanation"] = "Cannot evaluate empty text"
-            return result
-        
-        if answer.startswith("[ERROR:") or answer.startswith("[SYSTEM ERROR:"):
-            result["error"] = "Answer contains error"
-            result["explanation"] = "Answer execution failed"
-            return result
-        
-        # Build evaluation prompt
-        prompt = f"""You are an expert evaluator of scientific and biomedical answers. Your task is to evaluate the quality of a given answer by comparing it to an ideal reference answer.
+# ---------------------------------------------------------------------------
+# Rubric — the judge's system prompt. This is the same rubric used for the
+# manual Opus re-evaluation (results/reevaluation.md); structured outputs make
+# the "OUTPUT FORMAT" section from the old prompt unnecessary.
+# ---------------------------------------------------------------------------
+RUBRIC = """You are an expert evaluator of scientific and biomedical answers. \
+Evaluate the quality of a given answer by comparing it to an ideal reference answer.
 
-# EVALUATION CRITERIA
-
-Evaluate the answer on four criteria using a 1-5 scale:
+Score the answer on four criteria, each on a 1-5 scale:
 
 ## 1. INFORMATION RECALL (1-5)
 Does the answer contain all the necessary information from the ideal answer?
-- 5 (Excellent): Contains all key information from ideal answer
+- 5 (Excellent): Contains all key information from the ideal answer
 - 4 (Good): Contains most key information, minor omissions
 - 3 (Adequate): Contains essential information but misses some important details
 - 2 (Poor): Missing significant information
 - 1 (Very Poor): Missing most or all key information
 
 ## 2. INFORMATION PRECISION (1-5)
-Does the answer contain only relevant information, without unnecessary or irrelevant content?
+Does the answer contain only relevant information, without unnecessary content?
 - 5 (Excellent): All information is relevant and on-topic
 - 4 (Good): Mostly relevant with minimal unnecessary content
 - 3 (Adequate): Some irrelevant or tangential information
@@ -138,148 +100,198 @@ Is the answer easily readable, fluent, and well-structured?
 - 2 (Poor): Difficult to read, poor grammar or structure
 - 1 (Very Poor): Nearly unreadable, very poor language quality
 
-# OUTPUT FORMAT
+Be objective and consistent. Judge the answer's content and presentation against \
+the ideal answer, and give a brief (1-2 sentence) explanation for your scores."""
 
-You must respond using this exact format:
 
-RECALL: [score 1-5]
-PRECISION: [score 1-5]
-REPETITION: [score 1-5]
-READABILITY: [score 1-5]
-TOTAL: [sum of all four scores, 4-20]
-EXPLANATION: [Brief 1-2 sentence summary of the evaluation]
+class Evaluation(BaseModel):
+    """Validated judge output. Scores are also clamped to 1-5 after parsing as
+    a belt-and-suspenders guard."""
 
-# INPUT DATA
+    recall: int
+    precision: int
+    repetition: int
+    readability: int
+    explanation: str
 
-## Question (for context)
-{question if question else "Not provided"}
 
-## Ideal Answer (Reference)
-{ideal_answer}
+# Forced-tool-use schema. The judge is required to call this tool (and only
+# this tool), so the response is always a structured object — portable across
+# anthropic SDK versions that predate messages.parse / output_config.
+_SCORE_PROP = {"type": "integer", "enum": [1, 2, 3, 4, 5], "description": "Score from 1 (very poor) to 5 (excellent)"}
+EVAL_TOOL = {
+    "name": "record_evaluation",
+    "description": "Record the four 1-5 criterion scores and a brief explanation for the evaluated answer.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "recall": _SCORE_PROP,
+            "precision": _SCORE_PROP,
+            "repetition": _SCORE_PROP,
+            "readability": _SCORE_PROP,
+            "explanation": {"type": "string", "description": "1-2 sentence justification for the scores"},
+        },
+        "required": ["recall", "precision", "repetition", "readability", "explanation"],
+    },
+}
 
-## Answer to Evaluate
-{answer}
 
-# EVALUATION INSTRUCTIONS
+def _failed_eval(reason: str, explanation: str) -> Dict[str, Any]:
+    """Zero-score result used for un-evaluable or failed rows. A total_score of
+    0 is the sentinel the summary and downstream analyzers use to exclude a
+    row from score statistics."""
+    return {
+        "recall_score": 0,
+        "precision_score": 0,
+        "repetition_score": 0,
+        "readability_score": 0,
+        "total_score": 0,
+        "explanation": explanation,
+        "error": reason,
+    }
 
-1. Read the ideal answer carefully to understand what information should be present
-2. Compare the answer to evaluate against the ideal answer
-3. Assign scores for each of the four criteria
-4. Calculate the total score (sum of all four)
-5. Provide a brief explanation
 
-Be objective and consistent in your scoring. Focus on the quality of the answer content and presentation.
-"""
+class AnswerEvaluator:
+    """Scores answer quality with Claude Opus using four criteria."""
+
+    def __init__(self, model: str = DEFAULT_MODEL):
+        self.model = model
+        self.client = anthropic.Anthropic()
+        # Fail fast with a clear message instead of scoring every row 0 when no
+        # credential is available. The anthropic SDK resolves a key lazily (at
+        # call time), so check up front. `ant auth login` users have a key the
+        # SDK reads — set ANTHROPIC_API_KEY if you don't.
+        has_credential = bool(
+            os.environ.get("ANTHROPIC_API_KEY")
+            or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            or getattr(self.client, "api_key", None)
+            or getattr(self.client, "auth_token", None)
+        )
+        if not has_credential:
+            raise RuntimeError(
+                "No Anthropic credential found. Set ANTHROPIC_API_KEY (or "
+                "ANTHROPIC_AUTH_TOKEN, or run `ant auth login`). The plain "
+                "anthropic SDK does not read the `claude login` keychain."
+            )
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        print(f"Initializing Opus evaluator with model: {model}")
+
+    def evaluate_answer(
+        self,
+        answer: str,
+        ideal_answer: str,
+        question: str = "",
+    ) -> Dict[str, Any]:
+        """Evaluate one answer against the ideal answer.
+
+        Returns a dict with recall_score / precision_score / repetition_score /
+        readability_score / total_score / explanation / error (error is None on
+        success). Scores are 1-5; total_score is their sum (4-20).
+        """
+        if not answer or not ideal_answer:
+            return _failed_eval("Empty answer or ideal answer", "Cannot evaluate empty text")
+        if answer.startswith("[ERROR:") or answer.startswith("[SYSTEM ERROR:"):
+            return _failed_eval("Answer contains error", "Answer execution failed")
+
+        user_content = (
+            "Evaluate the following answer against the ideal reference answer.\n\n"
+            f"## Question\n{question or 'Not provided'}\n\n"
+            f"## Ideal Answer (reference)\n{ideal_answer}\n\n"
+            f"## Answer to Evaluate\n{answer}"
+        )
 
         try:
-            response = ollama.chat(
+            response = self.client.messages.create(
                 model=self.model,
-                messages=[{"role": "user", "content": prompt}],
-                options={"temperature": 0.1}  # Low temperature for consistent evaluation
+                max_tokens=1024,
+                system=[
+                    {
+                        "type": "text",
+                        "text": RUBRIC,
+                        # The rubric is identical across every call; cache it so
+                        # large batches pay for it once. Silently no-ops if the
+                        # rubric is below the model's minimum cacheable prefix.
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+                messages=[{"role": "user", "content": user_content}],
+                tools=[EVAL_TOOL],
+                tool_choice={"type": "tool", "name": "record_evaluation"},
             )
-            
-            # Parse response
-            llm_output = response.get('message', {}).get('content', '')
-            
-            # Extract scores using regex
-            recall_match = re.search(r'RECALL:\s*(\d+)', llm_output, re.IGNORECASE)
-            precision_match = re.search(r'PRECISION:\s*(\d+)', llm_output, re.IGNORECASE)
-            repetition_match = re.search(r'REPETITION:\s*(\d+)', llm_output, re.IGNORECASE)
-            readability_match = re.search(r'READABILITY:\s*(\d+)', llm_output, re.IGNORECASE)
-            total_match = re.search(r'TOTAL:\s*(\d+)', llm_output, re.IGNORECASE)
-            explanation_match = re.search(r'EXPLANATION:\s*(.+?)(?:\n|$)', llm_output, re.IGNORECASE | re.DOTALL)
-            
-            if recall_match:
-                result["recall_score"] = min(5, max(1, int(recall_match.group(1))))
-            if precision_match:
-                result["precision_score"] = min(5, max(1, int(precision_match.group(1))))
-            if repetition_match:
-                result["repetition_score"] = min(5, max(1, int(repetition_match.group(1))))
-            if readability_match:
-                result["readability_score"] = min(5, max(1, int(readability_match.group(1))))
-            
-            # Calculate total (verify against LLM's calculation)
-            calculated_total = (
-                result["recall_score"] + 
-                result["precision_score"] + 
-                result["repetition_score"] + 
-                result["readability_score"]
+
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                self.total_input_tokens += getattr(usage, "input_tokens", 0) or 0
+                self.total_output_tokens += getattr(usage, "output_tokens", 0) or 0
+
+            tool_block = next(
+                (b for b in response.content if getattr(b, "type", None) == "tool_use"),
+                None,
             )
-            
-            if total_match:
-                llm_total = int(total_match.group(1))
-                # Use calculated total if LLM's total doesn't match
-                result["total_score"] = calculated_total
-            else:
-                result["total_score"] = calculated_total
-            
-            if explanation_match:
-                result["explanation"] = explanation_match.group(1).strip()  # Limit length
-                
+            if tool_block is None:
+                return _failed_eval(
+                    "No tool call in response (possible refusal)",
+                    "Judge returned no parseable evaluation",
+                )
+
+            parsed = Evaluation(**tool_block.input)
+            clamp = lambda v: min(5, max(1, int(v)))
+            recall = clamp(parsed.recall)
+            precision = clamp(parsed.precision)
+            repetition = clamp(parsed.repetition)
+            readability = clamp(parsed.readability)
+
+            return {
+                "recall_score": recall,
+                "precision_score": precision,
+                "repetition_score": repetition,
+                "readability_score": readability,
+                "total_score": recall + precision + repetition + readability,
+                "explanation": parsed.explanation.strip(),
+                "error": None,
+            }
+        except (
+            anthropic.AuthenticationError,
+            anthropic.PermissionDeniedError,
+            anthropic.NotFoundError,
+        ):
+            # Bad key / no access / wrong --model would fail identically on
+            # every row — abort the whole run instead of zeroing all rows.
+            raise
         except Exception as e:
-            result["error"] = str(e)
-            result["explanation"] = f"Evaluation failed: {str(e)}"
-        
-        return result
+            return _failed_eval(str(e), f"Evaluation failed: {e}")
 
 
 def evaluate_row(
-    row: Dict, 
+    row: Dict,
     evaluator: AnswerEvaluator,
-    verbose: bool = False
-) -> Dict[str, Any]:   
-    """
-    Evaluate a single row from the results CSV.
-    
-    Args:
-        row: Dictionary containing CSV row data
-        evaluator: AnswerEvaluator instance
-        verbose: Print detailed progress
-        
-    Returns:
-        Dict with new columns to add for both baseline and TogoMCP
-    """
-    question = str(row.get('question', ''))
-    ideal_answer = str(row.get('ideal_answer', ''))
-    baseline_answer = str(row.get('baseline_answer', ''))
-    togomcp_answer = str(row.get('togomcp_answer', ''))
-    
-    baseline_success = str(row.get('baseline_success', 'True')).lower() == 'true'
-    togomcp_success = str(row.get('togomcp_success', 'True')).lower() == 'true'
-    
-    # Evaluate baseline answer
-    if baseline_success and baseline_answer and not baseline_answer.startswith('[ERROR'):
+    verbose: bool = False,
+) -> Dict[str, Any]:
+    """Evaluate the baseline and TogoMCP answers from one CSV row."""
+    question = str(row.get("question", ""))
+    ideal_answer = str(row.get("ideal_answer", ""))
+    baseline_answer = str(row.get("baseline_answer", ""))
+    togomcp_answer = str(row.get("togomcp_answer", ""))
+
+    baseline_success = str(row.get("baseline_success", "True")).lower() == "true"
+    togomcp_success = str(row.get("togomcp_success", "True")).lower() == "true"
+
+    if baseline_success and baseline_answer and not baseline_answer.startswith("[ERROR"):
         if verbose:
             print("    Evaluating baseline answer...")
         baseline_eval = evaluator.evaluate_answer(baseline_answer, ideal_answer, question)
     else:
-        baseline_eval = {
-            "recall_score": 0,
-            "precision_score": 0,
-            "repetition_score": 0,
-            "readability_score": 0,
-            "total_score": 0,
-            "explanation": "Answer failed or contains error",
-            "error": "Execution failed"
-        }
-    
-    # Evaluate TogoMCP answer
-    if togomcp_success and togomcp_answer and not togomcp_answer.startswith('[ERROR'):
+        baseline_eval = _failed_eval("Execution failed", "Answer failed or contains error")
+
+    if togomcp_success and togomcp_answer and not togomcp_answer.startswith("[ERROR"):
         if verbose:
             print("    Evaluating TogoMCP answer...")
         togomcp_eval = evaluator.evaluate_answer(togomcp_answer, ideal_answer, question)
     else:
-        togomcp_eval = {
-            "recall_score": 0,
-            "precision_score": 0,
-            "repetition_score": 0,
-            "readability_score": 0,
-            "total_score": 0,
-            "explanation": "Answer failed or contains error",
-            "error": "Execution failed"
-        }
-    
-    result = {
+        togomcp_eval = _failed_eval("Execution failed", "Answer failed or contains error")
+
+    return {
         # Baseline scores
         "baseline_recall": baseline_eval["recall_score"],
         "baseline_precision": baseline_eval["precision_score"],
@@ -287,7 +299,6 @@ def evaluate_row(
         "baseline_readability": baseline_eval["readability_score"],
         "baseline_total_score": baseline_eval["total_score"],
         "baseline_evaluation_explanation": baseline_eval["explanation"],
-        
         # TogoMCP scores
         "togomcp_recall": togomcp_eval["recall_score"],
         "togomcp_precision": togomcp_eval["precision_score"],
@@ -296,44 +307,27 @@ def evaluate_row(
         "togomcp_total_score": togomcp_eval["total_score"],
         "togomcp_evaluation_explanation": togomcp_eval["explanation"],
     }
-    
-    return result
 
 
 def process_csv(
-    input_path: Path, 
-    output_path: Optional[Path], 
+    input_path: Path,
+    output_path: Path,
     evaluator: AnswerEvaluator,
-    verbose: bool = True
+    verbose: bool = True,
 ) -> pd.DataFrame:
-    """
-    Process a CSV file and add evaluation columns.
-    
-    Args:
-        input_path: Path to input CSV file
-        output_path: Path to output CSV file (None = modify in place)
-        evaluator: AnswerEvaluator instance
-        verbose: Print progress
-        
-    Returns:
-        DataFrame with added evaluation columns
-    """
+    """Read a results CSV, add the 12 evaluation columns, and write it out."""
     if verbose:
-        print(f"\nProcessing: {input_path}")
-    
-    # Read CSV
+        print(f"\nProcessing: {input_path} -> {output_path}")
+
     df = pd.read_csv(input_path)
-    
+
     if verbose:
         print(f"  Found {len(df)} rows")
-        
-        # Check for existing evaluation columns
-        eval_columns = [col for col in df.columns if 'recall' in col or 'precision' in col or 'total_score' in col]
+        eval_columns = [c for c in df.columns if "recall" in c or "precision" in c or "total_score" in c]
         if eval_columns:
-            print(f"  Warning: Found existing evaluation columns - they will be overwritten")
-    
-    # New columns to add
-    new_columns = {
+            print("  Warning: existing evaluation columns will be overwritten")
+
+    new_columns: Dict[str, list] = {
         "baseline_recall": [],
         "baseline_precision": [],
         "baseline_repetition": [],
@@ -347,35 +341,27 @@ def process_csv(
         "togomcp_total_score": [],
         "togomcp_evaluation_explanation": [],
     }
-    
-    # Process each row
+
     for idx, row in df.iterrows():
         if verbose:
-            question_id = row.get('question_id', idx)
-            print(f"  Evaluating {question_id}...", end=" ")
-        
+            print(f"  Evaluating {row.get('question_id', idx)}...", end=" ")
+
         result = evaluate_row(row.to_dict(), evaluator, verbose=False)
-        
         for col, value in result.items():
-            if col in new_columns:
-                new_columns[col].append(value)
-        
+            new_columns[col].append(value)
+
         if verbose:
-            baseline_total = result.get("baseline_total_score", 0)
-            togomcp_total = result.get("togomcp_total_score", 0)
-            print(f"Baseline: {baseline_total}/20, TogoMCP: {togomcp_total}/20")
-    
-    # Add new columns to DataFrame
+            print(
+                f"Baseline: {result['baseline_total_score']}/20, "
+                f"TogoMCP: {result['togomcp_total_score']}/20"
+            )
+
     for col, values in new_columns.items():
         df[col] = values
-    
-    # Save to output
-    save_path = output_path or input_path
-    df.to_csv(save_path, index=False)
-    
+
+    df.to_csv(output_path, index=False)
     if verbose:
-        print(f"\n  ✓ Saved to: {save_path}")
-    
+        print(f"  Saved to: {output_path}")
     return df
 
 
@@ -384,138 +370,124 @@ def print_summary(df: pd.DataFrame, filename: str):
     print(f"\n{'='*70}")
     print(f"Evaluation Summary: {filename}")
     print(f"{'='*70}")
-    
+
     total = len(df)
-    
-    # Success statistics
-    if 'baseline_success' in df.columns:
-        baseline_success = (df['baseline_success'] == True).sum()
-        togomcp_success = (df['togomcp_success'] == True).sum()
-        print(f"\nExecution Success:")
+
+    if "baseline_success" in df.columns:
+        baseline_success = (df["baseline_success"] == True).sum()
+        togomcp_success = (df["togomcp_success"] == True).sum()
+        print("\nExecution Success:")
         print(f"  Baseline:  {baseline_success:3d}/{total} ({100*baseline_success/total:.1f}%)")
         print(f"  TogoMCP:   {togomcp_success:3d}/{total} ({100*togomcp_success/total:.1f}%)")
-    
-    # Score statistics (only for successful executions with score > 0)
-    baseline_evaluated = df[df['baseline_total_score'] > 0]
-    togomcp_evaluated = df[df['togomcp_total_score'] > 0]
-    
+
+    baseline_evaluated = df[df["baseline_total_score"] > 0]
+    togomcp_evaluated = df[df["togomcp_total_score"] > 0]
+
     if len(baseline_evaluated) > 0:
         print(f"\nBaseline Scores (n={len(baseline_evaluated)}):")
-        print(f"  Recall:      {baseline_evaluated['baseline_recall'].mean():.2f} ± {baseline_evaluated['baseline_recall'].std():.2f}")
-        print(f"  Precision:   {baseline_evaluated['baseline_precision'].mean():.2f} ± {baseline_evaluated['baseline_precision'].std():.2f}")
-        print(f"  Repetition:  {baseline_evaluated['baseline_repetition'].mean():.2f} ± {baseline_evaluated['baseline_repetition'].std():.2f}")
-        print(f"  Readability: {baseline_evaluated['baseline_readability'].mean():.2f} ± {baseline_evaluated['baseline_readability'].std():.2f}")
-        print(f"  Total:       {baseline_evaluated['baseline_total_score'].mean():.2f} ± {baseline_evaluated['baseline_total_score'].std():.2f} (out of 20)")
-    
+        for dim in ("recall", "precision", "repetition", "readability"):
+            col = f"baseline_{dim}"
+            print(f"  {dim.capitalize():12s} {baseline_evaluated[col].mean():.2f} ± {baseline_evaluated[col].std():.2f}")
+        print(f"  {'Total':12s} {baseline_evaluated['baseline_total_score'].mean():.2f} ± {baseline_evaluated['baseline_total_score'].std():.2f} (out of 20)")
+
     if len(togomcp_evaluated) > 0:
         print(f"\nTogoMCP Scores (n={len(togomcp_evaluated)}):")
-        print(f"  Recall:      {togomcp_evaluated['togomcp_recall'].mean():.2f} ± {togomcp_evaluated['togomcp_recall'].std():.2f}")
-        print(f"  Precision:   {togomcp_evaluated['togomcp_precision'].mean():.2f} ± {togomcp_evaluated['togomcp_precision'].std():.2f}")
-        print(f"  Repetition:  {togomcp_evaluated['togomcp_repetition'].mean():.2f} ± {togomcp_evaluated['togomcp_repetition'].std():.2f}")
-        print(f"  Readability: {togomcp_evaluated['togomcp_readability'].mean():.2f} ± {togomcp_evaluated['togomcp_readability'].std():.2f}")
-        print(f"  Total:       {togomcp_evaluated['togomcp_total_score'].mean():.2f} ± {togomcp_evaluated['togomcp_total_score'].std():.2f} (out of 20)")
-    
-    # Comparison (for successfully evaluated pairs)
-    both_evaluated = df[(df['baseline_total_score'] > 0) & (df['togomcp_total_score'] > 0)]
-    if len(both_evaluated) > 0:
-        print(f"\nComparative Analysis (n={len(both_evaluated)} pairs):")
-        score_diff = both_evaluated['togomcp_total_score'] - both_evaluated['baseline_total_score']
-        togomcp_better = (score_diff > 0).sum()
-        baseline_better = (score_diff < 0).sum()
-        tied = (score_diff == 0).sum()
-        
-        print(f"  TogoMCP better:  {togomcp_better:3d} ({100*togomcp_better/len(both_evaluated):.1f}%)")
-        print(f"  Baseline better: {baseline_better:3d} ({100*baseline_better/len(both_evaluated):.1f}%)")
-        print(f"  Tied:            {tied:3d} ({100*tied/len(both_evaluated):.1f}%)")
-        print(f"  Mean difference: {score_diff.mean():+.2f} (TogoMCP - Baseline)")
-    
+        for dim in ("recall", "precision", "repetition", "readability"):
+            col = f"togomcp_{dim}"
+            print(f"  {dim.capitalize():12s} {togomcp_evaluated[col].mean():.2f} ± {togomcp_evaluated[col].std():.2f}")
+        print(f"  {'Total':12s} {togomcp_evaluated['togomcp_total_score'].mean():.2f} ± {togomcp_evaluated['togomcp_total_score'].std():.2f} (out of 20)")
+
+    both = df[(df["baseline_total_score"] > 0) & (df["togomcp_total_score"] > 0)]
+    if len(both) > 0:
+        diff = both["togomcp_total_score"] - both["baseline_total_score"]
+        print(f"\nComparative Analysis (n={len(both)} pairs):")
+        print(f"  TogoMCP better:  {(diff > 0).sum():3d} ({100*(diff > 0).sum()/len(both):.1f}%)")
+        print(f"  Baseline better: {(diff < 0).sum():3d} ({100*(diff < 0).sum()/len(both):.1f}%)")
+        print(f"  Tied:            {(diff == 0).sum():3d} ({100*(diff == 0).sum()/len(both):.1f}%)")
+        print(f"  Mean difference: {diff.mean():+.2f} (TogoMCP - Baseline)")
+
     print(f"{'='*70}\n")
+
+
+def _versioned_paths(base: Path, runs: int) -> List[Path]:
+    """For runs>1, derive `<stem>-v1<suffix>` ... `<stem>-vN<suffix>` so the
+    output matches the v1..v5 naming used in results/reevaluation.md."""
+    if runs <= 1:
+        return [base]
+    return [base.with_name(f"{base.stem}-v{i}{base.suffix}") for i in range(1, runs + 1)]
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Add LLM-based evaluation scores to test results CSV",
+        description="Add Opus-based evaluation scores to a test-results CSV",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Evaluation Criteria:
-  1. Information Recall (1-5): Completeness of necessary information
-  2. Information Precision (1-5): Relevance of provided information
-  3. Information Repetition (1-5): Avoidance of redundancy
-  4. Readability (1-5): Clarity and fluency
-  Total Score: Sum of all four criteria (4-20)
+Evaluation Criteria (each 1-5; total 4-20):
+  1. Information Recall      - completeness of necessary information
+  2. Information Precision   - relevance of provided information
+  3. Information Repetition  - avoidance of redundancy
+  4. Readability             - clarity and fluency
 
 Examples:
   python add_llm_evaluation.py test_results.csv
   python add_llm_evaluation.py test_results.csv -o evaluated.csv
-  python add_llm_evaluation.py test_results.csv --llm-model llama3.2
-        """
+  python add_llm_evaluation.py test_results.csv --model claude-opus-4-7
+  python add_llm_evaluation.py test_results.csv -o results.csv --runs 5
+        """,
     )
+    parser.add_argument("input_file", help="Input CSV file from automated_test_runner.py")
+    parser.add_argument("-o", "--output", help="Output CSV file (default: overwrite input file)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Claude judge model (default: {DEFAULT_MODEL})")
     parser.add_argument(
-        "input_file",
-        help="Input CSV file from automated_test_runner.py"
+        "--runs",
+        type=int,
+        default=1,
+        help="Number of independent evaluation passes. >1 writes <output>-v1..-vN.csv",
     )
-    parser.add_argument(
-        "-o", "--output",
-        help="Output CSV file (default: overwrite input file)"
-    )
-    parser.add_argument(
-        "--llm-model",
-        default=DEFAULT_MODEL,
-        help=f"Ollama model for evaluation (default: {DEFAULT_MODEL})"
-    )
-    parser.add_argument(
-        "-q", "--quiet",
-        action="store_true",
-        help="Suppress progress output"
-    )
-    parser.add_argument(
-        "--no-summary",
-        action="store_true",
-        help="Don't print summary statistics"
-    )
-    
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    parser.add_argument("--no-summary", action="store_true", help="Don't print summary statistics")
+
     args = parser.parse_args()
-    
-    # Validate input file
+
     input_path = Path(args.input_file)
     if not input_path.exists():
         print(f"Error: File not found: {input_path}")
         sys.exit(1)
-    
-    # Initialize evaluator
+    if args.runs < 1:
+        print("Error: --runs must be >= 1")
+        sys.exit(1)
+
     try:
-        evaluator = AnswerEvaluator(model=args.llm_model)
+        evaluator = AnswerEvaluator(model=args.model)
     except Exception as e:
         print(f"Error initializing evaluator: {e}")
-        print("Make sure Ollama is running and the model is available.")
-        print(f"Try: ollama pull {args.llm_model}")
+        print("Set ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN / `ant auth login`).")
         sys.exit(1)
-    
-    # Process file
-    output_path = Path(args.output) if args.output else None
-    
-    try:
-        df = process_csv(
-            input_path, 
-            output_path, 
-            evaluator,
-            verbose=not args.quiet
-        )
-    except Exception as e:
-        print(f"Error processing CSV: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
-    
-    # Print summary
-    if not args.no_summary:
-        print_summary(df, input_path.name)
-    
-    print(f"✓ Evaluation complete!")
-    if output_path:
-        print(f"  Results saved to: {output_path}")
-    else:
-        print(f"  Results saved to: {input_path}")
+
+    base_output = Path(args.output) if args.output else input_path
+    output_paths = _versioned_paths(base_output, args.runs)
+
+    start = time.time()
+    for run_idx, out_path in enumerate(output_paths, start=1):
+        if args.runs > 1 and not args.quiet:
+            print(f"\n=== Evaluation run {run_idx}/{args.runs} ===")
+        try:
+            df = process_csv(input_path, out_path, evaluator, verbose=not args.quiet)
+        except Exception as e:
+            print(f"Error processing CSV: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+        if not args.no_summary:
+            print_summary(df, out_path.name)
+
+    elapsed = time.time() - start
+    print("✓ Evaluation complete!")
+    print(f"  Runs: {args.runs} | Output: {', '.join(p.name for p in output_paths)}")
+    print(
+        f"  Judge tokens: {evaluator.total_input_tokens:,} in / "
+        f"{evaluator.total_output_tokens:,} out | Wall time: {elapsed:.1f}s"
+    )
 
 
 if __name__ == "__main__":

--- a/benchmark/scripts/automated_test_runner.py
+++ b/benchmark/scripts/automated_test_runner.py
@@ -1113,6 +1113,15 @@ Pricing config (add to config.yaml to override defaults):
         help="Output path for results CSV",
         default="test_results.csv"
     )
+    parser.add_argument(
+        "--model",
+        help=(
+            "Model ID for both baseline and TogoMCP calls. Overrides any "
+            "'model' in the config file, which overrides the built-in default. "
+            "Lets you set the model once (e.g. for run_all_conditions.sh) "
+            "instead of editing every config*.yaml."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1128,6 +1137,11 @@ Pricing config (add to config.yaml to override defaults):
     except Exception as e:
         print(f"✗ Error initializing runner: {e}")
         sys.exit(1)
+
+    # Precedence: --model > config 'model' > built-in default_config.
+    if args.model:
+        runner.config["model"] = args.model
+        logger.info(f"Model set from --model: {args.model}")
 
     try:
         questions = runner.load_questions(args.question_files)

--- a/benchmark/scripts/automated_test_runner.py
+++ b/benchmark/scripts/automated_test_runner.py
@@ -66,13 +66,6 @@ except ImportError:
     print("Install with: pip install claude-agent-sdk")
     sys.exit(1)
 
-try:
-    import anthropic
-except ImportError:
-    print("Error: anthropic package not installed (for baseline tests).")
-    print("Install with: pip install anthropic")
-    sys.exit(1)
-
 import logging
 
 # Configure logging
@@ -162,23 +155,29 @@ Provide your answer as a single, well-formed paragraph that directly answers the
 Simply provide the factual answer as you would write an encyclopedia entry."""
 
     def __init__(self, config_path: Optional[str] = None):
-        """Initialize runner with configuration."""
+        """Initialize runner with configuration.
+
+        Both baseline and TogoMCP calls now run through the claude-agent-sdk
+        (Claude Code CLI), so authentication comes from the CLI itself: an
+        ANTHROPIC_API_KEY environment variable if set, otherwise the CLI's
+        stored login (OAuth / keychain). We therefore no longer require
+        ANTHROPIC_API_KEY up front; if no usable credential exists at all,
+        the SDK call fails and is reported per-question.
+        """
         self.config = self._load_config(config_path)
-        self.api_key = os.environ.get("ANTHROPIC_API_KEY")
-
-        if not self.api_key:
-            raise ValueError(
-                "ANTHROPIC_API_KEY environment variable not set. "
-                "Please set it with your API key."
-            )
-
-        self.baseline_client = anthropic.Anthropic(api_key=self.api_key)
         self.results = []
 
     def _load_config(self, config_path: Optional[str]) -> Dict:
         """Load configuration from YAML or JSON file, or use defaults."""
         default_config = {
             "model": "claude-sonnet-4-5-20250929",
+            # NOTE: max_tokens / temperature are retained for reference only.
+            # Both baseline and TogoMCP now run through the claude-agent-sdk
+            # (Claude Code CLI), which does NOT expose these sampling params,
+            # so they are no longer applied to either call. This is exactly
+            # what makes the two conditions comparable: identical (CLI-fixed)
+            # sampling, differing only in tool availability. Kept here so
+            # pre-existing config files that set them still load cleanly.
             "max_tokens": 4000,
             "temperature": 1.0,
             # ------------------------------------------------------------------
@@ -307,12 +306,38 @@ Simply provide the factual answer as you would write an encyclopedia entry."""
         return all_questions
 
     # ------------------------------------------------------------------
-    # Baseline call (Anthropic SDK – usage always available)
+    # Baseline call (claude-agent-sdk, no tools)
     # ------------------------------------------------------------------
 
-    def _make_baseline_call(self, question_text: str, answer_instruction: str = "") -> Dict:
+    async def _deny_all_tools(
+        self,
+        tool_name: str,
+        input_data: dict,
+        context: ToolPermissionContext
+    ) -> PermissionResultDeny:
+        """Deny every tool call: the baseline condition runs with no tools.
+
+        `allowed_tools=[]` only hides tool *definitions* from the model; the
+        SDK still exposes built-in agent tools (Read, Write, Bash, …) that the
+        model could attempt. This gate guarantees the baseline answer is built
+        purely from training knowledge, mirroring the safeguard the TogoMCP
+        path uses in `_auto_approve_mcp_tools`.
         """
-        Make baseline API call (no tools).
+        return PermissionResultDeny(
+            message="Baseline condition: no tools are available; answer from knowledge."
+        )
+
+    async def _make_baseline_call(self, question_text: str, answer_instruction: str = "") -> Dict:
+        """
+        Make baseline call (no tools) via the claude-agent-sdk / Claude Code CLI.
+
+        Routed through the SAME SDK and CLI as the TogoMCP call so both
+        conditions share identical sampling settings (the CLI's fixed
+        temperature/max_tokens, which are not externally configurable),
+        authentication, and cost accounting. The ONLY difference from the
+        TogoMCP call is tool availability: baseline registers no MCP servers,
+        advertises no tools, denies every tool attempt, and is capped at a
+        single turn.
 
         Returns dict with:
             - success: bool
@@ -331,38 +356,97 @@ Simply provide the factual answer as you would write an encyclopedia entry."""
         full_prompt = question_text + answer_instruction
 
         try:
-            response = self.baseline_client.messages.create(
+            options = ClaudeAgentOptions(
+                system_prompt=self.config["baseline_system_prompt"],
                 model=self.config["model"],
-                max_tokens=self.config["max_tokens"],
-                temperature=self.config["temperature"],
-                system=self.config["baseline_system_prompt"],
-                messages=[{"role": "user", "content": full_prompt}]
+                mcp_servers={},          # no database access
+                allowed_tools=[],        # advertise no tools to the model
+                disallowed_tools=self.config["disallowed_tools"],
+                can_use_tool=self._deny_all_tools,
+                max_turns=1,             # single-shot answer, no tool loop
+                # Same hermeticity guard as the TogoMCP path: do not inherit
+                # MCP servers / settings from ~/.claude or project .claude.
+                setting_sources=[],
             )
+
+            final_text   = None
+            total_input  = 0
+            total_output = 0
+            usage_found  = False
+            cost_usd     = 0.0
+            use_cli_cost = False
+
+            async with ClaudeSDKClient(options=options) as client:
+                await asyncio.wait_for(
+                    client.query(full_prompt),
+                    timeout=self.config["timeout"]
+                )
+
+                gen = aiter(client.receive_response())
+                while True:
+                    try:
+                        message = await asyncio.wait_for(
+                            anext(gen),
+                            timeout=self.config["timeout"]
+                        )
+                    except StopAsyncIteration:
+                        break
+
+                    usage = _extract_usage_from_obj(message)
+                    if usage:
+                        total_input  += usage["input_tokens"]
+                        total_output += usage["output_tokens"]
+                        usage_found   = True
+
+                    if isinstance(message, ResultMessage):
+                        if hasattr(message, 'result') and isinstance(message.result, str):
+                            final_text = message.result
+                        cli_cost = getattr(message, 'total_cost_usd', None)
+                        if cli_cost is not None:
+                            cost_usd = float(cli_cost)
+                            use_cli_cost = True
 
             elapsed_time = time.time() - start_time
 
-            text_content = [
-                block.text
-                for block in response.content
-                if block.type == "text"
-            ]
+            if not usage_found:
+                logger.warning(
+                    "Baseline: token usage not found in SDK response messages. "
+                    "Token counts will be 0."
+                )
 
-            input_tokens  = response.usage.input_tokens
-            output_tokens = response.usage.output_tokens
-            cost_usd = _calc_cost(input_tokens, output_tokens, self.config["pricing"])
+            if not use_cli_cost:
+                cost_usd = _calc_cost(total_input, total_output, self.config["pricing"])
+
+            # Treat an empty answer as a failure, same as the TogoMCP path: an
+            # empty ResultMessage usually means the subprocess died mid-stream
+            # and the SDK didn't raise.
+            if not final_text or not final_text.strip():
+                return {
+                    "success": False,
+                    "error": (
+                        "Empty response from claude-agent-sdk (baseline, no "
+                        "ResultMessage text). Likely subprocess failure — "
+                        "check test_runner.log."
+                    ),
+                    "elapsed_time": elapsed_time,
+                    "input_tokens": total_input,
+                    "output_tokens": total_output,
+                    "cost_usd": cost_usd,
+                }
 
             return {
                 "success": True,
-                "text": "\n".join(text_content),
+                "text": final_text,
                 "elapsed_time": elapsed_time,
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
+                "input_tokens": total_input,
+                "output_tokens": total_output,
                 "cost_usd": cost_usd,
             }
 
         except Exception as e:
             elapsed_time = time.time() - start_time
-            logger.error(f"Baseline call failed: {e}")
+            import traceback
+            logger.error(f"Baseline call failed: {str(e)}\n{traceback.format_exc()}")
             return {
                 "success": False,
                 "error": str(e),
@@ -726,7 +810,7 @@ Simply provide the factual answer as you would write an encyclopedia entry."""
 
         # === Baseline Test (No Tools) ===
         print("  ⏳ Running baseline test (no tools)...")
-        baseline_result = self._make_baseline_call(q_body, answer_instruction)
+        baseline_result = await self._make_baseline_call(q_body, answer_instruction)
 
         if baseline_result["success"]:
             print(

--- a/benchmark/scripts/automated_test_runner.py
+++ b/benchmark/scripts/automated_test_runner.py
@@ -171,15 +171,10 @@ Simply provide the factual answer as you would write an encyclopedia entry."""
         """Load configuration from YAML or JSON file, or use defaults."""
         default_config = {
             "model": "claude-sonnet-4-5-20250929",
-            # NOTE: max_tokens / temperature are retained for reference only.
-            # Both baseline and TogoMCP now run through the claude-agent-sdk
-            # (Claude Code CLI), which does NOT expose these sampling params,
-            # so they are no longer applied to either call. This is exactly
-            # what makes the two conditions comparable: identical (CLI-fixed)
-            # sampling, differing only in tool availability. Kept here so
-            # pre-existing config files that set them still load cleanly.
-            "max_tokens": 4000,
-            "temperature": 1.0,
+            # NOTE: sampling params (max_tokens / temperature) are intentionally
+            # absent. Both baseline and TogoMCP run through the claude-agent-sdk
+            # (Claude Code CLI), which does not expose them, so the two conditions
+            # share identical CLI-fixed sampling and differ only in tool access.
             # ------------------------------------------------------------------
             # Pricing (USD per 1 million tokens).
             # Defaults match Claude Sonnet 4.5 list prices; override in config.yaml

--- a/benchmark/scripts/config.yaml
+++ b/benchmark/scripts/config.yaml
@@ -6,8 +6,6 @@
 # - |- (pipe dash): Like |, but strips final newlines
 # - >- (greater dash): Like >, but strips final newlines
 
-model: claude-sonnet-4-5-20250929
-
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)
 # ---------------------------------------------------------------------------

--- a/benchmark/scripts/config.yaml
+++ b/benchmark/scripts/config.yaml
@@ -7,8 +7,6 @@
 # - >- (greater dash): Like >, but strips final newlines
 
 model: claude-sonnet-4-5-20250929
-max_tokens: 4000
-temperature: 1.0
 
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)

--- a/benchmark/scripts/config_no_guide1.yaml
+++ b/benchmark/scripts/config_no_guide1.yaml
@@ -6,8 +6,6 @@
 # - |- (pipe dash): Like |, but strips final newlines
 # - >- (greater dash): Like >, but strips final newlines
 
-model: claude-sonnet-4-5-20250929
-
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)
 # ---------------------------------------------------------------------------

--- a/benchmark/scripts/config_no_guide1.yaml
+++ b/benchmark/scripts/config_no_guide1.yaml
@@ -7,8 +7,6 @@
 # - >- (greater dash): Like >, but strips final newlines
 
 model: claude-sonnet-4-5-20250929
-max_tokens: 4000
-temperature: 1.0
 
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)

--- a/benchmark/scripts/config_no_guide2.yaml
+++ b/benchmark/scripts/config_no_guide2.yaml
@@ -6,8 +6,6 @@
 # - |- (pipe dash): Like |, but strips final newlines
 # - >- (greater dash): Like >, but strips final newlines
 
-model: claude-sonnet-4-5-20250929
-
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)
 # ---------------------------------------------------------------------------

--- a/benchmark/scripts/config_no_guide2.yaml
+++ b/benchmark/scripts/config_no_guide2.yaml
@@ -7,8 +7,6 @@
 # - >- (greater dash): Like >, but strips final newlines
 
 model: claude-sonnet-4-5-20250929
-max_tokens: 4000
-temperature: 1.0
 
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)

--- a/benchmark/scripts/config_no_guide2_no_test_server.yaml
+++ b/benchmark/scripts/config_no_guide2_no_test_server.yaml
@@ -10,8 +10,6 @@
 # against the matched ng2 run on the same questions.
 
 model: claude-sonnet-4-5-20250929
-max_tokens: 4000
-temperature: 1.0
 
 pricing:
   input_per_million: 3.00

--- a/benchmark/scripts/config_no_guide2_no_test_server.yaml
+++ b/benchmark/scripts/config_no_guide2_no_test_server.yaml
@@ -9,8 +9,6 @@
 # locally-configured `mcp__togomcp__*` server visible. Compare MIE usage rate
 # against the matched ng2 run on the same questions.
 
-model: claude-sonnet-4-5-20250929
-
 pricing:
   input_per_million: 3.00
   output_per_million: 15.00

--- a/benchmark/scripts/config_no_mie.yaml
+++ b/benchmark/scripts/config_no_mie.yaml
@@ -6,8 +6,6 @@
 # - |- (pipe dash): Like |, but strips final newlines
 # - >- (greater dash): Like >, but strips final newlines
 
-model: claude-sonnet-4-5-20250929
-
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)
 # ---------------------------------------------------------------------------

--- a/benchmark/scripts/config_no_mie.yaml
+++ b/benchmark/scripts/config_no_mie.yaml
@@ -7,8 +7,6 @@
 # - >- (greater dash): Like >, but strips final newlines
 
 model: claude-sonnet-4-5-20250929
-max_tokens: 4000
-temperature: 1.0
 
 # ---------------------------------------------------------------------------
 # Token pricing (USD per 1 million tokens)

--- a/benchmark/scripts/run_all_conditions.sh
+++ b/benchmark/scripts/run_all_conditions.sh
@@ -12,8 +12,12 @@
 # isolation when comparing tool-use behaviour.
 #
 # Usage:
-#   ./run_all_conditions.sh               # use today's date
-#   ./run_all_conditions.sh 2026-05-04    # use specific date
+#   ./run_all_conditions.sh                       # today's date, default model
+#   ./run_all_conditions.sh 2026-05-04            # specific date
+#   MODEL=claude-opus-4-8 ./run_all_conditions.sh # override the model for the whole sweep
+#
+# The model is set in ONE place (the MODEL variable below) and passed to every
+# condition via --model, so you never edit it in each config*.yaml.
 #
 # An existing CSV for a (condition, date) pair is skipped, so the script is
 # safely re-runnable after a partial run — delete the file to force a re-run.
@@ -21,6 +25,9 @@
 set -euo pipefail
 
 DATE="${1:-$(date +%Y-%m-%d)}"
+# One source of truth for the benchmark model. Override per-sweep with the
+# MODEL env var; the configs themselves no longer carry a 'model' key.
+MODEL="${MODEL:-claude-sonnet-4-5-20250929}"
 
 # cd into the directory holding this script so relative paths work regardless
 # of where the user invokes it from.
@@ -47,6 +54,7 @@ for entry in "${CONDITIONS[@]}"; do
     echo "=========================================================="
     echo "Condition: ${prefix}"
     echo "Config:    ${config}"
+    echo "Model:     ${MODEL}"
     echo "Output:    ${output}"
     echo "Log:       ${log}"
     echo "Started:   $(date '+%Y-%m-%d %H:%M:%S')"
@@ -64,6 +72,7 @@ for entry in "${CONDITIONS[@]}"; do
     python3 automated_test_runner.py \
         ../questions/question_*.yaml \
         -c "$config" \
+        --model "$MODEL" \
         -o "$output" 2>&1 | tee "$log"
 
     echo "✓ Completed ${prefix} at $(date '+%Y-%m-%d %H:%M:%S')"

--- a/benchmark/scripts/verify_questions.py
+++ b/benchmark/scripts/verify_questions.py
@@ -552,6 +552,7 @@ def verify_questions(targets=None):
     multi_db_2plus   = 0
     multi_db_3plus   = 0
     uniprot_count    = 0
+    sig_records      = []   # (num, type, sorted(dbs) tuple, template, keyword_id)
 
     all_issues   = []
     all_warnings = []
@@ -599,6 +600,18 @@ def verify_questions(targets=None):
             num = filepath.stem.replace("question_", "")
             for db in dbs:
                 db_question_map[db].append(num)
+
+        # Structural signature, for the near-duplicate guard below.
+        tmpl = str(data.get("question_template_used", "") or "").strip().lower()
+        kw = data.get("inspiration_keyword", {})
+        kw_id = kw.get("keyword_id", "") if isinstance(kw, dict) else ""
+        sig_records.append((
+            filepath.stem.replace("question_", ""),
+            q_type,
+            tuple(sorted(dbs)) if isinstance(dbs, list) else (),
+            tmpl,
+            kw_id,
+        ))
 
         total_questions += 1
 
@@ -706,6 +719,57 @@ def verify_questions(targets=None):
           f"questions ({pct_up:.1f}%, cap ≤70%)")
     if pct_up > 70:
         all_issues.append(f"UniProt usage {pct_up:.1f}% exceeds 70% cap")
+
+    # -- Structural near-duplicate guard (warnings; judgment is the skill's) -
+    # Cheap mechanical signals that two questions may share a structure. These
+    # are warnings, not errors — structural similarity is a judgment call made
+    # by the qa-generator's C26 self-review and the human checkpoint. The
+    # validator's job is to make collisions impossible to miss.
+    print(f"\nStructural Near-Duplicate Guard:")
+
+    # (a) Reused inspiration keyword — the tracker is supposed to keep these
+    #     unique, but nothing enforced it before.
+    kw_counter = Counter(r[4] for r in sig_records if r[4])
+    dup_kw = {k: c for k, c in kw_counter.items() if c > 1}
+    if dup_kw:
+        for k in sorted(dup_kw):
+            qs = [r[0] for r in sig_records if r[4] == k]
+            print(f"  ⚠  keyword {k} reused by questions {qs}")
+            all_warnings.append(f"keyword {k} reused by questions {qs}")
+    else:
+        print(f"  ✓ all inspiration keywords unique")
+
+    # (b) Identical (type, database-set, template) signature — a near-certain
+    #     clone.
+    sig_map = defaultdict(list)
+    for num, qtype, dbset, tmpl, _kw in sig_records:
+        sig_map[(qtype, dbset, tmpl)].append(num)
+    collisions = {k: v for k, v in sig_map.items() if len(v) > 1}
+    if collisions:
+        for (qtype, dbset, _tmpl), qs in sorted(collisions.items(), key=lambda x: x[1]):
+            print(f"  ⚠  same (type={qtype}, dbs={list(dbset)}, template) in {qs}")
+            all_warnings.append(
+                f"structural collision (type={qtype}, dbs={list(dbset)}, same template) "
+                f"in questions {qs}")
+    else:
+        print(f"  ✓ no (type, databases, template) signature collisions")
+
+    # (c) Same (type, database-pair) used by 3+ questions — informational; flags
+    #     clusters to eyeball for query-structure overlap (this is exactly what
+    #     the manual "differentiate Qxxx from Qyyy" revisions were fixing).
+    pair_map = defaultdict(list)
+    for num, qtype, dbset, _tmpl, _kw in sig_records:
+        pair_map[(qtype, dbset)].append(num)
+    heavy = {k: v for k, v in pair_map.items() if len(v) >= 3}
+    if heavy:
+        for (qtype, dbset), qs in sorted(heavy.items(), key=lambda x: -len(x[1])):
+            print(f"  ⚠  (type={qtype}, dbs={list(dbset)}) shared by {len(qs)} "
+                  f"questions {qs} — verify distinct query structure")
+            all_warnings.append(
+                f"(type={qtype}, dbs={list(dbset)}) shared by {len(qs)} questions {qs} "
+                f"— verify distinct query structure")
+    else:
+        print(f"  ✓ no (type, database-pair) cluster of 3+")
 
     # -- Coverage tracker --------------------------------------------------
     print(f"\n--- Coverage Tracker Verification ---")

--- a/benchmark/scripts/verify_questions.py
+++ b/benchmark/scripts/verify_questions.py
@@ -501,6 +501,37 @@ def verify_coverage_tracker(actual_counts: dict,
 # Main
 # ---------------------------------------------------------------------------
 
+def print_next_guidance(total: int, type_counts, db_counts: dict, uniprot_count: int):
+    """Forward-looking nudge for extending the set: which type and which
+    databases to add next to keep the distribution balanced. Informational
+    only — prints, never records issues/warnings."""
+    n_types = len(VALID_TYPES)
+    # Next balanced milestone = next size at which all types can be equal.
+    milestone = ((total // n_types) + 1) * n_types
+    per_type_target = milestone // n_types
+
+    print(f"\n--- Next-Question Guidance (for extending the set) ---")
+    print(f"Next balanced milestone: {milestone} questions "
+          f"({per_type_target} per type)")
+    print(f"Per-type shortfall to milestone (add the largest gaps first):")
+    rows = [(per_type_target - type_counts.get(qt, 0), qt, type_counts.get(qt, 0))
+            for qt in VALID_TYPES]
+    for short, qt, cnt in sorted(rows, key=lambda r: (-r[0], r[1])):
+        flag = "" if short > 0 else ("  (at target)" if short == 0 else "  (over target)")
+        print(f"    {qt:12s} {cnt:3d}  need +{max(short, 0)}{flag}")
+
+    ranked = sorted(VALID_DATABASES, key=lambda d: (db_counts.get(d, 0), d))
+    print(f"Most under-used databases (prefer these next):")
+    print("    " + "  ".join(f"{d}({db_counts.get(d, 0)})" for d in ranked[:8]))
+
+    cap_at_milestone = int(milestone * 0.70)
+    remaining = cap_at_milestone - uniprot_count
+    pct = uniprot_count / total * 100 if total else 0
+    print(f"UniProt headroom: {uniprot_count}/{total} ({pct:.1f}%); "
+          f"70% cap at {milestone} questions = {cap_at_milestone} "
+          f"→ {remaining} more UniProt question(s) allowed")
+
+
 def _print_issue_summary(all_issues: list, all_warnings: list):
     """Print the WARNINGS / ERRORS blocks shared by full and single-file runs."""
     if all_warnings:
@@ -775,6 +806,8 @@ def verify_questions(targets=None):
     print(f"\n--- Coverage Tracker Verification ---")
     verify_coverage_tracker(type_counts, db_counts, total_questions,
                             all_issues, all_warnings, base_dir)
+
+    print_next_guidance(total_questions, type_counts, db_counts, uniprot_count)
 
     _print_issue_summary(all_issues, all_warnings)
     return len(all_issues) == 0

--- a/benchmark/scripts/verify_questions.py
+++ b/benchmark/scripts/verify_questions.py
@@ -20,7 +20,9 @@ except ImportError:
 # Constants
 # ---------------------------------------------------------------------------
 
-BASE_PATH = Path("/Users/arkinjo/work/GitHub/togo-mcp/evaluation2/questions")
+# Resolve relative to this script so it works regardless of checkout location:
+# benchmark/scripts/verify_questions.py -> benchmark/questions
+BASE_PATH = Path(__file__).resolve().parents[1] / "questions"
 
 VALID_TYPES = {"yes_no", "factoid", "list", "summary", "choice"}
 
@@ -447,9 +449,10 @@ def verify_coverage_tracker(actual_counts: dict,
                              actual_db_counts: dict,
                              total: int,
                              issues_out: list,
-                             warnings_out: list):
+                             warnings_out: list,
+                             base_dir: Path = BASE_PATH):
     """Validate coverage_tracker.yaml against observed question data."""
-    tracker_path = BASE_PATH / "coverage_tracker.yaml"
+    tracker_path = base_dir / "coverage_tracker.yaml"
     if not tracker_path.exists():
         print(f"\n  ⚠  coverage_tracker.yaml not found")
         warnings_out.append("coverage_tracker.yaml not found")
@@ -498,8 +501,49 @@ def verify_coverage_tracker(actual_counts: dict,
 # Main
 # ---------------------------------------------------------------------------
 
-def verify_questions():
-    question_files = sorted(BASE_PATH.glob("question_*.yaml"))
+def _print_issue_summary(all_issues: list, all_warnings: list):
+    """Print the WARNINGS / ERRORS blocks shared by full and single-file runs."""
+    if all_warnings:
+        print(f"\n{'=' * 70}")
+        print(f"WARNINGS ({len(all_warnings)}):")
+        for w in all_warnings:
+            print(f"  ⚠  {w}")
+    if all_issues:
+        print(f"\n{'=' * 70}")
+        print(f"ERRORS ({len(all_issues)}):")
+        for err in all_issues:
+            print(f"  ❌ {err}")
+    else:
+        print(f"\n✓ No errors found!")
+    print(f"\n{'=' * 70}")
+    print(f"VERIFICATION COMPLETE  —  "
+          f"{len(all_issues)} error(s), {len(all_warnings)} warning(s)")
+    print(f"{'=' * 70}\n")
+
+
+def verify_questions(targets=None):
+    """Validate questions.
+
+    targets:
+      None / []         -> full run on the repo questions dir (per-question +
+                           aggregate distribution/coverage + tracker reconcile).
+      a single directory -> full run on that directory.
+      one or more files  -> single-file mode: per-question structural checks
+                           only. Aggregate and coverage-tracker checks are
+                           skipped (they need the whole set). This is what the
+                           qa-generator checkpoint uses on a candidate file
+                           before it is written into questions/.
+    """
+    single_file_mode = False
+    base_dir = BASE_PATH
+    if not targets:
+        question_files = sorted(BASE_PATH.glob("question_*.yaml"))
+    elif len(targets) == 1 and Path(targets[0]).is_dir():
+        base_dir = Path(targets[0])
+        question_files = sorted(base_dir.glob("question_*.yaml"))
+    else:
+        question_files = [Path(t) for t in targets]
+        single_file_mode = True
 
     total_questions  = 0
     all_types        = []
@@ -515,7 +559,11 @@ def verify_questions():
     print("=" * 70)
     print("TOGOMCP BENCHMARK QUESTIONS VERIFICATION")
     print("=" * 70)
-    print(f"\nScanning {BASE_PATH} ...")
+    if single_file_mode:
+        print(f"\nSingle-file mode: {len(question_files)} file(s) "
+              f"(aggregate & coverage-tracker checks skipped)")
+    else:
+        print(f"\nScanning {base_dir} ...")
 
     # -- Per-question checks -----------------------------------------------
     print("\n--- Per-Question Checks ---")
@@ -557,6 +605,11 @@ def verify_questions():
         all_issues.extend(q_issues)
         all_warnings.extend(q_warnings)
 
+    # Single-file (checkpoint) mode: per-question checks only.
+    if single_file_mode:
+        _print_issue_summary(all_issues, all_warnings)
+        return len(all_issues) == 0
+
     # -- Summary -----------------------------------------------------------
     type_counts = Counter(all_types)
     db_counts   = {db: len(qs) for db, qs in db_question_map.items()}
@@ -572,23 +625,38 @@ def verify_questions():
         pct = total_questions / 50 * 100
         print(f"  ⚠  PROGRESS: {total_questions}/50 ({pct:.0f}%)")
 
-    # -- Type distribution -------------------------------------------------
-    print(f"\nQuestion Type Distribution (target: 10 each, cap: 8-12):")
+    # -- Type distribution (scales with set size; balanced band ±2) --------
+    # Target is total/5 (5 types), not a hard-coded 10, so the check stays
+    # valid as the set grows past 50. A type is OVER if it exceeds target+2;
+    # UNDER (below target-2) is only an error at a balanced checkpoint (total
+    # a multiple of 5) — mid-extension it's a warning, since you add
+    # under-represented types first.
+    n_types = len(VALID_TYPES)
+    ideal = total_questions / n_types
+    cap_hi, cap_lo = ideal + 2, ideal - 2
+    balanced_checkpoint = (total_questions % n_types == 0)
+    print(f"\nQuestion Type Distribution "
+          f"(target ~{ideal:.0f} each, balanced band ±2):")
     for qtype in sorted(VALID_TYPES):
         cnt = type_counts.get(qtype, 0)
-        if cnt == 10:
-            sym = "✓"
-        elif 8 <= cnt <= 12:
-            sym = "~"
-        else:
-            sym = "❌"
         note = ""
-        if cnt > 12:
-            note = " ← OVER CAP!"
-            all_issues.append(f"Type '{qtype}' has {cnt} uses (hard cap is 12)")
-        elif cnt < 8 and total_questions >= 50:
-            note = " ← UNDER MINIMUM!"
-            all_issues.append(f"Type '{qtype}' has {cnt} uses (minimum is 8)")
+        if cnt > cap_hi:
+            sym = "❌"; note = f" ← OVER (> {cap_hi:.0f})"
+            all_issues.append(
+                f"Type '{qtype}' has {cnt} uses (> {cap_hi:.0f}; set size {total_questions})")
+        elif cnt < cap_lo:
+            if balanced_checkpoint:
+                sym = "❌"; note = f" ← UNDER (< {cap_lo:.0f})"
+                all_issues.append(
+                    f"Type '{qtype}' has {cnt} uses (< {cap_lo:.0f}; set size {total_questions})")
+            else:
+                sym = "⚠"; note = " ← under (set still growing)"
+                all_warnings.append(
+                    f"Type '{qtype}' has {cnt} uses (below balanced band; set still growing)")
+        elif abs(cnt - ideal) <= 0.5:
+            sym = "✓"
+        else:
+            sym = "~"
         print(f"  {sym} {qtype:12s}: {cnt:3d}{note}")
 
     # -- Duplicate IDs -----------------------------------------------------
@@ -642,32 +710,15 @@ def verify_questions():
     # -- Coverage tracker --------------------------------------------------
     print(f"\n--- Coverage Tracker Verification ---")
     verify_coverage_tracker(type_counts, db_counts, total_questions,
-                            all_issues, all_warnings)
+                            all_issues, all_warnings, base_dir)
 
-    # -- Warnings summary --------------------------------------------------
-    if all_warnings:
-        print(f"\n{'=' * 70}")
-        print(f"WARNINGS ({len(all_warnings)}):")
-        for w in all_warnings:
-            print(f"  ⚠  {w}")
-
-    # -- Issues summary ----------------------------------------------------
-    if all_issues:
-        print(f"\n{'=' * 70}")
-        print(f"ERRORS ({len(all_issues)}):")
-        for err in all_issues:
-            print(f"  ❌ {err}")
-    else:
-        print(f"\n✓ No errors found!")
-
-    print(f"\n{'=' * 70}")
-    print(f"VERIFICATION COMPLETE  —  "
-          f"{len(all_issues)} error(s), {len(all_warnings)} warning(s)")
-    print(f"{'=' * 70}\n")
-
+    _print_issue_summary(all_issues, all_warnings)
     return len(all_issues) == 0
 
 
 if __name__ == "__main__":
-    success = verify_questions()
+    # Optional args: a directory (full run on it) or one/more question files
+    # (single-file structural checks for the qa-generator checkpoint).
+    targets = sys.argv[1:]
+    success = verify_questions(targets or None)
     sys.exit(0 if success else 1)

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -238,5 +238,6 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 048 | P      | —      |
 | 049 | P      | —      |
 | 050 | P      | —      |
+| 051 | P      | —      |
 
-**Summary:** `P` = 50 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 50 / 50
+**Summary:** `P` = 51 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 51 / 51


### PR DESCRIPTION
A series of benchmark-harness improvements plus a new skill for growing the QA set. All commits are scoped to `benchmark/` and `.claude/skills/`.

## Answer-collection harness
- **Controlled comparison** — route the baseline through `claude-agent-sdk` (the same path as the TogoMCP arm), so the two conditions share identical CLI-fixed sampling, auth, and cost accounting and differ *only* in tool availability. Drop the now-unused `anthropic` baseline client and the hard `ANTHROPIC_API_KEY` startup requirement.
- **Dead config removed** — `max_tokens`/`temperature` no longer apply under the agent SDK; stripped from the runner and all five `config*.yaml`.
- **Model centralized** — a `--model` flag (precedence: `--model` > config > default) and a single `MODEL` var in `run_all_conditions.sh`, instead of repeating the model in every config.

## Evaluation
- **Ollama judge → Claude Opus judge.** `add_llm_evaluation.py` now calls the Messages API with Claude Opus and **forced tool use** (validated JSON scores — no regex), replacing the discarded local `llama3.2` pass and automating the manual Opus re-evaluation. Same rubric, same 12 columns, so `results_analyzer.py` / `generate_dashboard.py` are unaffected. Adds `--runs N` for the 5-independent-run batch and fail-fast auth handling. Verified live (baseline 14/20, TogoMCP 13/20 on question_004).

## qa-generator skill (new) + validator hardening
- **`.claude/skills/qa-generator/`** — produces new benchmark questions one at a time under the v5.5.0 type-first protocol, with three hard rules (nothing invented; question scope = query scope; every GROUP BY arithmetically verified), a 25→26-point self-review (added **C26 structural near-duplicate**), and a per-question approval checkpoint. Stops at validated questions; does not trigger billed benchmark runs.
- **`verify_questions.py`** fixed and extended: repo-relative path (it pointed at a stale `togo-mcp/evaluation2` path and scanned nothing); type-distribution scaled to `total/5 ±2` so it survives growth past 50; single-file mode for the checkpoint; a **structural near-duplicate guard** (reused keyword / identical `(type, databases, template)` signature / `(type, db-pair)` clusters); and a **Next-Question Guidance** block (per-type shortfall, under-used databases, UniProt headroom).
- **First generated question** — `question_051` (cobalamin reactions by EC class; `choice`, chebi+rhea), produced end-to-end against live ChEBI/Rhea/PubMed, every count verified (Checkpoint B: 10 = 10), tracker + progress table updated. Set now passes at **51 questions, 0 errors**.

## Verification
- `verify_questions.py` (full): 0 errors on all 51 questions.
- Evaluator and runner changes smoke-tested live.
- All Python touched compiles; `run_all_conditions.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)