### PR TITLE
QA Q061 + BRENDA MIE fixes + shape-correctness audits + usage-guide BULK MODE

### DIFF
--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -312,8 +312,24 @@ If this fails, fix the YAML before calling the work done.
 1. Re-run the Phase 2b predicate survey and compare against the documented predicates. Any predicate with COUNT > 0 that is absent from the shape must be either added or explicitly noted as intentionally excluded.
 2. Confirm every `@<ShapeRef>` has a defined `<…Shape>` block.
 3. For every predicate marked `?` (optional), confirm with a cardinality query that at least one subject has 0 values for it. For every predicate with no modifier (required), confirm its COUNT equals the class instance count.
+4. **Verify `@<ShapeRef>` object-class conformance — not just that the ref resolves.** Item 2 confirms the *block exists*; this confirms the *objects actually belong to it*. For every predicate written as `<predicate> @<TargetShape>`, GROUP BY the object's `rdf:type` and confirm the result includes `<TargetShape>`'s declared anchor class. A predicate whose objects are *not* typed as the referenced shape's class — or are split across several classes — is a shape error (or an undocumented polymorphic link, cf. Phase 2's polymorphism probe): fix the `@<…>` target, or split it and document the polymorphism. A blank-node target with no `rdf:type` is itself a finding — note it explicitly rather than implying a typed class.
 
-This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example.
+   ```sparql
+   SELECT ?objType (COUNT(*) AS ?n) WHERE {
+     GRAPH <…> { ?s a <SubjectClass> ; <predicate> ?o .
+                 OPTIONAL { ?o a ?objType } }
+   } GROUP BY ?objType ORDER BY DESC(?n)
+   ```
+
+5. **Probe the value type of *every* literal-valued predicate in the shape — not only the ones a query will filter on.** Phase 2's datatype probe (the `DATATYPE()` table) is scoped to literals you plan to match exactly; this is the blanket pass that catches a wrong `xsd:…` annotation on an incidental field. For each predicate whose shape value is a literal datatype, GROUP BY its actual datatype and confirm the shape's annotation matches the stored form. A mismatch (e.g. shape says `xsd:integer`, data stores plain or `xsd:string`), or a predicate that stores **mixed** datatypes, must be corrected in the shape and — if it affects exact matching — surfaced in `critical_warnings`.
+
+   ```sparql
+   SELECT (DATATYPE(?o) AS ?dt) (COUNT(*) AS ?n) WHERE {
+     GRAPH <…> { ?s a <SubjectClass> ; <predicate> ?o }
+   } GROUP BY (DATATYPE(?o)) ORDER BY DESC(?n)
+   ```
+
+This step is not optional. `shape_expressions` is the section a downstream LLM relies on most heavily for query construction. An unaudited shape is equivalent to an untested SPARQL example. Items 4–5 are what separate a shape that is *internally consistent* from one that is *true to the data*: a resolvable `@<ref>` pointing at the wrong object class, or a confidently-wrong datatype, both produce queries that run and silently return nothing.
 
 **5f. Verify `critical_warnings` content.** For every predicate name and IRI string cited in `critical_warnings`, run a minimal query confirming it exists in the endpoint:
 
@@ -363,7 +379,8 @@ Only after Phases 1–5 are complete, report to the user:
   - Statistics verified: [date]
   - YAML parses cleanly
   - shape_expressions audited: all shapes verified against live predicate surveys,
-    all @<ShapeRef>s resolved, all cardinality modifiers confirmed
+    all @<ShapeRef>s resolved AND their object classes confirmed by rdf:type GROUP BY,
+    all cardinality modifiers confirmed, all literal-valued predicates datatype-probed
   - critical_warnings verified: all cited predicate names and IRIs confirmed against endpoint
   - cross_references verified: IRI forms confirmed by DESCRIBE, coverage % from COUNT queries
   - schema_info.categories checked: all tokens exact-matched against list_categories()

--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,7 +96,7 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 60
+total_questions: 61
 
 question_types:
   yes_no:
@@ -105,9 +105,9 @@ question_types:
     status: 'ok'  # 12 uses - balanced 60-question milestone (12 per type)
 
   factoid:
-    count: 12
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056']
-    status: 'ok'  # 12 uses - extending past 50 (target ~total/5)
+    count: 13
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061']
+    status: 'ok'  # 13 uses - first past balanced-60 milestone (Q061)
 
   list:
     count: 12
