### PR TITLE
fix(tools): correct tool contracts and improve find_databases keyword matching for LLM handling

### DIFF
--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -8,6 +8,8 @@ import respx
 
 from togo_mcp.api_tools import (
     _resolve_query_alias,
+    search_chembl_id_lookup,
+    search_chembl_molecule,
     search_chembl_target,
     search_pdb_entity,
     search_reactome_entity,
@@ -109,6 +111,45 @@ class TestSearchChemblTarget:
         assert result["total_count"] == 1
         assert result["results"][0]["chembl_id"] == "CHEMBL203"
         assert result["results"][0]["name"] == "EGFR"
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates_error_key(self) -> None:
+        """An upstream failure must surface as {'error': ...}, NOT collapse into
+        an empty {'total_count': 0, 'results': []} that reads as 'no matches'.
+
+        Regression: previously the caller did bulk.get('targets', []) on the
+        error dict, swallowing the failure.
+        """
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(return_value=httpx.Response(500, text="Server Error"))
+            result = await search_chembl_target("EGFR")
+        assert "error" in result
+        assert "ChEMBL REST API request failed" in result["error"]
+        assert "total_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_molecule_http_error_propagates_error_key(self) -> None:
+        """search_chembl_molecule propagates the upstream-failure payload."""
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/molecule/search.json"
+            ).mock(return_value=httpx.Response(500, text="Server Error"))
+            result = await search_chembl_molecule("aspirin")
+        assert "error" in result
+        assert "total_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_id_lookup_http_error_propagates_error_key(self) -> None:
+        """search_chembl_id_lookup propagates the upstream-failure payload."""
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
+            ).mock(return_value=httpx.Response(500, text="Server Error"))
+            result = await search_chembl_id_lookup("CHEMBL25")
+        assert "error" in result
+        assert "total_count" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_json_string_returns.py
+++ b/tests/test_json_string_returns.py
@@ -13,7 +13,12 @@ import httpx
 import pytest
 import respx
 
-from togo_mcp.rdf_portal import find_databases, list_databases
+from togo_mcp.rdf_portal import (
+    _keyword_matches,
+    _singularize,
+    find_databases,
+    list_databases,
+)
 from togo_mcp.togoid import convertId, getRelation
 
 _TOGOID = "https://api.togoid.dbcls.jp"
@@ -35,6 +40,44 @@ class TestRdfPortalListReturns:
         hit = find_databases(keywords=["protein"])
         assert isinstance(hit, str)
         assert isinstance(json.loads(hit), list)
