### PR TITLE
benchmark: add questions 056 (MassBank) and 057 (BRENDA+HGNC)

### DIFF
--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,7 +96,7 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 55
+total_questions: 57
 
 question_types:
   yes_no:
@@ -105,14 +105,14 @@ question_types:
     status: 'ok'  # 11 uses - extending past 50 (target ~total/5)
 
   factoid:
-    count: 11
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052']
-    status: 'ok'  # 11 uses - extending past 50 (target ~total/5)
+    count: 12
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056']
+    status: 'ok'  # 12 uses - extending past 50 (target ~total/5)
 
   list:
-    count: 11
-    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054']
-    status: 'ok'  # 11 uses - extending past 50 (target ~total/5)
+    count: 12
+    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057']
+    status: 'ok'  # 12 uses - extending past 50 (target ~total/5)
 
   summary:
     count: 11
@@ -146,13 +146,13 @@ databases:
     status: 'ok'
 
   chembl:
-    count: 7
-    questions: ['005', '006', '009', '021', '039', '041', '049']
+    count: 8
+    questions: ['005', '006', '007', '009', '021', '039', '041', '049']
     status: 'ok'
 
   chebi:
-    count: 6
-    questions: ['004', '011', '024', '043', '045', '051']
+    count: 7
+    questions: ['004', '011', '024', '043', '045', '051', '056']
     status: 'ok'
 
   reactome:
@@ -186,8 +186,8 @@ databases:
     status: 'ok'
 
   go:
-    count: 8
-    questions: ['002', '004', '014', '015', '021', '022', '024', '049']
+    count: 9
+    questions: ['002', '003', '004', '014', '015', '021', '022', '024', '049']
     status: 'ok'
 
   taxonomy:
@@ -241,9 +241,9 @@ databases:
     status: 'ok'
 
   hgnc:
-    count: 1
-    questions: ['052']
-    status: 'ok'  # newly added life-science DB, first use
+    count: 2
+    questions: ['052', '057']
+    status: 'ok'  # newly added life-science DB
 
   bgee:
     count: 2
@@ -251,9 +251,9 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   brenda:
-    count: 1
-    questions: ['053']
-    status: 'ok'  # newly added life-science DB, first use
+    count: 2
+    questions: ['053', '057']
+    status: 'ok'  # newly added life-science DB
 
   jpostdb:
     count: 1
@@ -265,17 +265,22 @@ databases:
     questions: ['055']
     status: 'ok'  # newly added life-science DB, first use
 
+  massbank:
+    count: 1
+    questions: ['056']
+    status: 'ok'  # newly added life-science DB, first use
+
 multi_database_metrics:
   two_plus_databases:
-    count: 55
-    percentage: 100.0  # 55/55 (Q055 is 3-DB: oma + uniprot + bgee)
+    count: 57
+    percentage: 100.0  # 57/57 (Q057 is 2-DB: hgnc + brenda)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
     count: 21
     questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055']
-    percentage: 38.2  # 21/55 (Q055 is 3-DB: oma + uniprot + bgee)
+    percentage: 36.8  # 21/57 (Q057 is 2-DB: hgnc + brenda, not counted here)
     target: '>= 20%'
     status: 'excellent'
 
@@ -335,6 +340,8 @@ keywords_used:
   - 'KW-0289'  # Folate biosynthesis (Q053)
   - 'KW-0211'  # Defensin (Q054)
   - 'KW-0641'  # Proline biosynthesis (Q055)