@@ -251,8 +251,8 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   brenda:
-    count: 2
-    questions: ['053', '057']
+    count: 3
+    questions: ['053', '057', '061']
     status: 'ok'  # newly added life-science DB
 
   jpostdb:
@@ -266,21 +266,21 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   massbank:
-    count: 2
-    questions: ['056', '059']
+    count: 3
+    questions: ['056', '059', '061']
     status: 'ok'  # newly added life-science DB
 
 multi_database_metrics:
   two_plus_databases:
-    count: 60
-    percentage: 100.0  # 60/60 (Q060 is 2-DB: uniprot + oma)
+    count: 61
+    percentage: 100.0  # 61/61 (Q061 is 2-DB: brenda + massbank)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
     count: 22
     questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059']
-    percentage: 36.7  # 22/60 (Q060 is 2-DB: uniprot + oma)
+    percentage: 36.1  # 22/61 (Q061 is 2-DB: brenda + massbank)
     target: '>= 20%'
     status: 'excellent'
 
@@ -345,6 +345,7 @@ keywords_used:
   - 'KW-0195'  # Cyclin (Q058)
   - 'KW-0786'  # Thiamine pyrophosphate (Q059)
   - 'KW-0223'  # Dioxygenase (Q060)
+  - 'KW-0210'  # Decarboxylase (Q061)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_061.yaml
+++ b/benchmark/questions/question_061.yaml
@@ -1,0 +1,211 @@
+---
+id: question_061
+type: factoid
+body: >-
+  Considering the distinct small-molecule products of all enzymatic reactions
+  catalyzed by carboxy-lyase (decarboxylase) enzymes of EC class 4.1.1, how many
+  of these products — counted by unique chemical structure (InChIKey) — have at
+  least one experimental reference tandem mass spectrum available in a public
+  mass-spectral library?
+
+inspiration_keyword:
+  keyword_id: KW-0210
+  name: Decarboxylase
+  category: Molecular function
+
+togomcp_databases_used:
+  - brenda
+  - massbank
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Tried to retrieve the specific count directly from the literature with four
+    PubMed searches: "decarboxylase reaction products mass spectral library
+    MassBank coverage"; "MassBank metabolite coverage enzyme reaction products
+    metabolomics database completeness"; "biogenic amines decarboxylase tandem
+    mass spectrometry reference spectra fraction available"; and the broad
+    "MassBank mass spectral database metabolomics". Read the abstracts of the
+    current MassBank resource paper and the MS/MS identification review returned
+    by the broad search.
+  result: |
+    The three targeted queries returned zero records. The broad query returned
+    16 general records (e.g. the current MassBank resource description, which
+    reports only library-wide totals of 119,845 spectra for 18,529 compounds,
+    and reviews of MS/MS library-search methods that discuss spectral coverage
+    only qualitatively). No publication enumerates how many products of EC 4.1.1
+    decarboxylase reactions are represented in a reference spectral library;
+    the figure requires intersecting an enzyme-reaction product set with a
+    spectral library by chemical-structure identifier.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+sparql_queries:
+  - query_number: 1
+    database: brenda
+    description: >-
+      Enumerate the distinct InChIKeys of all product compounds of reactions
+      classified under any EC 4.1.1.x (carboxy-lyase / decarboxylase) class.
+      The InChIKey lives on the structure node (compound -> hasStructure ->
+      structure -> hasInChIKey) as a string literal prefixed "InChIKey="; the
+      prefix is stripped to obtain the bare key. This is the denominator set
+      (no product compound carries hasInChIKey directly, see query 2, so the
+      structure path is complete). 526 distinct product compounds exist; 467
+      carry at least one InChIKey-bearing structure.
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+      SELECT DISTINCT ?key
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?reaction d3o:catalyzedByClass ?ec .
+        FILTER(STRSTARTS(STR(?ec), "https://purl.dsmz.de/brenda/ec/4.1.1."))
+        ?prod a d3o:Product ; d3o:partOf ?reaction ; d3o:refersToCompound ?compound .
+        ?compound d3o:hasStructure ?struct .
+        ?struct d3o:hasInChIKey ?ikRaw .
+        BIND(STRAFTER(STR(?ikRaw), "InChIKey=") AS ?key)
+      }
+    result_count: 467
+
+  - query_number: 2
+    database: brenda
+    description: >-
+      Completeness check (Rule 2, no undercount): confirm that no EC 4.1.1
+      product compound carries an InChIKey directly on the compound node, so the
+      structure-node path used in query 1 captures every product InChIKey. The
+      count of product compounds with a direct hasInChIKey is 0.
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+      SELECT (COUNT(DISTINCT ?compound) AS ?nCompoundsDirectInChIKey)
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        ?reaction d3o:catalyzedByClass ?ec .
+        FILTER(STRSTARTS(STR(?ec), "https://purl.dsmz.de/brenda/ec/4.1.1."))
+        ?prod a d3o:Product ; d3o:partOf ?reaction ; d3o:refersToCompound ?compound .
+        ?compound d3o:hasInChIKey ?cDirect .
+      }
+    result_count: 0
+
+  - query_number: 3
+    database: massbank
+    description: >-
+      Federated intersection on the shared `primary` endpoint (endpoint_name:
+      primary): for every distinct EC 4.1.1 product InChIKey (from the BRENDA
+      graph), build the identifiers.org InChIKey IRI and require at least one
+      MassBank chemical-substance node bearing that schema:inChIKey IRI. Grouped
+      by key with a representative compound label and the per-compound spectrum
+      count; the number of grouped rows (distinct matched InChIKeys) is 156.
+      Top hits include trans-resveratrol (64), tyramine (63), salicylic acid
+      (53), indole-3-acetic acid (50), 4-hydroxybenzoic acid (50), tryptamine
+      (39), dopamine (34), L-glutamic acid (34), GABA (31), serotonin (29),
+      spermidine (25), cadaverine (14), beta-alanine (20).
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+      PREFIX schema: <https://schema.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?key (SAMPLE(?label) AS ?name) (COUNT(DISTINCT ?mbCompound) AS ?nSpectra)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/brenda> {
+          ?reaction d3o:catalyzedByClass ?ec .
+          FILTER(STRSTARTS(STR(?ec), "https://purl.dsmz.de/brenda/ec/4.1.1."))
+          ?prod a d3o:Product ; d3o:partOf ?reaction ; d3o:refersToCompound ?compound .
+          ?compound rdfs:label ?label ; d3o:hasStructure ?struct .
+          ?struct d3o:hasInChIKey ?ikRaw .
+          BIND(STRAFTER(STR(?ikRaw), "InChIKey=") AS ?key)
+        }
+        BIND(IRI(CONCAT("http://identifiers.org/inchikey/", ?key)) AS ?ikIRI)
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          ?mbCompound schema:inChIKey ?ikIRI .
+        }
+      }
+      GROUP BY ?key
+    result_count: 156
+
+  - query_number: 4
+    database: massbank
+    description: >-
+      Arithmetic verification (Rule 3) of the GROUP BY in query 3: a single
+      COUNT(DISTINCT ?key) over the identical federated criteria confirms the
+      number of distinct EC 4.1.1 product InChIKeys with a MassBank reference
+      spectrum is 156, equal to the row count of query 3.
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+      PREFIX schema: <https://schema.org/>
+      SELECT (COUNT(DISTINCT ?key) AS ?nKeysWithMassBank)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/brenda> {
+          ?reaction d3o:catalyzedByClass ?ec .
+          FILTER(STRSTARTS(STR(?ec), "https://purl.dsmz.de/brenda/ec/4.1.1."))
+          ?prod a d3o:Product ; d3o:partOf ?reaction ; d3o:refersToCompound ?compound .
+          ?compound d3o:hasStructure ?struct .
+          ?struct d3o:hasInChIKey ?ikRaw .
+          BIND(STRAFTER(STR(?ikRaw), "InChIKey=") AS ?key)
+        }
+        BIND(IRI(CONCAT("http://identifiers.org/inchikey/", ?key)) AS ?ikIRI)
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          ?mbCompound schema:inChIKey ?ikIRI .
+        }
+      }
+    result_count: 156
+
+rdf_triples: |
+  @prefix d3o: <https://purl.dsmz.de/schema/> .
+  @prefix schema: <https://schema.org/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+  <https://purl.dsmz.de/brenda/reaction/I_275> d3o:catalyzedByClass <https://purl.dsmz.de/brenda/ec/4.1.1.15> .
+  # Database: BRENDA | Query: 1 | Comment: the IUBMB reaction "L-glutamate = 4-aminobutanoate + CO2" is classified under EC 4.1.1.15 (glutamate decarboxylase), a carboxy-lyase
+  <https://purl.dsmz.de/brenda/product/484> d3o:partOf <https://purl.dsmz.de/brenda/reaction/I_275> .
+  # Database: BRENDA | Query: 1 | Comment: product role node for the EC 4.1.1.15 reaction
+  <https://purl.dsmz.de/brenda/product/484> d3o:refersToCompound <https://purl.dsmz.de/brenda/compound/484> .
+  # Database: BRENDA | Query: 1 | Comment: the product role resolves to the actual chemical compound
+  <https://purl.dsmz.de/brenda/compound/484> rdfs:label "gamma-aminobutyric acid zwitterion" .
+  # Database: BRENDA | Query: 1 | Comment: the product is GABA, a classic decarboxylation output
+  <https://purl.dsmz.de/brenda/compound/484> d3o:hasStructure <https://purl.dsmz.de/brenda/structure/597> .
+  # Database: BRENDA | Query: 1 | Comment: the InChIKey is carried on the structure node, not the compound node
+  <https://purl.dsmz.de/brenda/structure/597> d3o:hasInChIKey "InChIKey=BTCSSZJGUNDROE-UHFFFAOYSA-N" .
+  # Database: BRENDA | Query: 1 | Comment: structure-node InChIKey literal (prefixed "InChIKey="); stripped to BTCSSZJGUNDROE-UHFFFAOYSA-N for the join
+  _:massbankGABA schema:inChIKey <http://identifiers.org/inchikey/BTCSSZJGUNDROE-UHFFFAOYSA-N> .
+  # Database: MassBank | Query: 3 | Comment: a MassBank chemical-substance node (e.g. nodeID://b1833386727, label "GABA") bears the matching InChIKey IRI, so GABA is one of the 156 matched products
+  <https://purl.dsmz.de/brenda/compound/437> rdfs:label "cadaverine" .
+  # Database: BRENDA | Query: 3 | Comment: cadaverine, product of lysine decarboxylase (EC 4.1.1.18), is another matched product
+  _:massbankCadaverine schema:inChIKey <http://identifiers.org/inchikey/VHRGRCVQAFMJIZ-UHFFFAOYSA-N> .
+  # Database: MassBank | Query: 3 | Comment: cadaverine has 14 distinct MassBank reference spectra under this InChIKey IRI
+
+exact_answer: 156
+
+ideal_answer: |
+  Carboxy-lyase enzymes of EC class 4.1.1 catalyze reactions whose recorded
+  products span 467 chemically distinct structures (counted by InChIKey), drawn
+  from 526 product compound records across 125 individual EC 4.1.1 sub-subclasses.
+  Of these 467 distinct products, 156 (about 33%) have at least one experimental
+  reference tandem mass spectrum in a public mass-spectral library. The covered
+  products are dominated by biologically prominent decarboxylation outputs:
+  biogenic amines and amino-acid-derived metabolites such as tyramine, dopamine,
+  serotonin, tryptamine, cadaverine, gamma-aminobutyric acid (GABA), beta-alanine
+  and spermidine, alongside aromatic acids and related small molecules including
+  salicylic acid, 4-hydroxybenzoic acid, indole-3-acetic acid and trans-resveratrol.
+  The remaining two-thirds of EC 4.1.1 products lack reference spectra, reflecting
+  that many decarboxylase substrates, charged zwitterions and unstable
+  intermediates are under-represented in curated spectral collections. The figure
+  of 156 is the number of unique chemical structures shared between the
+  decarboxylase reaction-product set and the spectral library, quantifying how
+  much of EC 4.1.1 product chemistry is currently characterized by experimental
+  fragmentation data.
+
+question_template_used: Cross-database InChIKey intersection - count of enzyme-reaction products with reference mass spectra
+
+time_spent:
+  exploration: 20
+  formulation: 12
+  verification: 8
+  pubmed_test: 12
+  extraction: 8
+  documentation: 12
+  total: 72

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -248,5 +248,6 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 058 | P      | —      |
 | 059 | P      | —      |
 | 060 | P      | —      |
