### PR TITLE
ci: package skills into .skill archives

### DIFF
--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -1,0 +1,48 @@
+name: Package skills
+
+# Bundles each Claude Code skill under .claude/skills/<name>/ into a
+# <name>.skill zip archive. NOTE: `.skill` is NOT an official Claude Code
+# format — it is a local packaging convention here. To install one, unzip it
+# into a skills directory, e.g.  unzip qa-generator.skill -d .claude/skills/
+
+on:
+  push:
+    tags: ['skills-v*']     # e.g. git tag skills-v1 && git push origin skills-v1
+  workflow_dispatch:         # allow manual runs from the Actions tab
+
+permissions:
+  contents: write            # needed to attach assets to a Release on tag runs
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build .skill archives
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          shopt -s nullglob
+          for dir in .claude/skills/*/; do
+            name="$(basename "$dir")"
+            ( cd .claude/skills && \
+              zip -r "../../dist/${name}.skill" "$name" \
+                  -x '*/worktrees/*' '*/.DS_Store' '*/__pycache__/*' )
+            echo "built dist/${name}.skill"
+          done
+          echo "--- built archives ---"
+          ls -la dist
+
+      - name: Upload as workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: skills
+          path: dist/*.skill
+          if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.skill


### PR DESCRIPTION
## What

Adds `.github/workflows/package-skills.yml` — a CI workflow that bundles each Claude Code skill under `.claude/skills/<name>/` into a `<name>.skill` zip archive.

## Behaviour

- **Triggers:** `skills-v*` tag pushes, and manual `workflow_dispatch` from the Actions tab.
- **Build:** zips each skill directory into `dist/<name>.skill` (excludes `worktrees/`, `.DS_Store`, `__pycache__/`).
- **Output:** always uploads the archives as workflow **artifacts**; on tag runs, also **attaches them to a GitHub Release** (`permissions: contents: write`).
- `dist/` is already gitignored, so nothing is committed back.

Verified locally with the same zip loop — all six skills archive cleanly, each with the skill directory at the archive root (`unzip <name>.skill -d .claude/skills/` restores it).

## Caveat

`.skill` is **not** an official Claude Code format — Claude Code distributes skills as directories (or bundled inside plugins). These archives are a convenience packaging convention for sharing; the proper installable route would be a plugin + marketplace. Documented inline in the workflow header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)