+  - 'KW-0663'  # Pyridoxal phosphate (Q056)
+  - 'KW-0032'  # Aminotransferase (Q057)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_056.yaml
+++ b/benchmark/questions/question_056.yaml
@@ -1,0 +1,208 @@
+id: question_056
+type: factoid
+body: >-
+  How many reference tandem mass spectrometry (MS/MS) spectra are catalogued for the
+  vitamin B6-derived enzyme cofactor pyridoxal 5'-phosphate?
+
+inspiration_keyword:
+  keyword_id: KW-0663
+  name: Pyridoxal phosphate
+  category: Ligand
+
+togomcp_databases_used:
+  - chebi
+  - massbank
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 15 minutes
+  method: |
+    Query 1: "pyridoxal 5'-phosphate MassBank reference mass spectra number" — 0 results.
+    Query 2: "pyridoxal phosphate tandem mass spectrometry reference spectral library count
+      instrument types" — 0 results.
+    Query 3 (broad, to confirm the topic exists): "pyridoxal 5'-phosphate mass spectrometry
+      fragmentation" — 23 results; read abstracts of PMID 35003002 and PMID 31233711.
+  result: |
+    The two targeted queries returned nothing. The broad query found 23 articles, but they
+    are mechanistic or applied studies — e.g. detecting the covalent PLP-Lys302 adduct of a
+    transcription factor by MS (PMID 35003002), and a method for sequencing PLP-modified
+    peptides by multi-stage tandem MS (PMID 31233711). None enumerates how many curated
+    reference MS/MS spectra exist for free pyridoxal 5'-phosphate. That figure is a property
+    of the current spectral-repository snapshot, not of any publication, so it cannot be
+    recovered from the literature.
+  conclusion: PASS (cannot answer from literature - requires current RDF repository state)
+
+sparql_queries:
+  - query_number: 1
+    database: chebi
+    description: |
+      Resolve the cofactor pyridoxal 5'-phosphate to its canonical chemical identity and
+      structure key (standard InChIKey), which is the join key used to gather its reference
+      spectra. The neutral free cofactor is CHEBI:18405 (formula C8H10NO6P); its standard
+      InChIKey is NGVDGCNFYWLIFO-UHFFFAOYSA-N.
+    query: |
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX chemrof: <https://w3id.org/chemrof/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?label ?formula ?mass ?inchikey ?charge
+      FROM <http://rdf.ebi.ac.uk/dataset/chebi>
+      WHERE {
+        obo:CHEBI_18405 a owl:Class ;
+                        rdfs:label ?label .
+        OPTIONAL { obo:CHEBI_18405 chemrof:generalized_empirical_formula ?formula }
+        OPTIONAL { obo:CHEBI_18405 chemrof:mass ?mass }
+        OPTIONAL { obo:CHEBI_18405 chemrof:inchi_key_string ?inchikey }
+        OPTIONAL { obo:CHEBI_18405 chemrof:charge ?charge }
+      }
+    result_count: 1
+
+  - query_number: 2
+    database: massbank
+    description: |
+      Count the distinct reference mass spectra whose measured chemical substance is
+      pyridoxal 5'-phosphate, matched by its standard InChIKey IRI (the structure-based
+      join key recommended by the schema; names are not used). Returns 22. A skeleton-block
+      scan (FILTER CONTAINS "NGVDGCNFYWLIFO") confirmed this neutral InChIKey is the only
+      PLP structure key present, so no protonation/charge variant is missed (Rule 2 scope).
+    query: |
+      PREFIX mb: <http://www.massbank.jp/ontology/>
+      PREFIX schema: <https://schema.org/>
+
+      SELECT (COUNT(DISTINCT ?spectrum) AS ?nSpectra)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          ?c schema:inChIKey <http://identifiers.org/inchikey/NGVDGCNFYWLIFO-UHFFFAOYSA-N> .
+          ?spectrum mb:compound ?c .
+        }
+      }
+    result_count: 1
+
+  - query_number: 3
+    database: massbank
+    description: |
+      Arithmetic-verification / breakdown of the 22 spectra by acquisition method
+      (instrument type x ion mode x MS level). The four groups sum to 8 + 6 + 4 + 4 = 22,
+      matching the total in Query 2, and confirm every record is a tandem (MS2) spectrum.
+    query: |
+      PREFIX mb: <http://www.massbank.jp/ontology/>
+      PREFIX schema: <https://schema.org/>
+
+      SELECT ?instrument_type ?ion_mode ?ms_type (COUNT(DISTINCT ?spectrum) AS ?n)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          ?c schema:inChIKey <http://identifiers.org/inchikey/NGVDGCNFYWLIFO-UHFFFAOYSA-N> .
+          ?spectrum mb:compound ?c ;
+                    mb:analytical_methods_and_conditions ?ac .
+          ?ac mb:instrument_type ?instrument_type ;
+              mb:ion_mode ?ion_mode ;
+              mb:ms_type ?ms_type .
+        }
+      }
+      GROUP BY ?instrument_type ?ion_mode ?ms_type
+      ORDER BY DESC(?n)
+    result_count: 4
+
+rdf_triples: |
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix owl: <http://www.w3.org/2002/07/owl#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix chemrof: <https://w3id.org/chemrof/> .
+  @prefix mb: <http://www.massbank.jp/ontology/> .
+  @prefix schema: <https://schema.org/> .
+  @prefix dcterms: <http://purl.org/dc/terms/> .
+
+  obo:CHEBI_18405 a owl:Class .
+  # Database: ChEBI | Query: 1 | Comment: pyridoxal 5'-phosphate chemical entity
+  obo:CHEBI_18405 rdfs:label "pyridoxal 5'-phosphate" .
+  # Database: ChEBI | Query: 1 | Comment: preferred name of the cofactor
+  obo:CHEBI_18405 chemrof:generalized_empirical_formula "C8H10NO6P" .
+  # Database: ChEBI | Query: 1 | Comment: molecular formula
+  obo:CHEBI_18405 chemrof:mass 247.143 .
+  # Database: ChEBI | Query: 1 | Comment: average molecular mass
+  obo:CHEBI_18405 chemrof:inchi_key_string "NGVDGCNFYWLIFO-UHFFFAOYSA-N" .
+  # Database: ChEBI | Query: 1 | Comment: standard InChIKey = structure-based join key into the spectral repository
+
+  <https://identifiers.org/massbank/MSBNK-Keio_Univ-KO001615> a mb:MassSpectrum .
+  # Database: MassBank | Query: 2 | Comment: one of the 22 reference spectra for PLP
+  <https://identifiers.org/massbank/MSBNK-Keio_Univ-KO001615> dcterms:identifier "MSBNK-Keio_Univ-KO001615" .
+  # Database: MassBank | Query: 2 | Comment: MassBank accession
+  <https://identifiers.org/massbank/MSBNK-Keio_Univ-KO001615> mb:compound _:plp1 .
+  # Database: MassBank | Query: 2 | Comment: links the spectrum to its measured chemical substance
+  _:plp1 a schema:chemicalsubstance .
+  # Database: MassBank | Query: 2 | Comment: chemical-substance node (lowercase class IRI)
+  _:plp1 schema:inChIKey <http://identifiers.org/inchikey/NGVDGCNFYWLIFO-UHFFFAOYSA-N> .
+  # Database: MassBank | Query: 2 | Comment: same InChIKey as ChEBI CHEBI:18405 — the cross-database link
+  _:plp1 schema:molecularFormula "C8H10NO6P" .
+  # Database: MassBank | Query: 2 | Comment: formula matches the ChEBI record
+  <https://identifiers.org/massbank/MSBNK-Keio_Univ-KO001615> mb:analytical_methods_and_conditions _:ac1 .
+  # Database: MassBank | Query: 3 | Comment: acquisition method node
+  _:ac1 mb:instrument_type "LC-ESI-QQ" .
+  # Database: MassBank | Query: 3 | Comment: instrument type (triple-quadrupole LC-ESI)
+  _:ac1 mb:ion_mode "NEGATIVE" .
+  # Database: MassBank | Query: 3 | Comment: negative ion mode
+  _:ac1 mb:ms_type "MS2" .
+  # Database: MassBank | Query: 3 | Comment: tandem (MS/MS) acquisition
+  <https://identifiers.org/massbank/MSBNK-RIKEN-PR100274> a mb:MassSpectrum .
+  # Database: MassBank | Query: 2 | Comment: another of the 22 reference spectra for PLP
+  <https://identifiers.org/massbank/MSBNK-RIKEN-PR100274> dcterms:identifier "MSBNK-RIKEN-PR100274" .
+  # Database: MassBank | Query: 2 | Comment: MassBank accession (different contributor)
+  <https://identifiers.org/massbank/MSBNK-RIKEN-PR100274> mb:compound _:plp2 .
+  # Database: MassBank | Query: 2 | Comment: links the spectrum to its measured chemical substance
+  _:plp2 a schema:chemicalsubstance .
+  # Database: MassBank | Query: 2 | Comment: chemical-substance node
+  _:plp2 schema:inChIKey <http://identifiers.org/inchikey/NGVDGCNFYWLIFO-UHFFFAOYSA-N> .
+  # Database: MassBank | Query: 2 | Comment: same PLP InChIKey
+  <https://identifiers.org/massbank/MSBNK-RIKEN-PR100274> mb:analytical_methods_and_conditions _:ac2 .
+  # Database: MassBank | Query: 3 | Comment: acquisition method node
+  _:ac2 mb:instrument_type "LC-ESI-QTOF" .
+  # Database: MassBank | Query: 3 | Comment: instrument type (quadrupole time-of-flight LC-ESI)
+  _:ac2 mb:ion_mode "POSITIVE" .
+  # Database: MassBank | Query: 3 | Comment: positive ion mode
+  _:ac2 mb:ms_type "MS2" .
+  # Database: MassBank | Query: 3 | Comment: tandem (MS/MS) acquisition
+
+exact_answer: 22
+
+ideal_answer: |
+  There are 22 reference tandem mass spectra (MS/MS) catalogued for pyridoxal 5'-phosphate, the
+  phosphorylated, catalytically active form of vitamin B6 that serves as an enzyme cofactor
+  (ChEBI:18405; molecular formula C8H10NO6P; standard InChIKey NGVDGCNFYWLIFO-UHFFFAOYSA-N). All
+  22 records are MS2 spectra acquired by liquid-chromatography electrospray ionization, split
+  across two instrument geometries and both ionization polarities: 14 on a triple-quadrupole
+  (LC-ESI-QQ; 8 negative + 6 positive) and 8 on a quadrupole time-of-flight (LC-ESI-QTOF; 4
+  negative + 4 positive), which sums to 22. Spectra were contributed by several laboratories
+  (e.g. Keio University and RIKEN). The compound was matched by its standard InChIKey rather than
+  by name, and a scan of the full InChIKey skeleton confirmed this neutral structure key is the
+  only representation of pyridoxal 5'-phosphate present, so no charge/protonation variant is
+  omitted from the count.
+
+question_template_used: "Cross-database structure-to-spectrum count (InChIKey join ChEBI -> MassBank)"
+
+structured_vocabulary_check:
+  concept: pyridoxal 5'-phosphate
+  ontology_used: ChEBI
+  resolved_entity: "CHEBI:18405 (pyridoxal 5'-phosphate)"
+  structure_key: "InChIKey NGVDGCNFYWLIFO-UHFFFAOYSA-N"
+  scope_note: >-
+    Skeleton-block scan (CONTAINS "NGVDGCNFYWLIFO") over MassBank InChIKeys returned only the
+    neutral -N form; the ChEBI dianion CHEBI:597326 (...-L) has no MassBank spectra, so scope is
+    complete.
+  comprehensive: true
+
+time_spent:
+  exploration: 35 minutes
+  formulation: 15 minutes
+  verification: 20 minutes
+  pubmed_test: 15 minutes
+  extraction: 20 minutes
+  documentation: 20 minutes
+  total: 125 minutes