+| 061 | P      | —      |
 
-**Summary:** `P` = 60 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 60 / 60
+**Summary:** `P` = 61 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 61 / 61

--- a/togo_mcp/data/mie/brenda.yaml
+++ b/togo_mcp/data/mie/brenda.yaml
@@ -38,9 +38,9 @@ schema_info:
     - http://rdfportal.org/dataset/brenda
   kw_search_tools: []
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-28"
-    mie_updated: "2026-04-29"
+    mie_updated: "2026-06-30"
     data_version: "Release 2026"
     update_frequency: "Irregular"
   access:
@@ -60,7 +60,8 @@ critical_warnings: |
   - EFFECTOR ROLES ARE CONTEXT-SPECIFIC: Inhibitor and Activator IRIs represent the
     *role* of a compound in context, not the compound itself. Each inhibitor/activator
     node has `d3o:refersToCompound` → the actual ChemicalCompound node (which holds
-    the label, InChI, and InChIKey). Do not expect structural data on the inhibitor IRI.
+    the label; its InChI/InChIKey live on a separate MolecularStructure node reached via
+    `d3o:hasStructure`, see below). Do not expect structural data on the inhibitor IRI.
   - REACTION IRI PREFIXES: Reactions have two subtypes in their IRI: `reaction/I_N`
     (IUBMB reactions, canonical) and `reaction/S_N` (substrate-specific variants).
     The predicate `d3o:isIubmbReaction` is present on IUBMB reactions. Both types have