+
+
+class TestKeywordMatcher:
+    """Multi-word / plural / word-order matching for find_databases.
+
+    Regression for phrase misses: "drug targets" and "clinical variants" are
+    hinted verbatim in the Usage Guide but previously returned [] because the
+    matcher did a brittle whole-phrase substring test against space-joined
+    curated keywords.
+    """
+
+    def test_singularize_drops_trailing_s(self) -> None:
+        assert _singularize("targets") == "target"
+        assert _singularize("variants") == "variant"
+
+    def test_singularize_leaves_ss_and_short_words(self) -> None:
+        assert _singularize("class") == "class"  # 'ss' ending kept
+        assert _singularize("is") == "is"  # too short
+        assert _singularize("kinase") == "kinase"  # no trailing 's'
+
+    def test_phrase_matches_out_of_order_and_plural(self) -> None:
+        hay = "compound drug target bioactivity assay"
+        assert _keyword_matches("drug targets", hay)  # plural + adjacent
+        assert _keyword_matches("targets of drugs", hay)  # reordered + stopword
+
+    def test_phrase_requires_all_content_tokens(self) -> None:
+        hay = "compound drug bioactivity assay"  # no 'target'
+        assert not _keyword_matches("drug targets", hay)
+
+    def test_drug_targets_finds_chembl_first(self) -> None:
+        res = json.loads(find_databases(keywords="drug targets"))
+        dbs = [r["database"] for r in res]
+        assert "chembl" in dbs
+        assert dbs[0] == "chembl"  # ranked first
+
+    def test_clinical_variants_finds_clinvar(self) -> None:
+        res = json.loads(find_databases(keywords="clinical variants"))
+        assert "clinvar" in [r["database"] for r in res]
 
 
 class TestTogoidListReturns:

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -158,7 +158,10 @@ async def search_uniprot_entity(
         limit (int): The maximum number of results to return. Default is 20.
 
     Returns:
-        str: TSV-formatted results with columns: accession, protein_name, organism_name.
+        str: TSV-formatted results with columns: accession, protein_name,
+        organism_name. On upstream/HTTP failure this tool does NOT raise — it
+        returns a plain string beginning with "Error:" (not TSV). Check for that
+        prefix before parsing rows.
     """
     query = _resolve_query_alias(
         query,
@@ -249,7 +252,10 @@ async def search_chembl_id_lookup(
     `search`, `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Returns:
-        str: A JSON-formatted string containing the search results.
+        dict: {'total_count' (int), 'results' (list)} where each result has
+        'chembl_id', 'entity_type', and 'score'. On upstream/HTTP failure this
+        tool does NOT raise — it returns a dict with a single 'error' key
+        instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -266,6 +272,10 @@ async def search_chembl_id_lookup(
             "search, term, keyword, keywords, search_term, name."
         )
     bulk = await search_chembl_generic("chembl_id_lookup", query, limit)
+    if "error" in bulk:
+        # Propagate the upstream-failure payload rather than silently
+        # collapsing it into an empty {'total_count': 0, 'results': []}.
+        return bulk
     total_count = bulk.get("page_meta", {}).get("total_count", 0)
     parsed_results = []
     for result in bulk.get("chembl_id_lookups", []):
@@ -343,8 +353,10 @@ async def search_chembl_target(
         - CELL-LINE: Cell line target
         - ORGANISM: Whole organism target
 
-    Raises:
-        httpx.HTTPError: If the API request fails
+    On upstream/HTTP failure this tool does NOT raise — it returns a dict with a
+    single 'error' key (a message plus a "fall back to SPARQL" hint) instead of
+    the usual {'total_count', 'results'} shape. Check for 'error' before reading
+    'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -361,6 +373,10 @@ async def search_chembl_target(
             "search, term, keyword, keywords, search_term, name."
         )
     bulk = await search_chembl_generic("target", query, limit)
+    if "error" in bulk:
+        # Propagate the upstream-failure payload rather than silently
+        # collapsing it into an empty {'total_count': 0, 'results': []}.
+        return bulk
     total_count = bulk.get("page_meta", {}).get("total_count", 0)
 
     parsed_results = []
@@ -444,8 +460,10 @@ async def search_chembl_molecule(
         - Higher scores indicate better matches to the query
         - For structure-based searches, use SMILES or InChI notation
 
-    Raises:
-        httpx.HTTPError: If the API request fails
+    On upstream/HTTP failure this tool does NOT raise — it returns a dict with a
+    single 'error' key (a message plus a "fall back to SPARQL" hint) instead of
+    the usual {'total_count', 'results'} shape. Check for 'error' before reading
+    'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -462,6 +480,10 @@ async def search_chembl_molecule(
             "search, term, keyword, keywords, search_term, name."
         )
     bulk = await search_chembl_generic("molecule", query, limit)
+    if "error" in bulk:
+        # Propagate the upstream-failure payload rather than silently
+        # collapsing it into an empty {'total_count': 0, 'results': []}.
+        return bulk
     total_count = bulk.get("page_meta", {}).get("total_count", 0)
     parsed_results = []
     for molecule in bulk.get("molecules", []):
@@ -485,7 +507,9 @@ async def get_pubchem_compound_id(compound_name: str) -> str:
     Args: Compound name
         example: "resveratrol"
 
-    Returns: PubChem Compound ID in the JSON format
+    Returns: PubChem Compound ID in the JSON format. On upstream/HTTP failure
+        this tool does NOT raise — it returns a plain string beginning with
+        "Error:" (not JSON). Check for that prefix before parsing.
     """
     url = f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound_name}/cids/JSON"
     try:
@@ -513,7 +537,9 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
     Args: PubChem Compound ID
         example: "445154"
 