--- a/benchmark/questions/question_057.yaml
+++ b/benchmark/questions/question_057.yaml
@@ -1,0 +1,240 @@
+id: question_057
+type: list
+body: >-
+  List the approved human gene symbols for aminotransferases (enzymes in EC class 2.6.1.-)
+  whose human enzyme is experimentally documented to be inhibited by aminooxyacetate.
+
+inspiration_keyword:
+  keyword_id: KW-0032
+  name: Aminotransferase
+  category: Molecular function
+
+togomcp_databases_used:
+  - hgnc
+  - brenda
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 15 minutes
+  method: |
+    Query 1: "aminooxyacetate inhibition human aminotransferases comprehensive list EC 2.6.1" — 0 results.
+    Query 2: "aminooxyacetic acid branched chain aminotransferase kynurenine aminotransferase inhibition" — 0 results.
+    Query 3 (broad, to confirm topic exists): "aminooxyacetate transaminase inhibitor" — 361 results;
+      read abstracts of PMID 38646781 and PMID 36272463.
+  result: |
+    Aminooxyacetate is a well-known generic transaminase inhibitor (361 articles), but the
+    literature consists of single-enzyme or physiological studies — e.g. its effect on the
+    mitochondrial transaminase GOT2 in muscle/C2C12 mitochondria (PMID 38646781) and on
+    oxaloacetate clearance and complex-II respiration (PMID 36272463). No publication
+    enumerates the set of approved human aminotransferase genes for which inhibition by
+    aminooxyacetate is curated in the human enzyme. That set is a property of the current
+    enzyme-database curation (and notably is NOT what textbook biochemistry predicts, since
+    the documented set excludes the canonical cytosolic isoenzyme GOT1), so it cannot be
+    recovered from the literature or from training knowledge.
+  conclusion: PASS (cannot answer from literature - requires current RDF curation state)
+
+sparql_queries:
+  - query_number: 1
+    database: hgnc
+    description: |
+      Establish the candidate universe: approved human genes whose enzyme is classified as an
+      aminotransferase (EC 2.6.1.-). Cross-references are typed nodes, so navigate
+      gene -> rdfs:seeAlso -> (a idt:ec-code) -> dct:identifier and prefix-filter "2.6.1.".
+      Returns 22 gene-EC rows spanning 16 distinct genes and 15 EC numbers (some genes carry
+      more than one EC number, e.g. AGXT 2.6.1.44/2.6.1.51).
+    query: |
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT DISTINCT ?symbol ?ecNum
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              rdfs:seeAlso ?ecRef .
+        ?ecRef a idt:ec-code ;
+               dct:identifier ?ecNum .
+        FILTER(STRSTARTS(?ecNum, "2.6.1."))
+      }
+      ORDER BY ?ecNum ?symbol
+    result_count: 22
+
+  - query_number: 2
+    database: brenda
+    description: |
+      Gold query (cross-database, single primary endpoint, both graphs). Of the 16 candidate
+      human aminotransferase genes, keep those whose EC class has an inhibitor record that
+      (a) refers to aminooxyacetate and (b) is documented in the human enzyme (organism
+      taxID 9606). HGNC supplies the approved gene symbol and EC code; BRENDA supplies the
+      organism-resolved inhibitor curation — neither database alone can answer this.
+      The EC link is the IRI-path string of the BRENDA EC node matched to the HGNC EC code
+      (BIND + STR=STR, per both MIE cross-database recipes). Aminooxyacetate is pinned to its
+      canonical BRENDA compound node (compound/1019); the only other aminooxyacetate node,
+      the hemihydrochloride salt compound/75944, was checked separately and inhibits 0 of
+      these human aminotransferases, so this scope is complete. Returns 14 distinct genes
+      (the answer); it excludes GOT1 and GFPT1, which are in the candidate universe but lack
+      a curated human aminooxyacetate-inhibition record.
+    query: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT DISTINCT ?symbol
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/hgnc> {
+          ?gene a m2r:Gene ;
+                rdfs:label ?symbol ;
+                rdfs:seeAlso ?ecRef .
+          ?ecRef a idt:ec-code ;
+                 dct:identifier ?ecNum .
+          FILTER(STRSTARTS(?ecNum, "2.6.1."))
+        }
+        GRAPH <http://rdfportal.org/dataset/brenda> {
+          ?ec a d3o:ECNumber .
+          BIND(STRAFTER(STR(?ec), "https://purl.dsmz.de/brenda/ec/") AS ?ecNum2)
+          FILTER(STR(?ecNum2) = STR(?ecNum))
+          ?inhibitor a d3o:Inhibitor ;
+                     d3o:affectsClass ?ec ;
+                     d3o:foundIn ?org ;
+                     d3o:refersToCompound <https://purl.dsmz.de/brenda/compound/1019> .
+          ?org d3o:hasTaxID 9606 .
+        }
+      }
+      ORDER BY ?symbol
+    result_count: 14
+
+  - query_number: 3
+    database: brenda
+    description: |
+      Arithmetic verification of the list length: COUNT(DISTINCT ?symbol) over the identical
+      criteria as Query 2. Returns 14, matching the 14 gene symbols listed by Query 2.
+    query: |
+      PREFIX d3o:  <https://purl.dsmz.de/schema/>
+      PREFIX m2r:  <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      PREFIX idt:  <http://identifiers.org/>
+
+      SELECT (COUNT(DISTINCT ?symbol) AS ?nGenes)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/hgnc> {
+          ?gene a m2r:Gene ; rdfs:label ?symbol ; rdfs:seeAlso ?ecRef .
+          ?ecRef a idt:ec-code ; dct:identifier ?ecNum .
+          FILTER(STRSTARTS(?ecNum, "2.6.1."))
+        }
+        GRAPH <http://rdfportal.org/dataset/brenda> {
+          ?ec a d3o:ECNumber .
+          BIND(STRAFTER(STR(?ec), "https://purl.dsmz.de/brenda/ec/") AS ?ecNum2)
+          FILTER(STR(?ecNum2) = STR(?ecNum))
+          ?inhibitor a d3o:Inhibitor ;
+                     d3o:affectsClass ?ec ;
+                     d3o:foundIn ?org ;
+                     d3o:refersToCompound <https://purl.dsmz.de/brenda/compound/1019> .
+          ?org d3o:hasTaxID 9606 .
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix m2r:  <http://med2rdf.org/ontology/med2rdf#> .
+  @prefix d3o:  <https://purl.dsmz.de/schema/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix dct:  <http://purl.org/dc/terms/> .
+  @prefix idt:  <http://identifiers.org/> .
+
+  <http://identifiers.org/hgnc/4552> a m2r:Gene .
+  # Database: HGNC | Query: 1 | Comment: approved human gene GPT (one answer-list member)
+  <http://identifiers.org/hgnc/4552> rdfs:label "GPT" .
+  # Database: HGNC | Query: 1 | Comment: official gene symbol
+  <http://identifiers.org/hgnc/4552> rdfs:seeAlso <http://identifiers.org/ec-code/2.6.1.2> .
+  # Database: HGNC | Query: 1 | Comment: GPT cross-referenced to EC 2.6.1.2 (alanine transaminase)
+  <http://identifiers.org/ec-code/2.6.1.2> a idt:ec-code .
+  # Database: HGNC | Query: 1 | Comment: typed EC-code cross-reference node
+  <http://identifiers.org/ec-code/2.6.1.2> dct:identifier "2.6.1.2" .
+  # Database: HGNC | Query: 1 | Comment: EC number string = join key to BRENDA
+  <http://identifiers.org/hgnc/976> a m2r:Gene .
+  # Database: HGNC | Query: 1 | Comment: approved human gene BCAT1 (one answer-list member)
+  <http://identifiers.org/hgnc/976> rdfs:label "BCAT1" .
+  # Database: HGNC | Query: 1 | Comment: official gene symbol
+  <http://identifiers.org/hgnc/976> rdfs:seeAlso <http://identifiers.org/ec-code/2.6.1.42> .
+  # Database: HGNC | Query: 1 | Comment: BCAT1 cross-referenced to EC 2.6.1.42
+  <http://identifiers.org/ec-code/2.6.1.42> dct:identifier "2.6.1.42" .
+  # Database: HGNC | Query: 1 | Comment: EC number string = join key to BRENDA
+
+  <https://purl.dsmz.de/brenda/ec/2.6.1.2> a d3o:ECNumber .
+  # Database: BRENDA | Query: 2 | Comment: EC node whose IRI path "2.6.1.2" matches the HGNC EC code
+  <https://purl.dsmz.de/brenda/ec/2.6.1.2> rdfs:label "alanine transaminase" .
+  # Database: BRENDA | Query: 2 | Comment: enzyme name for EC 2.6.1.2 (= GPT)
+  <https://purl.dsmz.de/brenda/inhibitor/1019> a d3o:Inhibitor .
+  # Database: BRENDA | Query: 2 | Comment: inhibitor role node
+  <https://purl.dsmz.de/brenda/inhibitor/1019> d3o:affectsClass <https://purl.dsmz.de/brenda/ec/2.6.1.2> .
+  # Database: BRENDA | Query: 2 | Comment: this inhibition affects EC 2.6.1.2
+  <https://purl.dsmz.de/brenda/inhibitor/1019> d3o:foundIn _:org9606 .
+  # Database: BRENDA | Query: 2 | Comment: documented in the human enzyme context
+  _:org9606 d3o:hasTaxID 9606 .
+  # Database: BRENDA | Query: 2 | Comment: organism is Homo sapiens (NCBI taxID 9606)
+  _:org9606 rdfs:label "Homo sapiens" .
+  # Database: BRENDA | Query: 2 | Comment: organism label
+  <https://purl.dsmz.de/brenda/inhibitor/1019> d3o:refersToCompound <https://purl.dsmz.de/brenda/compound/1019> .
+  # Database: BRENDA | Query: 2 | Comment: the inhibitor compound
+  <https://purl.dsmz.de/brenda/compound/1019> rdfs:label "Aminooxyacetate" .
+  # Database: BRENDA | Query: 2 | Comment: compound = aminooxyacetate
+  <https://purl.dsmz.de/brenda/compound/1019> d3o:hasStructure _:str1019 .
+  # Database: BRENDA | Query: 2 | Comment: structure node for aminooxyacetate
+  _:str1019 d3o:hasInChIKey "InChIKey=NQRKYASMKDDGHT-UHFFFAOYSA-M" .
+  # Database: BRENDA | Query: 2 | Comment: InChIKey confirming compound identity (canonical node, not the salt)
+
+exact_answer:
+  - AADAT
+  - ABAT
+  - AGXT
+  - AGXT2
+  - BCAT1
+  - BCAT2
+  - GOT2
+  - GPT
+  - GPT2
+  - KYAT1
+  - KYAT3
+  - OAT
+  - PSAT1
+  - TAT
+
+ideal_answer: |
+  Fourteen approved human genes encode aminotransferases (EC 2.6.1.-) whose human enzyme is
+  curated as inhibited by aminooxyacetate: AADAT, ABAT, AGXT, AGXT2, BCAT1, BCAT2, GOT2, GPT,
+  GPT2, KYAT1, KYAT3, OAT, PSAT1, and TAT. These span the major transamination reactions of
+  human metabolism — aspartate/alanine transamination (GOT2, GPT, GPT2), branched-chain amino
+  acid catabolism (BCAT1, BCAT2), GABA turnover (ABAT), ornithine and glyoxylate metabolism
+  (OAT, AGXT, AGXT2), serine biosynthesis (PSAT1), and the kynurenine/2-aminoadipate pathways
+  (AADAT, KYAT1, KYAT3). Aminooxyacetate is a general inhibitor of pyridoxal 5'-phosphate
+  (PLP)-dependent enzymes, forming a stable oxime with the PLP cofactor shared by all
+  aminotransferases, which is why it is documented across this broad set. The candidate
+  universe contains 16 human aminotransferase genes; the two not returned are GFPT1 and the
+  cytosolic aspartate aminotransferase GOT1, for which no human-enzyme aminooxyacetate
+  inhibition record is curated — an absence in the current database rather than a biochemical
+  expectation, since GOT1 is a classic PLP transaminase. Answering therefore requires joining
+  the approved human gene/EC nomenclature to organism-resolved enzyme inhibitor curation; it
+  cannot be derived from either source alone or from prior knowledge.
+
+question_template_used: "Cross-database filtered list (HGNC gene symbol <-> BRENDA inhibitor via EC number)"
+
+time_spent:
+  exploration: 50 minutes
+  formulation: 20 minutes
+  verification: 20 minutes
+  pubmed_test: 15 minutes
+  extraction: 20 minutes
+  documentation: 25 minutes
+  total: 150 minutes

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -243,5 +243,7 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 053 | P      | —      |
 | 054 | P      | —      |
 | 055 | P      | —      |