@@ -74,6 +75,25 @@ critical_warnings: |
   - TISSUE AND LOCALIZATION USE `d3o:expresses`: Tissue and Localization nodes link to
     enzymes via `d3o:expresses` (not `d3o:foundIn`). The predicate direction is:
     tissue/localization → enzyme, not enzyme → tissue/localization.
+  - STRUCTURE DATA IS ONE HOP FROM THE COMPOUND: InChI and InChIKey are NOT on the
+    ChemicalCompound node — they live on a MolecularStructure node reached via
+    `?compound d3o:hasStructure ?struct ; ?struct d3o:hasInChIKey ?k`. Querying
+    `?compound d3o:hasInChIKey` directly returns 0 rows. Each compound has at most ONE
+    InChIKey-bearing structure (there is never more than one distinct InChIKey per
+    compound), but only ~80% of compounds (171,721 of 214,688) have one — the other ~20%
+    carry only dangling `hasStructure` references to untyped stub nodes with no InChI/
+    InChIKey, so the join above yields nothing for them. A compound may list several
+    `hasStructure` objects, but at most one resolves to a real typed MolecularStructure;
+    the rest are empty stubs. Use an OPTIONAL on the structure→InChIKey hop if you need to
+    keep structure-less compounds in the result.
+  - INCHIKEY LITERAL CARRIES AN `InChIKey=` PREFIX: `d3o:hasInChIKey` stores the value as
+    `"InChIKey=ATHGHQPFGPMSJY-UHFFFAOYSA-N"`, NOT the bare `"ATHGHQPFGPMSJY-UHFFFAOYSA-N"`.
+    Exact-matching a bare key — `FILTER(?k = "ATHGHQPFGPMSJY-UHFFFAOYSA-N")` or a `VALUES`
+    block of bare keys — returns 0 rows (the #1 silent-fail spot here). To match, or to
+    federate to MassBank / ChEBI / PubChem (which key on the bare InChIKey, e.g. the IRI
+    `http://identifiers.org/inchikey/<KEY>`), strip the prefix first:
+    `BIND(STRAFTER(STR(?k), "InChIKey=") AS ?key)`. (The InChI literal likewise begins
+    `"InChI=1S/..."`, but that is the standard InChI form, so InChI needs no stripping.)
 
 shape_expressions: |
   PREFIX d3o:  <https://purl.dsmz.de/schema/>
@@ -97,7 +117,7 @@ shape_expressions: |
     rdfs:label xsd:string ;          # enzyme common name, e.g. "ornithine decarboxylase"
     dct:description xsd:string ;     # IUBMB description, e.g. "A pyridoxal-phosphate protein."
     d3o:hasSynonyms xsd:string + ;   # gene names, isoform names, synonyms
-    d3o:hasSystematicName xsd:string # IUBMB systematic name
+    d3o:hasSystematicName xsd:string ? # IUBMB systematic name; ~91% of EC classes (6,793 of 7,453)
   }
 
   # IRI pattern: https://purl.dsmz.de/brenda/organism/{N}