-    Returns: Compound attributes in the JSON format
+    Returns: Compound attributes in the JSON format. On upstream/HTTP failure
+        this tool does NOT raise — it returns a plain string beginning with
+        "Error:" (not JSON). Check for that prefix before parsing.
     """
     url = "https://togodx.dbcls.jp/human/sparqlist/api/metastanza_pubchem_compound"
     params = {"id": pubchem_compound_id}
@@ -820,7 +846,10 @@ async def search_mesh_descriptor(
         limit (int): The maximum number of results to return. Default is 10.
 
     Returns:
-        str: A JSON-formatted string containing the search results.
+        str: A JSON-formatted string containing the search results. On
+        upstream/HTTP failure this tool does NOT raise — it returns a plain
+        string beginning with "Error:" (not JSON). Check for that prefix before
+        parsing.
     """
     query = _resolve_query_alias(
         query,

--- a/togo_mcp/ncbi_tools.py
+++ b/togo_mcp/ncbi_tools.py
@@ -164,10 +164,15 @@ def _validate_query_field_tags(query: str, database: str) -> dict[str, Any]:
             issues.append(f"Term '{term}' found without [Organism] field tag")
             suggestions.append(f"Consider: '{term.capitalize()}[Organism]'")
 
-    # Detect potential gene symbols without [Gene Name] tag (uppercase 3+ letters)
+    # Detect potential gene symbols without [Gene Name] tag (uppercase 3+ letters).
+    # Exclude boolean operators, which are also all-caps and would otherwise be
+    # flagged as gene symbols (e.g. suggesting 'AND[Gene Name]').
     if database == "gene":
         gene_pattern = r"\b[A-Z]{3,}\d*\b"
-        potential_genes = re.findall(gene_pattern, query)
+        _boolean_ops = {"AND", "OR", "NOT"}
+        potential_genes = [
+            g for g in re.findall(gene_pattern, query) if g not in _boolean_ops
+        ]
         if potential_genes and "[Gene Name]" not in query:
             issues.append(
                 f"Potential gene symbols found without [Gene Name] tag: {', '.join(set(potential_genes))}"

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -430,6 +430,42 @@ def _normalize_terms(value: str | list[str] | None) -> list[str]:
     return [s.strip().lower() for s in value if isinstance(s, str) and s.strip()]
 
 
+# Filler words dropped from multi-word keyword phrases so a phrase like
+# "mechanism of action" matches on its content words, not the connective tissue.
+_PHRASE_STOPWORDS = frozenset(
+    {"of", "the", "and", "or", "a", "an", "for", "to", "in", "on", "with"}
+)
+
+
+def _singularize(token: str) -> str:
+    """Naive plural→singular: drop a trailing 's' so a query for "targets"
+    matches curated "target" and "variants" matches "variant". Leaves 'ss'
+    endings and short words alone (class, is, gas)."""
+    if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+        return token[:-1]
+    return token
+
+
+def _keyword_matches(keyword: str, haystack: str) -> bool:
+    """True if `keyword` matches `haystack`.
+
+    A user keyword may be a multi-word phrase (e.g. "drug targets"). It matches
+    when every content token is found in the haystack as a substring —
+    order-independent and plural-tolerant (each token is tested both as-is and
+    singularized). This is deliberately looser than a literal phrase-substring
+    test, which brittly failed on word order and plurals: "drug targets" missed
+    the curated "drug"+"target", and "clinical variants" missed "clinical
+    significance"+"variant". Both are hinted verbatim in the Usage Guide, so the
+    matcher must honor them.
+    """
+    tokens = [t for t in keyword.split() if t not in _PHRASE_STOPWORDS]
+    if not tokens:  # phrase was entirely stopwords — fall back to raw tokens
+        tokens = keyword.split()
+    if not tokens:
+        return False
+    return all((t in haystack) or (_singularize(t) in haystack) for t in tokens)
+
+
 def _make_snippet(text: str, keyword: str, context: int = 80) -> str:
     """Return ~context chars surrounding the first occurrence of keyword (case-insensitive).
     Falls back to the leading slice when no match is found."""
@@ -452,8 +488,14 @@ def find_databases(
         str | list[str] | None,
         Field(
             description=(
-                "Keyword or list of keywords (case-insensitive substring match against "
-                "title, description, and the database's curated keywords field)."
+                "Data-type / domain keyword(s) describing the KIND of data you "
+                "need (e.g. 'drug targets', 'variants', 'expression', 'pathways', "
+                "'orthologs'), as a single string or a list. Matched (case-"
+                "insensitively, order- and plural-tolerant) against each database's "
+                "title, description, and curated keywords. Prefer several related "
+                "terms (OR-matched) over one narrow phrase. Do NOT pass specific "
+                "entities (gene symbols, drug names, accessions) — use the search_* "
+                "tools for those."
             )
         ),
     ] = None,
@@ -488,17 +530,34 @@ def find_databases(
     """
     Database discovery — REQUIRED first step for any TogoMCP workflow.
 
-    Always call this BEFORE `get_MIE_file()` or `run_sparql()`. Pass any search
-    terms you have (gene, pathway, drug target, variant, organism, disease,
-    enzyme class, etc.) as `keywords`. Returns 1–3 candidate databases scoped
-    to your terms — much more efficient than browsing the full catalog.
+    Always call this BEFORE `get_MIE_file()` or `run_sparql()`. Returns 1–3
+    candidate databases scoped to your terms — much more efficient than browsing
+    the full catalog.
+
+    HOW TO CHOOSE `keywords` (this is what makes or breaks the search):
+    - Match is against each database's curated KIND-OF-DATA vocabulary, plus its
+      title and description — NOT against specific entities. So feed data-type /
+      domain words: "drug targets", "variants", "expression", "pathways",
+      "orthologs", "structures", "compounds", "reactions", "glycans".
+    - Do NOT pass a specific entity as a keyword — a gene symbol (BRCA1), drug
+      name (imatinib), accession (P04637), or a narrow class term (kinase,
+      GPCR). Those are not in the index and will miss; look entities up with the
+      `search_*` tools (search_uniprot_entity, search_chembl_target, …) instead.
+    - Pass SEVERAL related terms as a list, not one narrow phrase. Matching is
+      OR by default (`match="any"`), so more synonyms = higher recall, e.g.
+      keywords=["drug target", "inhibitor", "bioactivity"] rather than just
+      "kinase". Multi-word phrases and plurals are handled (each content word is
+      matched independently and singularized).
+    - If the result is empty, GENERALIZE: swap the term for a broader
+      data-domain synonym ("kinase" → "enzyme" / "drug target"; "SNP" →
+      "variant") and retry, or call `list_categories()` to browse domains.
 
     Workflow:
     1. find_databases(keywords=[...]) — identify 1–3 relevant databases.
     2. get_MIE_file(database) — learn each candidate's schema and SPARQL idioms.
     3. run_sparql() — query with the discovered structured properties.
 
-    Common keywords to try: "MANE" (Ensembl), "drug targets" (ChEMBL),
+    Proven keywords: "MANE" (Ensembl), "drug targets" (ChEMBL),
     "clinical variants" (ClinVar), "pathways" (Reactome), "variants" (gnomAD),
     "ortholog" (OMA), "expression" (Bgee).
 
@@ -529,7 +588,7 @@ def find_databases(
             r["description"].lower(),
             " ".join(r["keywords"]),
         ])
-        matched = [k for k in kw_list if k in haystack]
+        matched = [k for k in kw_list if _keyword_matches(k, haystack)]
 
         if kw_list:
             if match == "all" and len(matched) < len(kw_list):

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -293,12 +293,15 @@ async def get_MIE_file(
     dbname: str = "",
     db: str = "",
 ) -> str:
-    f"""
+    """
     Get the MIE file containing the ShEx schema, RDF and SPARQL examples of a specific RDF database in YAML format, which can be used as a hint to build SPARQL queries.
+
+    (The authoritative list of supported `database` values is injected into the
+    tool `description=` on the decorator above; see DATABASE_DESCRIPTION.)
 
     Args:
         database (str): The name of the database for which to retrieve the shape expression.
-            Accepts aliases `dbname` and `db`. Supported values are {", ".join(SPARQL_ENDPOINT.keys())}.
+            Accepts aliases `dbname` and `db`.
         dbname (str, optional): Alias for `database`.
         db (str, optional): Alias for `database`.
 

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -86,6 +86,9 @@ async def getRelation(source: str, target: str) -> str:
     before calling convertId. Also reveals the nature of the relationship
     (e.g., "encoded by", "has structure", "is target of").
 
+    This is a single-hop, pairwise check: pass `source` and `target` as two
+    separate args (unlike convertId, which takes one comma-joined `route`).
+
     Args:
         source: Source database key (e.g., 'uniprot', 'ncbigene', 'chembl_target')
         target: Target database key (e.g., 'pdb', 'ensembl_gene', 'hgnc')
@@ -214,7 +217,9 @@ async def convertId(
             (e.g., ["672", "675", "7157"]) or a comma-separated string
             ("672,675,7157").
             Examples: "672,675,7157" (NCBI Gene IDs), "P38398,P04637" (UniProt)
-        route: Comma-separated pair of dataset keys: 'source,target'.
+        route: Comma-separated pair of dataset keys: 'source,target'. NOTE: this
+            is a single joined string, NOT separate `source`/`target` args (as in
+            countId/getRelation) — because a route may be multi-hop (3+ datasets).
             Examples:
                 - 'ncbigene,uniprot' (Gene → Protein)
                 - 'uniprot,pdb' (Protein → 3D Structure)
@@ -272,6 +277,9 @@ async def countId(source: str, target: str, ids: str | list[str]) -> dict:
         - Verify your IDs are in the correct format
         - Estimate result size before a large convertId call
         - Check if a conversion route works for your specific IDs
+
+    This is a single-hop, pairwise check: pass `source` and `target` as two
+    separate args (unlike convertId, which takes one comma-joined `route`).
 
     Args:
         source: Source database key (e.g., 'ncbigene', 'uniprot')


### PR DESCRIPTION
## Summary

A review of the MCP tool surface (names, descriptions, arguments, returns, error messages) turned up several places where documented behavior diverged from actual behavior — the kind of mismatch that quietly mislead LLM callers. This PR corrects those contracts and makes `find_databases` keyword matching robust to real-world phrasing.

## Changes

**Tool contracts & docstrings** (`7ad68e6`)
- `get_MIE_file`: the docstring was an f-string (a `JoinedStr`, not `__doc__`) — dead code re-evaluated every call. Converted to a plain docstring; the authoritative database list already lives in `description=`.
- ChEMBL `target`/`molecule`/`id_lookup`: now **propagate** the `{"error": ...}` payload on upstream failure instead of collapsing it into an empty `{"total_count": 0, "results": []}` that reads as "no matches". Fixed the docstrings' false `Raises: httpx.HTTPError` / wrong `Returns: str` claims.
- UniProt / MeSH / PubChem search tools: documented the `"Error:"`-string fallback in their `Returns:` sections so callers check the prefix before parsing.
- NCBI `esearch`: excluded boolean operators (`AND`/`OR`/`NOT`) from the gene-symbol heuristic, which previously suggested nonsense like `'AND[Gene Name]'`.
- TogoID `convertId`/`countId`/`getRelation`: cross-referenced the `route` (single comma-joined, multi-hop) vs `source`/`target` (pairwise) distinction so an LLM doesn't mix the two shapes.

**`find_databases` keyword matching** (`d1f5b5e`)
- Multi-word / plural phrases hinted verbatim in the Usage Guide (`"drug targets"`, `"clinical variants"`) previously returned `[]` because matching did a brittle whole-phrase substring test against space-joined curated keywords. New `_keyword_matches` tokenizes each keyword, drops filler stopwords, and requires every content token as a substring (tested as-is and singularized) — order-independent and plural-tolerant.
- Rewrote the docstring and `keywords` Field description to steer callers toward the curated KIND-OF-DATA vocabulary: feed data-domain terms, pass several OR-matched synonyms, do **not** pass specific entities (gene symbols, drug names, accessions — those go to the `search_*` tools), and generalize/retry on empty. This rescues out-of-vocabulary terms like `kinase` (retry → `enzyme`/`drug target`) without editing the curated MIE keyword sets.

## Notes
- Only one behavioral change to a returned payload: ChEMBL error propagation. Everything else is docstring/heuristic/matcher.
- MIE `keywords` data was deliberately left untouched (the `kinase` coverage gap is addressed via docstring guidance, not curation).

## Tests
- New regression tests for the three ChEMBL error paths and for `find_databases` matching (singularization edge cases, out-of-order/plural phrases, all-tokens-required, and the two Usage-Guide phrases resolving to `chembl` first / `clinvar`).
- Full suite: **83 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)