+| 056 | P      | —      |
+| 057 | P      | —      |
 
-**Summary:** `P` = 55 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 55 / 55
+**Summary:** `P` = 57 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 57 / 57


### PR DESCRIPTION
## What

Two new, fully-validated benchmark questions (set grows 55 → 57), generated via the `qa-generator` skill against live RDF endpoints.

### Q056 — factoid · chebi + massbank · KW-0663 Pyridoxal phosphate
How many reference tandem MS/MS spectra are catalogued for pyridoxal 5'-phosphate? **Answer: 22** (all MS2: 14 LC-ESI-QQ + 8 LC-ESI-QTOF). ChEBI supplies the canonical InChIKey; MassBank supplies the spectra. **First question to cover MassBank** (previously the only uncovered life-science DB).

### Q057 — list · hgnc + brenda · KW-0032 Aminotransferase
Approved human gene symbols for EC 2.6.1.- aminotransferases whose human enzyme is documented as inhibited by aminooxyacetate. **Answer: 14 genes** (AADAT, ABAT, AGXT, AGXT2, BCAT1, BCAT2, GOT2, GPT, GPT2, KYAT1, KYAT3, OAT, PSAT1, TAT) — the 16-gene EC 2.6.1.- universe minus GOT1/GFPT1, which lack a curated human inhibition record. Genuine cross-database EC-number join on the shared `primary` endpoint; not guessable from textbook biochemistry, so it requires live curation.

## Tracker reconciliation
- `total_questions` 55 → 57; `factoid` 11 → 12, `list` 11 → 12
- `chebi` 6 → 7; new `massbank` block; `hgnc` 1 → 2; `brenda` 1 → 2
- `multi_database_metrics` and `keywords_used` updated (KW-0663, KW-0032)
- Also corrected two **pre-existing** tracker drifts surfaced by the validator: `go` 8 → 9 (Q003 was missing), `chembl` 7 → 8 (Q007 was missing)

## Validation
`python benchmark/scripts/verify_questions.py` → **0 errors**. Structural Near-Duplicate Guard clean (unique keywords, no signature collisions, no 3+ cluster).

Note: `.claude/settings.json` (session permission accumulation) is intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)