@@ -106,7 +126,7 @@ shape_expressions: |
     a [ d3o:BiologicalMaterial ] ;
     rdfs:label xsd:string ;          # organism name/strain
     d3o:hasSynonym xsd:string * ;    # synonyms including taxonomic lineage strings
-    d3o:hasTaxID xsd:integer ? ;     # NCBI Taxonomy ID as integer; ~50% coverage
+    d3o:hasTaxID xsd:int ? ;         # NCBI Taxonomy ID, stored as xsd:int (~49% coverage, 14,976 nodes); Virtuoso value-matches a plain `9606` literal
     d3o:hasIdentifier IRI ?          # link to external taxonomy resource
   }
 
@@ -147,17 +167,20 @@ shape_expressions: |
   <CompoundShape> {
     a [ d3o:ChemicalCompound d3o:ChemicalMaterial ] ;
     rdfs:label xsd:string ;          # compound name, e.g. "spermidine"
-    d3o:hasIdentifier xsd:integer ;  # internal BRENDA compound ID integer
+    d3o:hasIdentifier xsd:int ;      # internal BRENDA compound ID (stored as xsd:int)
     d3o:hasSynonym xsd:string * ;    # alternative names
-    d3o:hasStructure @<StructureShape> +  # one or more molecular structure entries
+    d3o:hasStructure @<StructureShape> +  # 1+ links; ~80% of compounds have one TYPED structure (below), the rest are dangling untyped stubs
   }
 
   # IRI pattern: https://purl.dsmz.de/brenda/structure/{N}
-  # ~171,721 structure entries
+  # 171,721 typed structure entries — one per the 80% of compounds that have InChI data.
+  # NOTE: ~107K hasStructure objects are dangling untyped nodes (no triples) and do NOT
+  # match this shape; filter on `?struct a d3o:MolecularStructure` (or just require
+  # d3o:hasInChIKey) to keep only real structures.
   <StructureShape> {
     a [ d3o:MolecularStructure ] ;
-    d3o:hasInChI xsd:string ;        # InChI string for structure lookup
-    d3o:hasInChIKey xsd:string       # InChIKey for exact-match searches
+    d3o:hasInChI xsd:string ;        # InChI string, stored with the standard "InChI=1S/..." prefix
+    d3o:hasInChIKey xsd:string       # InChIKey, stored WITH a non-standard "InChIKey=" prefix — strip via STRAFTER for bare-key matching/federation (see critical_warnings)
   }
 
   # IRI pattern: https://purl.dsmz.de/brenda/reaction/{I_N or S_N}
@@ -167,7 +190,7 @@ shape_expressions: |
     rdfs:label xsd:string ;              # reaction equation string, e.g. "L-ornithine = putrescine + CO2"
     d3o:catalyzedBy @<EnzymeShape> * ;   # specific enzyme instances
     d3o:catalyzedByClass @<ECNumberShape> + ;  # EC class(es) that catalyze this
-    d3o:isIubmbReaction xsd:boolean ? ; # present on IUBMB canonical reactions (I_ prefix)
+    d3o:isIubmbReaction xsd:boolean ;   # on EVERY reaction: true for the 8,674 IUBMB (I_) reactions, false for the 131,186 substrate-specific (S_) variants
     d3o:partOf @<PathwayShape> * ;
     d3o:hasReference @<ReferenceShape> *
   }
@@ -542,8 +565,8 @@ architectural_notes:
 
   data_quality:
     - "Organism nodes are strain-specific (e.g. 'Saccharomyces cerevisiae X 2180') — multiple per species"
-    - "hasTaxID is present on ~50% of organism nodes; absent entries need label-based lookup"
-    - "Compounds have multiple structure nodes (different stereoisomers, salts, isotopes)"
+    - "hasTaxID is present on ~49% of organism nodes (14,976 of 30,338); absent entries need label-based lookup"
+    - "InChIKey/structure coverage is ~80% (171,721 of 214,688 compounds), exactly one InChIKey each; the other ~20% have only dangling hasStructure stubs with no InChI/InChIKey"
     - "Inhibitor/139 (spermidine) affects 100+ EC classes — very broad inhibitor nodes exist"
 
   text_search_justification:
@@ -555,8 +578,8 @@ architectural_notes:
 
 data_statistics:
   total_entities: 54720
-  verified_date: "2026-04-28"
-  verification_method: "Direct COUNT on d3o:Enzyme instances from earlier class-count query"
+  verified_date: "2026-06-30"
+  verification_method: "Direct COUNT on d3o:Enzyme instances; all class counts below re-verified 2026-06-30 against the live graph and unchanged from 2026-04-28 (Release 2026)"
 
   coverage:
     enzyme_instances:
@@ -570,7 +593,15 @@ data_statistics:
     compounds:
       value: "214,688 chemical compounds"
       calculation: "COUNT of d3o:ChemicalCompound class"
-      verified_date: "2026-04-28"
+      verified_date: "2026-06-30"
+    structures:
+      value: "171,721 typed MolecularStructure nodes (with InChI + InChIKey)"
+      calculation: "COUNT of d3o:MolecularStructure class"
+      verified_date: "2026-06-30"
+    compounds_with_inchikey:
+      value: "171,721 compounds carry an InChIKey (80.0% of 214,688); exactly one key each"
+      calculation: "COUNT(DISTINCT ?cmpd) where ?cmpd d3o:hasStructure/d3o:hasInChIKey ?k — remaining ~20% have only dangling hasStructure stubs"
+      verified_date: "2026-06-30"
     reactions:
       value: "139,860 reactions"
       calculation: "COUNT of d3o:Reaction class"

--- a/togo_mcp/data/resources/togomcp_usage_guide_v5.md
+++ b/togo_mcp/data/resources/togomcp_usage_guide_v5.md
@@ -20,10 +20,33 @@ any follow-up that extends a prior answer / any message with no bounded answer i
 
 ---
 
+## ⛔ GATE 0a — WORKLOAD TYPE (check this too, orthogonal to GATE 0)
+
+Does the task require enumerating/processing a result set whose size is
+unknown but plausibly large (counts in the thousands+), or comparing
+full graph contents rather than a sample?
+
+Signals: "all triples", "every X", "compare graph A vs B in full",
+"how many total", "extract the full set of Y for offline analysis",
+"audit/diff an ontology against its data usage".
+
+```
+Interactive (bounded, sample-sized) → proceed to GATE 0 as today
+Bulk/heavy (large or unknown extent) → see BULK MODE section below.
+  Do NOT run an unbounded SPARQL query directly — the endpoint has a
+  ~60s ceiling and will very likely time out, burning a tool call for
+  nothing. Probe size first.
+```
+
+---
+
 ## 🚫 CRITICAL RULES
 
-**1. No filesystem or scripting tools.** 8× slower, 2× more tool calls, wrong answers.
-If post-processing feels necessary, the SPARQL query is wrong — fix it instead.
+**1. No filesystem or scripting tools — for interactive/bounded questions.**
+8× slower, 2× more tool calls, wrong answers *in that regime*. If
+post-processing feels necessary on a bounded question, the SPARQL query
+is wrong — fix it instead. For bulk/heavy workloads (GATE 0a), see
+BULK MODE — scripting is the correct tool there, not a workaround.
 
 **2. Max 2 consecutive `run_sparql` calls.** Counter resets after any non-SPARQL call.
 At call #3: stop. Pivot to a search tool, `ncbi_esearch`, `togoid_convertId`, or
@@ -208,6 +231,39 @@ cross-DB → `ncbi_esummary` for detail → one concise paragraph. Each fact onc
 
 ---
 
+## 🏗️ BULK MODE — heavy retrieval / full comparison tasks
+
+Triggered by GATE 0a. Treat `run_sparql` as a probe, not a retrieval
+engine, once a task leaves bounded/sample-sized territory.
+
+1. **Study the shape first, with cheap bounded probes only:**
+   - `get_MIE_file(database)` — schema + `critical_warnings`.
+   - `get_graph_list(database)` — which named graphs hold what.
+   - `COUNT(*)` queries to size the problem before touching it:
+     `SELECT (COUNT(*) AS ?c) WHERE { ... }` — never skip sizing an
+     unbounded task.
+   - One or two `LIMIT 50` samples to confirm predicate/datatype shape.
+
+2. **Decide:** can this be done in ≤2–3 bounded SPARQL calls (one
+   `GROUP BY`, one `VALUES` batch)? If yes, stay in normal SPARQL
+   discipline (LIMIT, max 2 consecutive) — this was not actually bulk.
+
+3. **If not, switch to scripting:**
+   - Extract via paginated SPARQL (`OFFSET`/`LIMIT` loops, ~5k–10k
+     rows/page) driven from a script, not one giant query.
+   - Do joins, set comparison, ontology diffing, and aggregation
+     locally after extraction — not server-side in one query.
+   - Example from practice: confirming whether a predicate is defined
+     as part of an ontology vs. only used in data — probe `get_graph_list`
+     → bounded `COUNT(*)` per candidate graph → only escalate to a
+     scripted/paginated pull if a full dump turns out to be necessary.
+
+4. **Never retry an unbounded query verbatim after a timeout.** Either
+   add `LIMIT`/`OFFSET` pagination, narrow with a specific
+   `GRAPH`/`VALUES` clause, or fall back to scripted pagination per (3).
+
+---
+
 ## ⚠️ KNOWN-HARD QUERIES
 
 | Pattern | Fallback |
@@ -217,6 +273,7 @@ cross-DB → `ncbi_esummary` for detail → one concise paragraph. Each fact onc
 | Human metalloprotease targets + structure counts | `togoid_convertId uniprot→pdb`; report counts separately. |
 | Rhea reactions filtered by UniProt keyword | Read UniProt MIE for keyword IRI (`up:classifiedWith`); EC-prefix fallback overcounts. |
 | Bacterial gene counts via NCBI | Field tags mandatory: `"Archaea[Organism] AND nifH[Gene Name]"` — omitting loses 70–80%. |
+| Full predicate/ontology coverage across many graphs | `COUNT`-first probing per graph (BULK MODE), not one cross-graph query |
 
 ---
 


### PR DESCRIPTION
Four related improvements from one session, grouped as separate commits.

## 1. `benchmark(qa)`: add question 061
Factoid, **brenda + massbank** (novel two-DB pairing joined on InChIKey over the shared `primary` endpoint): of the 467 distinct InChIKeys among products of EC 4.1.1 carboxy-lyase reactions, **156 (33%)** have a MassBank reference spectrum. First question past the balanced-60 milestone (factoid 12→13; brenda & massbank each 2→3). All counts live-verified; both necessity gates pass; full validator reports 0 errors.

## 2. `skills(mie-generator)`: shape-correctness audits (Phase 5e.4 / 5e.5)
Closes the gap between a shape that is *internally consistent* and one that is *true to the data*:
- **5e.4** — verify `@<ShapeRef>` object-class conformance via `rdf:type` GROUP BY, not just that the referenced block exists.
- **5e.5** — blanket `DATATYPE()` probe of every literal-valued predicate, not only the ones a query filters on.

Both ship with copy-ready helper queries; sign-off checklist updated.

## 3. `mie(brenda)`: correct InChIKey/structure modeling, re-verify (v2.2)
Driven by the new 5e audits against the live endpoint:
- InChIKey coverage is **~80%** (171,721/214,688), **exactly one key per compound**; the other ~20% carry only dangling untyped `hasStructure` stubs. Corrects an earlier "several structure nodes / use COUNT DISTINCT" rationale and the `data_quality` note.
- `hasIdentifier` & `hasTaxID` are `xsd:int` (not `xsd:integer`); Virtuoso value-matches a plain literal, so example queries are unaffected.
- `isIubmbReaction` is on **every** reaction (8,674 true / 131,186 false), not just IUBMB; `hasSystematicName` ~91% (now optional).
- `data_statistics` gains `structures` and `compounds_with_inchikey`; all 13 class counts re-verified unchanged (Release 2026).

## 4. `docs(usage-guide)`: BULK MODE for heavy/full-comparison workloads
- **GATE 0a** classifies workload type (bounded vs bulk/unknown-extent), orthogonal to GATE 0.
- CRITICAL RULES item 1 rescoped to interactive/bounded questions; scripting is the correct tool for bulk workloads.
- New **BULK MODE** section: probe size first (`COUNT`/`get_graph_list`/`LIMIT`), decide if ≤2–3 bounded calls suffice, else paginate via script; never retry an unbounded query verbatim after a timeout.
- KNOWN-HARD QUERIES gains a full predicate/ontology-coverage row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)