### PR TITLE
benchmark: add questions 066–069 (jPOST, BRENDA, MassBank, NBRC×taxonomy)

### DIFF
--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,7 +96,7 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 65
+total_questions: 68
 
 question_types:
   yes_no:
@@ -105,14 +105,14 @@ question_types:
     status: 'ok'  # 13 uses - Q064 (antioxidant ubiquity via Bgee absence calls)
 
   factoid:
-    count: 13
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061']
-    status: 'ok'  # 13 uses - first past balanced-60 milestone (Q061)
+    count: 14
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066']
+    status: 'ok'  # 14 uses - Q066 (LIM-domain family top phosphopeptide protein via jPOST)
 
   list:
-    count: 13
-    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062']
-    status: 'ok'  # 13 uses - Q062 (long QT syndrome glycogene list)
+    count: 14
+    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068']
+    status: 'ok'  # 14 uses - Q068 (retinoids with MassBank reference spectra)
 
   summary:
     count: 13
@@ -120,15 +120,15 @@ question_types:
     status: 'ok'  # 13 uses - Q065 completes the balanced 65-question milestone (all five types at 13)
 
   choice:
-    count: 13
-    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063']
-    status: 'ok'  # 13 uses - Q063 (keratin-family chromosomal distribution)
+    count: 14
+    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067']
+    status: 'ok'  # 14 uses - Q067 (human prenyltransferase EC with widest BRENDA organism breadth)
 
 databases:
   uniprot:
-    count: 31
-    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065']
-    status: 'ok'  # At 47.7%, below 70% cap
+    count: 33
+    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067']
+    status: 'ok'  # At 49.3%, below 70% cap
 
   rhea:
     count: 11
@@ -151,8 +151,8 @@ databases:
     status: 'ok'
 
   chebi:
-    count: 8
-    questions: ['004', '011', '024', '043', '045', '051', '056', '059']
+    count: 9
+    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068']
     status: 'ok'
 
   reactome:
@@ -251,13 +251,13 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   brenda:
-    count: 3
-    questions: ['053', '057', '061']
+    count: 4
+    questions: ['053', '057', '061', '067']
     status: 'ok'  # newly added life-science DB
 
   jpostdb:
-    count: 2
-    questions: ['054', '058']
+    count: 3
+    questions: ['054', '058', '066']
     status: 'ok'  # newly added life-science DB
 
   oma:
@@ -266,21 +266,21 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   massbank:
-    count: 3
-    questions: ['056', '059', '061']
+    count: 4
+    questions: ['056', '059', '061', '068']
     status: 'ok'  # newly added life-science DB
 
 multi_database_metrics:
   two_plus_databases:
-    count: 65
-    percentage: 100.0  # 65/65 (Q065 is 3-DB: uniprot + hgnc + bgee)
+    count: 68
+    percentage: 100.0  # 68/68 (Q068 is 2-DB: chebi + massbank)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
     count: 23
     questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065']
-    percentage: 35.4  # 23/65 (Q065 is 3-DB: uniprot + hgnc + bgee)
+    percentage: 33.8  # 23/68 (Q068 is 2-DB: chebi + massbank)
     target: '>= 20%'
     status: 'excellent'
 
@@ -350,6 +350,9 @@ keywords_used:
   - 'KW-0416'  # Keratin (Q063)
   - 'KW-0049'  # Antioxidant (Q064)
   - 'KW-0031'  # Aminopeptidase (Q065)
+  - 'KW-0440'  # LIM domain (Q066)
+  - 'KW-0637'  # Prenyltransferase (Q067)
+  - 'KW-0845'  # Vitamin A (Q068)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,13 +96,13 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 68
+total_questions: 69
 
 question_types:
   yes_no:
-    count: 13
-    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064']
-    status: 'ok'  # 13 uses - Q064 (antioxidant ubiquity via Bgee absence calls)
+    count: 14
+    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069']
+    status: 'ok'  # 14 uses - Q069 (most-represented NBRC archaeal type-strain class is methanogenic; nbrc+taxonomy)
 
   factoid:
     count: 14
@@ -191,9 +191,14 @@ databases:
     status: 'ok'
 
   taxonomy:
-    count: 7
-    questions: ['014', '016', '018', '020', '034', '048', '050']
+    count: 8
+    questions: ['014', '016', '018', '020', '034', '048', '050', '069']
     status: 'ok'
+
+  nbrc:
+    count: 1
+    questions: ['069']
+    status: 'ok'  # newly added life-science DB (NITE Biological Resource Center culture catalogue); first use Q069
 
   mondo:
     count: 3
@@ -272,15 +277,15 @@ databases:
 
 multi_database_metrics:
   two_plus_databases:
-    count: 68
-    percentage: 100.0  # 68/68 (Q068 is 2-DB: chebi + massbank)
+    count: 69
+    percentage: 100.0  # 69/69 (Q069 is 2-DB: nbrc + taxonomy)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
     count: 23
     questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065']
-    percentage: 33.8  # 23/68 (Q068 is 2-DB: chebi + massbank)
+    percentage: 33.3  # 23/69 (Q069 is 2-DB: nbrc + taxonomy)
     target: '>= 20%'
     status: 'excellent'
 
@@ -353,6 +358,7 @@ keywords_used:
   - 'KW-0440'  # LIM domain (Q066)
   - 'KW-0637'  # Prenyltransferase (Q067)
   - 'KW-0845'  # Vitamin A (Q068)
+  - 'KW-0484'  # Methanogenesis (Q069)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_066.yaml
+++ b/benchmark/questions/question_066.yaml
@@ -1,0 +1,272 @@
+---
+id: question_066
+type: factoid
+body: >-
+  Consider the complete set of reviewed human proteins that are annotated as
+  containing a LIM domain. Across publicly reanalyzed shotgun mass-spectrometry
+  proteomics datasets, each of these proteins can be identified with some number
+  of distinct phosphorylated peptide sequences (peptides for which at least one
+  supporting spectrum carries a phospho modification). Which single LIM-domain
+  protein has been detected with the greatest number of distinct phosphopeptide
+  sequences, and how many distinct phosphopeptide sequences is that?
+
+inspiration_keyword:
+  keyword_id: KW-0440
+  name: LIM domain
+  category: Domain
+
+togomcp_databases_used:
+  - uniprot
+  - jpostdb
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Attempted to answer the specific ranking question from the literature with
+    four PubMed searches: (1) "LIM domain protein family phosphoproteome
+    phosphopeptide comparison"; (2) "LMO7 phosphorylation phosphopeptides mass
+    spectrometry proteomics"; (3) "LMO7 phosphorylation" (7 hits, abstracts
+    read); (4) "LIM domain proteins comparative phosphorylation sites paxillin
+    zyxin". Read the abstracts of the LMO7 phosphorylation hits.
+  result: |
+    No article compares distinct phosphopeptide counts across the human
+    LIM-domain family or ranks its members by phosphoproteomic evidence. The
+    LMO7-phosphorylation hits describe single-protein biology — a DAPK3-specific
+    phospho-site on LMO7 controlling STING ubiquitination (Nat Immunol 2021,
+    doi:10.1038/s41590-021-00896-3), LMO7 as a TGF-beta feedback regulator in
+    fibrosis (Circulation 2019, doi:10.1161/CIRCULATIONAHA.118.034615), and an
+    LMO7-BRAF fusion in thyroid carcinoma (Thyroid 2018,
+    doi:10.1089/thy.2017.0258) — none of which enumerates phosphopeptides or
+    compares LIM-domain proteins against one another. The answer is a
+    repository-state-dependent aggregate over reanalyzed proteomics datasets and
+    cannot be recovered from the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# Scope is fixed by the UniProt keyword KW-0440 (LIM domain), not by an ontology
+# subtree, so no OLS4 getDescendants expansion applies. The full 71-protein
+# family (Query 1) is carried verbatim into the jPOST VALUES block (Query 2) —
+# no sampling.
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Establish the complete family scope — all reviewed Homo sapiens
+      (taxon 9606) proteins classified with keyword KW-0440 (LIM domain).
+      Returns 71 distinct accessions; this exact set is the VALUES block for
+      Query 2 (no sampling).
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+
+      SELECT DISTINCT ?protein
+      WHERE {
+        ?protein a up:Protein ;
+                 up:reviewed 1 ;
+                 up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+                 up:classifiedWith keywords:440 .
+      }
+    result_count: 71
+
+  - query_number: 2
+    database: jpostdb
+    description: >-
+      For every one of the 71 LIM-domain UniProt accessions, count the distinct
+      phosphopeptide sequences: peptides whose supporting PSM carries a phospho
+      modification (Unimod:21), reached via Protein -> hasPeptideEvidence ->
+      hasPeptide -> hasPsm -> hasModification, with the amino-acid string taken
+      from the sequence blank node. Grouped per protein, ordered descending.
+      41 of the 71 proteins return >=1 phosphopeptide; the top row is LMO7
+      (Q8WWI1) with 50, ahead of LIMA1 (Q9UHB6, 39) and LIMCH1 (Q9UPQ0, 36).
+    query: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX unimod: <http://www.unimod.org/obo/unimod.obo#>
+
+      SELECT ?up (COUNT(DISTINCT ?seq) AS ?nPhosphoPep)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          VALUES ?up {
+            <http://purl.uniprot.org/uniprot/O14639> <http://purl.uniprot.org/uniprot/Q6H8Q1> <http://purl.uniprot.org/uniprot/O94929>
+            <http://purl.uniprot.org/uniprot/Q96IF1> <http://purl.uniprot.org/uniprot/P50238> <http://purl.uniprot.org/uniprot/P52943>
+            <http://purl.uniprot.org/uniprot/Q6Q6R5> <http://purl.uniprot.org/uniprot/P21291> <http://purl.uniprot.org/uniprot/Q16527>
+            <http://purl.uniprot.org/uniprot/P50461> <http://purl.uniprot.org/uniprot/Q8WUP2> <http://purl.uniprot.org/uniprot/Q13642>
+            <http://purl.uniprot.org/uniprot/Q14192> <http://purl.uniprot.org/uniprot/Q13643> <http://purl.uniprot.org/uniprot/Q5TD97>
+            <http://purl.uniprot.org/uniprot/P61371> <http://purl.uniprot.org/uniprot/Q96A47> <http://purl.uniprot.org/uniprot/Q14847>
+            <http://purl.uniprot.org/uniprot/O75112> <http://purl.uniprot.org/uniprot/P48742> <http://purl.uniprot.org/uniprot/P50458>
+            <http://purl.uniprot.org/uniprot/Q9UBR4> <http://purl.uniprot.org/uniprot/Q969G2> <http://purl.uniprot.org/uniprot/Q9H2C1>
+            <http://purl.uniprot.org/uniprot/Q9UPM6> <http://purl.uniprot.org/uniprot/Q68G74> <http://purl.uniprot.org/uniprot/Q9NQ69>
+            <http://purl.uniprot.org/uniprot/Q9UHB6> <http://purl.uniprot.org/uniprot/Q9UPQ0> <http://purl.uniprot.org/uniprot/Q9UGP4>
+            <http://purl.uniprot.org/uniprot/Q9BT23> <http://purl.uniprot.org/uniprot/P53667> <http://purl.uniprot.org/uniprot/P53671>
+            <http://purl.uniprot.org/uniprot/P48059> <http://purl.uniprot.org/uniprot/Q7Z4I7> <http://purl.uniprot.org/uniprot/P0CW19>
+            <http://purl.uniprot.org/uniprot/P0CW20> <http://purl.uniprot.org/uniprot/Q9NZU5> <http://purl.uniprot.org/uniprot/P25800>
+            <http://purl.uniprot.org/uniprot/P25791> <http://purl.uniprot.org/uniprot/Q8TAP4> <http://purl.uniprot.org/uniprot/P61968>
+            <http://purl.uniprot.org/uniprot/Q8WWI1> <http://purl.uniprot.org/uniprot/Q8TE12> <http://purl.uniprot.org/uniprot/O60663>
+            <http://purl.uniprot.org/uniprot/Q93052> <http://purl.uniprot.org/uniprot/O60711> <http://purl.uniprot.org/uniprot/Q8TDZ2>
+            <http://purl.uniprot.org/uniprot/O94851> <http://purl.uniprot.org/uniprot/Q7RTP6> <http://purl.uniprot.org/uniprot/Q8N3F8>
+            <http://purl.uniprot.org/uniprot/Q8IY33> <http://purl.uniprot.org/uniprot/Q86VF7> <http://purl.uniprot.org/uniprot/O00151>
+            <http://purl.uniprot.org/uniprot/Q96JY6> <http://purl.uniprot.org/uniprot/Q53GG5> <http://purl.uniprot.org/uniprot/P50479>
+            <http://purl.uniprot.org/uniprot/Q96HC4> <http://purl.uniprot.org/uniprot/Q9NR12> <http://purl.uniprot.org/uniprot/Q96MT3>
+            <http://purl.uniprot.org/uniprot/Q7Z3G6> <http://purl.uniprot.org/uniprot/O43900> <http://purl.uniprot.org/uniprot/Q2TBC4>
+            <http://purl.uniprot.org/uniprot/P49023> <http://purl.uniprot.org/uniprot/O95171> <http://purl.uniprot.org/uniprot/Q9UGI8>
+            <http://purl.uniprot.org/uniprot/O43294> <http://purl.uniprot.org/uniprot/Q15654> <http://purl.uniprot.org/uniprot/A6NIX2>
+            <http://purl.uniprot.org/uniprot/O15231> <http://purl.uniprot.org/uniprot/Q15942>
+          }
+          ?prot a jpost:Protein ;
+                jpost:hasDatabaseSequence ?up ;
+                jpost:hasPeptideEvidence/jpost:hasPeptide ?pep .
+          ?pep jpost:hasPsm/jpost:hasModification ?mod .
+          ?mod a unimod:UNIMOD_21 .
+          ?pep jpost:hasSequence [ a obo:MS_1001344 ; rdf:value ?seq ] .
+        }
+      }
+      GROUP BY ?up
+      ORDER BY DESC(?nPhosphoPep)
+    result_count: 41
+
+  - query_number: 3
+    database: jpostdb
+    description: >-
+      Arithmetic verification for the Query 2 GROUP BY: independently count how
+      many of the 71 LIM-domain proteins have at least one phosphopeptide
+      (Unimod:21) in jPOST. Returns 41, matching the 41 grouped rows of Query 2
+      (no protein dropped; the 30 proteins absent from Query 2 have zero
+      phosphopeptides).
+    query: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+      PREFIX unimod: <http://www.unimod.org/obo/unimod.obo#>
+
+      SELECT (COUNT(DISTINCT ?up) AS ?nProteinsWithPhospho)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          VALUES ?up {
+            <http://purl.uniprot.org/uniprot/O14639> <http://purl.uniprot.org/uniprot/Q6H8Q1> <http://purl.uniprot.org/uniprot/O94929>
+            <http://purl.uniprot.org/uniprot/Q96IF1> <http://purl.uniprot.org/uniprot/P50238> <http://purl.uniprot.org/uniprot/P52943>
+            <http://purl.uniprot.org/uniprot/Q6Q6R5> <http://purl.uniprot.org/uniprot/P21291> <http://purl.uniprot.org/uniprot/Q16527>
+            <http://purl.uniprot.org/uniprot/P50461> <http://purl.uniprot.org/uniprot/Q8WUP2> <http://purl.uniprot.org/uniprot/Q13642>
+            <http://purl.uniprot.org/uniprot/Q14192> <http://purl.uniprot.org/uniprot/Q13643> <http://purl.uniprot.org/uniprot/Q5TD97>
+            <http://purl.uniprot.org/uniprot/P61371> <http://purl.uniprot.org/uniprot/Q96A47> <http://purl.uniprot.org/uniprot/Q14847>
+            <http://purl.uniprot.org/uniprot/O75112> <http://purl.uniprot.org/uniprot/P48742> <http://purl.uniprot.org/uniprot/P50458>
+            <http://purl.uniprot.org/uniprot/Q9UBR4> <http://purl.uniprot.org/uniprot/Q969G2> <http://purl.uniprot.org/uniprot/Q9H2C1>
+            <http://purl.uniprot.org/uniprot/Q9UPM6> <http://purl.uniprot.org/uniprot/Q68G74> <http://purl.uniprot.org/uniprot/Q9NQ69>
+            <http://purl.uniprot.org/uniprot/Q9UHB6> <http://purl.uniprot.org/uniprot/Q9UPQ0> <http://purl.uniprot.org/uniprot/Q9UGP4>
+            <http://purl.uniprot.org/uniprot/Q9BT23> <http://purl.uniprot.org/uniprot/P53667> <http://purl.uniprot.org/uniprot/P53671>
+            <http://purl.uniprot.org/uniprot/P48059> <http://purl.uniprot.org/uniprot/Q7Z4I7> <http://purl.uniprot.org/uniprot/P0CW19>
+            <http://purl.uniprot.org/uniprot/P0CW20> <http://purl.uniprot.org/uniprot/Q9NZU5> <http://purl.uniprot.org/uniprot/P25800>
+            <http://purl.uniprot.org/uniprot/P25791> <http://purl.uniprot.org/uniprot/Q8TAP4> <http://purl.uniprot.org/uniprot/P61968>
+            <http://purl.uniprot.org/uniprot/Q8WWI1> <http://purl.uniprot.org/uniprot/Q8TE12> <http://purl.uniprot.org/uniprot/O60663>
+            <http://purl.uniprot.org/uniprot/Q93052> <http://purl.uniprot.org/uniprot/O60711> <http://purl.uniprot.org/uniprot/Q8TDZ2>
+            <http://purl.uniprot.org/uniprot/O94851> <http://purl.uniprot.org/uniprot/Q7RTP6> <http://purl.uniprot.org/uniprot/Q8N3F8>
+            <http://purl.uniprot.org/uniprot/Q8IY33> <http://purl.uniprot.org/uniprot/Q86VF7> <http://purl.uniprot.org/uniprot/O00151>
+            <http://purl.uniprot.org/uniprot/Q96JY6> <http://purl.uniprot.org/uniprot/Q53GG5> <http://purl.uniprot.org/uniprot/P50479>
+            <http://purl.uniprot.org/uniprot/Q96HC4> <http://purl.uniprot.org/uniprot/Q9NR12> <http://purl.uniprot.org/uniprot/Q96MT3>
+            <http://purl.uniprot.org/uniprot/Q7Z3G6> <http://purl.uniprot.org/uniprot/O43900> <http://purl.uniprot.org/uniprot/Q2TBC4>
+            <http://purl.uniprot.org/uniprot/P49023> <http://purl.uniprot.org/uniprot/O95171> <http://purl.uniprot.org/uniprot/Q9UGI8>
+            <http://purl.uniprot.org/uniprot/O43294> <http://purl.uniprot.org/uniprot/Q15654> <http://purl.uniprot.org/uniprot/A6NIX2>
+            <http://purl.uniprot.org/uniprot/O15231> <http://purl.uniprot.org/uniprot/Q15942>
+          }
+          ?prot a jpost:Protein ;
+                jpost:hasDatabaseSequence ?up ;
+                jpost:hasPeptideEvidence/jpost:hasPeptide ?pep .
+          ?pep jpost:hasPsm/jpost:hasModification ?mod .
+          ?mod a unimod:UNIMOD_21 .
+        }
+      }
+    result_count: 1
+
+  - query_number: 4
+    database: jpostdb
+    description: >-
+      Independent confirmation of the winner's value: count distinct
+      phosphopeptide sequences for LMO7 (UniProt Q8WWI1) alone, anchored solely
+      on its hasDatabaseSequence link (no VALUES block). Returns 50, matching
+      the top row of Query 2.
+    query: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX unimod: <http://www.unimod.org/obo/unimod.obo#>
+
+      SELECT (COUNT(DISTINCT ?seq) AS ?nSeqLMO7)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          ?prot a jpost:Protein ;
+                jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/Q8WWI1> ;
+                jpost:hasPeptideEvidence/jpost:hasPeptide ?pep .
+          ?pep jpost:hasPsm/jpost:hasModification ?mod .
+          ?mod a unimod:UNIMOD_21 .
+          ?pep jpost:hasSequence [ a obo:MS_1001344 ; rdf:value ?seq ] .
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix up: <http://purl.uniprot.org/core/> .
+  @prefix keywords: <http://purl.uniprot.org/keywords/> .
+  @prefix jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix unimod: <http://www.unimod.org/obo/unimod.obo#> .
+  @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+  <http://purl.uniprot.org/uniprot/Q8WWI1> a up:Protein .
+  # Database: UniProt | Query: 1 | Comment: LMO7, the winning protein, a reviewed human entry
+  <http://purl.uniprot.org/uniprot/Q8WWI1> up:reviewed 1 .
+  # Database: UniProt | Query: 1 | Comment: Swiss-Prot reviewed, one of the 71 in-scope proteins
+  <http://purl.uniprot.org/uniprot/Q8WWI1> up:organism <http://purl.uniprot.org/taxonomy/9606> .
+  # Database: UniProt | Query: 1 | Comment: human (taxon 9606) — the fixed species scope
+  <http://purl.uniprot.org/uniprot/Q8WWI1> up:classifiedWith keywords:440 .
+  # Database: UniProt | Query: 1 | Comment: annotated with keyword KW-0440 (LIM domain), defining the family
+  <http://rdf.jpostdb.org/entry/PRT1780_1_Q8WWI1> a jpost:Protein .
+  # Database: jPOST | Query: 2 | Comment: an identified-protein record for LMO7 (project 1780, dataset 1)
+  <http://rdf.jpostdb.org/entry/PRT1780_1_Q8WWI1> jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/Q8WWI1> .
+  # Database: jPOST | Query: 2 | Comment: typed cross-reference tying the jPOST protein record to UniProt Q8WWI1
+  <http://rdf.jpostdb.org/entry/PRT1780_1_Q8WWI1> jpost:hasPeptideEvidence _:ev .
+  # Database: jPOST | Query: 2 | Comment: the LMO7 record links to peptide-level evidence
+  _:ev jpost:hasPeptide _:pep .
+  # Database: jPOST | Query: 2 | Comment: the evidence node points to a detected peptide
+  _:pep jpost:hasSequence _:seqnode .
+  # Database: jPOST | Query: 2 | Comment: the peptide's amino-acid string lives on a child sequence node
+  _:seqnode rdf:value "AGSPETK" .
+  # Database: jPOST | Query: 2 | Comment: one of LMO7's 50 distinct detected phosphopeptide sequences
+  _:pep jpost:hasPsm _:psm .
+  # Database: jPOST | Query: 2 | Comment: the peptide is supported by a peptide-spectrum match
+  _:psm jpost:hasModification _:mod .
+  # Database: jPOST | Query: 2 | Comment: that PSM carries a modification
+  _:mod a unimod:UNIMOD_21 .
+  # Database: jPOST | Query: 2 | Comment: the modification is a phospho group (Unimod:21), qualifying AGSPETK as a phosphopeptide
+
+exact_answer: "LMO7 (UniProt:Q8WWI1); 50 distinct phosphopeptide sequences"
+
+ideal_answer: |
+  Of the 71 reviewed human proteins carrying a LIM domain, LMO7 (UniProt Q8WWI1)
+  has been detected with more distinct phosphopeptide sequences than any other
+  member — 50 distinct phospho-modified peptide sequences across the reanalyzed
+  proteomics datasets. It leads the family clearly, ahead of LIMA1 (Q9UHB6, 39)
+  and LIMCH1 (Q9UPQ0, 36), with MICAL3 (29), MICALL1 and ABLIM1 (22 each), and
+  paxillin (PXN, 20) following. Only 41 of the 71 LIM-domain proteins are
+  observed with any phosphopeptide at all, so the remaining 30 contribute none.
+  LMO7 is a large multidomain LIM protein that acts as an E3-ligase adaptor and
+  transcriptional/cytoskeletal regulator; its position at the top of this ranking
+  reflects both its size and its extensive phosphoregulation, and the value is a
+  live aggregate over deposited spectra rather than a curated annotation.
+
+question_template_used: family-wide PTM-evidence ranking (UniProt keyword scope -> jPOST distinct-phosphopeptide count -> argmax)
+
+time_spent:
+  exploration: 20
+  formulation: 15
+  verification: 10
+  pubmed_test: 12
+  extraction: 10
+  documentation: 15
+  total: 82

--- a/benchmark/questions/question_067.yaml
+++ b/benchmark/questions/question_067.yaml
@@ -1,0 +1,203 @@
+---
+id: question_067
+type: choice
+body: >-
+  The human genome encodes prenyltransferases (EC 2.5.1 sub-subclass) that fall
+  into four enzyme activities carrying a complete, fully assigned EC number:
+  4-hydroxybenzoate polyprenyltransferase (gene UBIAD1, EC 2.5.1.39), protein
+  farnesyltransferase (EC 2.5.1.58), protein geranylgeranyltransferase type I
+  (EC 2.5.1.59), and Rab / type-II protein geranylgeranyltransferase
+  (EC 2.5.1.60). In a comprehensive, manually curated enzyme-function knowledge
+  base that records, for each EC class, every distinct source organism in which
+  the activity has been experimentally characterized, which of these four enzyme
+  activities is documented across the greatest number of distinct organisms?
+
+choices:
+  - "4-Hydroxybenzoate polyprenyltransferase — human UBIAD1 (EC 2.5.1.39)"
+  - "Protein farnesyltransferase — human FNTA/FNTB (EC 2.5.1.58)"
+  - "Protein geranylgeranyltransferase type I — human FNTA/PGGT1B (EC 2.5.1.59)"
+  - "Rab / type-II protein geranylgeranyltransferase — human RABGGTA/RABGGTB (EC 2.5.1.60)"
+
+inspiration_keyword:
+  keyword_id: KW-0637
+  name: Prenyltransferase
+  category: Molecular function
+
+togomcp_databases_used:
+  - uniprot
+  - brenda
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Tried to answer the ranking from the literature with four PubMed searches:
+    (1) "prenyltransferase enzymes comparison number of organisms taxonomic
+    distribution farnesyltransferase geranylgeranyltransferase"; (2) "BRENDA
+    database organism coverage prenyltransferase EC 2.5.1.39 species count";
+    (3) "protein prenyltransferases evolutionary conservation across eukaryotes
+    farnesyltransferase geranylgeranyltransferase Rab"; (4) "4-hydroxybenzoate
+    polyprenyltransferase ubiquinone biosynthesis conservation bacteria
+    eukaryotes distribution".
+  result: |
+    All four searches returned zero results. No paper tabulates the number of
+    distinct source organisms in which each of these four EC-classified
+    activities has been experimentally characterized, and none ranks them against
+    one another on that basis. The answer is a property of the current curated
+    experimental-characterization records for each EC class — a database-state
+    aggregate that shifts as curation grows — and cannot be recovered from the
+    primary literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# The option set is fixed by UniProt keyword KW-0637 (Prenyltransferase): Query 1
+# enumerates the EC numbers assigned to reviewed human prenyltransferases. Five
+# EC strings are returned, but one (2.5.1.-) is an INCOMPLETE/wildcard EC — not a
+# queryable BRENDA EC class and a redundant secondary annotation of UBIAD1 (whose
+# complete activity 2.5.1.39 is already in scope). The four COMPLETE EC classes
+# (2.5.1.39, .58, .59, .60) are the full comparison set; all four are carried into
+# Query 2 (no sampling). No ontology getDescendants expansion applies (keyword-,
+# not ontology-subtree-, scoped).
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Establish the option set — the EC numbers assigned to reviewed human
+      (taxon 9606) proteins classified with keyword KW-0637 (Prenyltransferase),
+      with their gene symbols. Returns 5 EC strings; four are complete
+      (2.5.1.39 = UBIAD1; 2.5.1.58 = FNTA/FNTB; 2.5.1.59 = FNTA/PGGT1B;
+      2.5.1.60 = RABGGTA/RABGGTB) and one (2.5.1.-) is an incomplete wildcard EC
+      excluded from the comparison. The four complete ECs are the choices.
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?ec (GROUP_CONCAT(DISTINCT ?gene; separator=", ") AS ?genes)
+      WHERE {
+        ?protein a up:Protein ;
+                 up:reviewed 1 ;
+                 up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+                 up:classifiedWith keywords:637 ;
+                 up:enzyme ?ec .
+        OPTIONAL { ?protein up:encodedBy ?g . ?g skos:prefLabel ?gene . }
+      }
+      GROUP BY ?ec
+      ORDER BY ?ec
+    result_count: 5
+
+  - query_number: 2
+    database: brenda
+    description: >-
+      For each of the four complete prenyltransferase EC classes, count the
+      distinct source organisms in which enzyme instances of that class are
+      documented (enzyme instance -> d3o:foundIn -> organism). Grouped per EC,
+      ordered descending. The top row is EC 2.5.1.39 (4-hydroxybenzoate
+      polyprenyltransferase, UBIAD1's activity) with 1171 organisms, ahead of
+      2.5.1.58 (1077), 2.5.1.59 (1001), and 2.5.1.60 (499).
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?ec ?ecLabel (COUNT(DISTINCT ?organism) AS ?nOrg)
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        VALUES ?ec {
+          <https://purl.dsmz.de/brenda/ec/2.5.1.39>
+          <https://purl.dsmz.de/brenda/ec/2.5.1.58>
+          <https://purl.dsmz.de/brenda/ec/2.5.1.59>
+          <https://purl.dsmz.de/brenda/ec/2.5.1.60>
+        }
+        ?ec rdfs:label ?ecLabel .
+        ?enzyme d3o:isClassifiedAs ?ec ;
+                d3o:foundIn ?organism .
+      }
+      GROUP BY ?ec ?ecLabel
+      ORDER BY DESC(?nOrg)
+    result_count: 4
+
+  - query_number: 3
+    database: brenda
+    description: >-
+      Arithmetic verification for the Query 2 GROUP BY. Independently re-count the
+      winner's organisms (EC 2.5.1.39 alone -> 1171, confirming the top row) and
+      the distinct UNION of organisms across all four ECs (-> 1382). The per-EC
+      counts sum to 3748, far exceeding the 1382-organism union: the categories
+      are NOT a partition (most organisms carry several of these prenyltransferases
+      and are counted under more than one EC). The winner alone spans 1171 of the
+      1382 union organisms.
+    query: |
+      PREFIX d3o: <https://purl.dsmz.de/schema/>
+
+      SELECT
+        (COUNT(DISTINCT ?orgWin) AS ?winnerOrgs)
+        (COUNT(DISTINCT ?orgAll) AS ?unionOrgs)
+      FROM <http://rdfportal.org/dataset/brenda>
+      WHERE {
+        {
+          ?eWin d3o:isClassifiedAs <https://purl.dsmz.de/brenda/ec/2.5.1.39> ;
+                d3o:foundIn ?orgWin .
+        }
+        UNION
+        {
+          VALUES ?ecAll {
+            <https://purl.dsmz.de/brenda/ec/2.5.1.39>
+            <https://purl.dsmz.de/brenda/ec/2.5.1.58>
+            <https://purl.dsmz.de/brenda/ec/2.5.1.59>
+            <https://purl.dsmz.de/brenda/ec/2.5.1.60>
+          }
+          ?eAll d3o:isClassifiedAs ?ecAll ;
+                d3o:foundIn ?orgAll .
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix up: <http://purl.uniprot.org/core/> .
+  @prefix keywords: <http://purl.uniprot.org/keywords/> .
+  @prefix upenz: <http://purl.uniprot.org/enzyme/> .
+  @prefix d3o: <https://purl.dsmz.de/schema/> .
+  @prefix ec: <https://purl.dsmz.de/brenda/ec/> .
+  @prefix enz: <https://purl.dsmz.de/brenda/enzyme/> .
+  @prefix org: <https://purl.dsmz.de/brenda/organism/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+  <http://purl.uniprot.org/uniprot/Q9Y5Z9> a up:Protein .
+  # Database: UniProt | Query: 1 | Comment: UBIAD1, the human gene product behind the winning enzyme activity
+  <http://purl.uniprot.org/uniprot/Q9Y5Z9> up:classifiedWith keywords:637 .
+  # Database: UniProt | Query: 1 | Comment: classified with KW-0637 (Prenyltransferase) — the keyword defining the four-option set
+  <http://purl.uniprot.org/uniprot/Q9Y5Z9> up:enzyme upenz:2.5.1.39 .
+  # Database: UniProt | Query: 1 | Comment: UBIAD1's fully assigned EC activity, EC 2.5.1.39 (the winning class)
+  ec:2.5.1.39 rdfs:label "4-hydroxybenzoate polyprenyltransferase" .
+  # Database: BRENDA | Query: 2 | Comment: the label of the winning EC class in the curated enzyme knowledge base
+  enz:1975 d3o:isClassifiedAs ec:2.5.1.39 .
+  # Database: BRENDA | Query: 2 | Comment: one BRENDA enzyme instance classified under EC 2.5.1.39
+  enz:1975 d3o:foundIn org:18692 .
+  # Database: BRENDA | Query: 2 | Comment: that instance is documented in a source organism (one of the 1171 distinct organisms for this EC)
+  org:18692 rdfs:label "Oryza sativa" .
+  # Database: BRENDA | Query: 2 | Comment: the organism name for this enzyme instance
+
+exact_answer:
+  - "4-Hydroxybenzoate polyprenyltransferase — human UBIAD1 (EC 2.5.1.39)"
+
+ideal_answer: |
+  Among the four fully classified enzyme activities of the human prenyltransferases, 4-hydroxybenzoate polyprenyltransferase — the activity assigned to UBIAD1, EC 2.5.1.39 — is documented across the most distinct source organisms, 1,171, narrowly ahead of protein farnesyltransferase (EC 2.5.1.58, 1,077 organisms), protein geranylgeranyltransferase type I (EC 2.5.1.59, 1,001), and the Rab / type-II protein geranylgeranyltransferase (EC 2.5.1.60, 499). The ranking tracks biology: EC 2.5.1.39 is a core enzyme of ubiquinone (coenzyme Q) biosynthesis, an essentially universal pathway of aerobic life, so its activity has been experimentally characterized across a very broad phylogenetic range; the CaaX and Rab protein-prenyltransferases, although also widely conserved in eukaryotes, have been characterized in fewer organisms, and the Rab enzyme least of all. The four activities together span a union of 1,382 distinct organisms, while the per-activity counts sum to 3,748 — far more — because most organisms possess several of these prenyltransferases and are therefore counted under more than one EC class; the winning activity alone accounts for 1,171 of the 1,382 union organisms. The comparison depends on the current body of experimental-characterization data for each class rather than on any fixed sequence property.
+
+question_template_used: comparative facet ranking among a keyword-defined enzyme family (UniProt keyword -> EC set -> BRENDA organism-breadth argmax)
+
+time_spent:
+  exploration: 25
+  formulation: 15
+  verification: 8
+  pubmed_test: 12
+  extraction: 10
+  documentation: 15
+  total: 85

--- a/benchmark/questions/question_068.yaml
+++ b/benchmark/questions/question_068.yaml
@@ -1,0 +1,170 @@
+---
+id: question_068
+type: list
+body: >-
+  Retinoids are the class of vitamin A-related isoprenoid compounds — retinol,
+  retinal and retinoic acid, together with their geometric isomers, their
+  oxidized and conjugated metabolites, and synthetic retinoid drugs — and well
+  over one hundred structurally defined members are recognized. Only a small
+  fraction of them have at least one reference tandem mass spectrum deposited in
+  the public small-molecule reference mass-spectral libraries used for compound
+  identification in metabolomics. Considering the full set of structurally
+  defined retinoids, list every retinoid for which at least one such reference
+  mass spectrum exists.
+
+inspiration_keyword:
+  keyword_id: KW-0845
+  name: Vitamin A
+  category: Ligand
+
+togomcp_databases_used:
+  - chebi
+  - massbank
+
+verification_score:
+  biological_insight: 2
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 10
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Tried to answer the coverage list from the literature with three PubMed
+    searches: (1) "retinoids reference tandem mass spectra MassBank spectral
+    library coverage metabolites"; (2) "which retinoid metabolites have reference
+    MS/MS spectra available public spectral database"; (3) "retinoid metabolomics
+    LC-MS/MS identification bexarotene retinoic acid retinal retinol reference
+    spectra".
+  result: |
+    All three searches returned zero results. No publication enumerates which
+    members of the retinoid class have a reference tandem mass spectrum in a
+    public spectral library; that is a property of the current library holdings,
+    keyed structure-by-structure on InChIKey, and it shifts as libraries grow.
+    It cannot be recovered from the primary literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY - DESCENDANTS CHECKED (OLS4:getDescendants)
+# CHEBI:26537 (retinoid): 114 descendants (115 including the class node itself).
+# All are carried into scope via rdfs:subClassOf* (Query 1); 101 of the 115 carry
+# a standard InChIKey (a defined structure that a spectral library can key on).
+# The MassBank check (Query 2) runs over ALL 101 InChIKeys - no sampling.
+
+sparql_queries:
+  - query_number: 1
+    database: chebi
+    description: >-
+      Establish the full retinoid scope - every member of the ChEBI 'retinoid'
+      class (CHEBI:26537) via rdfs:subClassOf*, restricted to those carrying a
+      standard InChIKey (a defined structure). Returns 101 distinct retinoid
+      structures (the class subtree has 115 members including the class node; 101
+      have an InChIKey). This InChIKey set is the exact scope of Query 2.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT DISTINCT ?c ?ik
+      WHERE {
+        GRAPH <http://rdf.ebi.ac.uk/dataset/chebi> {
+          ?c rdfs:subClassOf* <http://purl.obolibrary.org/obo/CHEBI_26537> ;
+             <https://w3id.org/chemrof/inchi_key_string> ?ik .
+        }
+      }
+    result_count: 101
+
+  - query_number: 2
+    database: massbank
+    description: >-
+      Over the full set of 101 retinoid InChIKeys from Query 1 (built into the
+      VALUES block as identifiers.org InChIKey IRIs - the form MassBank uses),
+      find which retinoids have at least one reference spectrum, with a spectrum
+      count per compound. Exactly 5 match: bexarotene (28 spectra),
+      all-trans-retinoic acid (7), retinoic acid / unspecified geometry (4),
+      all-trans-retinal (3), and retinol (2). MassBank and ChEBI sit on different
+      endpoints, so the InChIKey set from Query 1 is passed in explicitly.
+    query: |
+      PREFIX mb: <http://www.massbank.jp/ontology/>
+      PREFIX schema: <https://schema.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?ik (SAMPLE(?name) AS ?compound) (COUNT(DISTINCT ?spectrum) AS ?nSpectra)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          VALUES ?ik { <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-XFYACQKRSA-N> <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-UHFFFAOYSA-N> <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-ZVCIMWCZSA-N> <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-YCNIQYBTSA-N> <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-OVSJKPMPSA-N> <http://identifiers.org/inchikey/VYGQUTWHTHXGQB-FFHKNEKCSA-N> <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-OVSJKPMPSA-N> <http://identifiers.org/inchikey/WIYYXLSPNGTKOH-IIFYKUDISA-N> <http://identifiers.org/inchikey/WIYYXLSPNGTKOH-ZAEWJIFQSA-N> <http://identifiers.org/inchikey/WIYYXLSPNGTKOH-IRPZNPCQSA-N> <http://identifiers.org/inchikey/WIYYXLSPNGTKOH-OGBLRLSYSA-N> <http://identifiers.org/inchikey/VYGQUTWHTHXGQB-ILAPVCSWSA-N> <http://identifiers.org/inchikey/QLFIHDFIMGLXEA-XOEOKOMISA-N> <http://identifiers.org/inchikey/VYGQUTWHTHXGQB-UMNZIDCRSA-N> <http://identifiers.org/inchikey/GGCUJPCCTQNTJF-NAXRMXIQSA-N> <http://identifiers.org/inchikey/GIEPJVBJRPHMTO-FCKHSPHMSA-N> <http://identifiers.org/inchikey/DGCPGJKPROZYMN-ZMNXUKPGSA-N> <http://identifiers.org/inchikey/UNNCFEGUDGBPCH-ZMNXUKPGSA-N> <http://identifiers.org/inchikey/UWNJDGDPQWPMBF-ZMNXUKPGSA-N> <http://identifiers.org/inchikey/QUKONIROJIAMOO-ZMNXUKPGSA-N> <http://identifiers.org/inchikey/CYVVUYORRQQAQE-RMWYGNQTSA-N> <http://identifiers.org/inchikey/PLILDISEFZJECC-RMWYGNQTSA-N> <http://identifiers.org/inchikey/BZPOQLONXBJGAZ-WSPRJJCZSA-N> <http://identifiers.org/inchikey/AWGMQQGZWRIUJI-UBMBPVGBSA-N> <http://identifiers.org/inchikey/ZGISOPBIAXHOTQ-OUGXGHBNSA-N> <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-HWCYFHEPSA-N> <http://identifiers.org/inchikey/KGUMXGDKXYTTEY-NAXRMXIQSA-N> <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-MKOSUFFBSA-N> <http://identifiers.org/inchikey/XSJOIRFEYHJNAW-FCKHSPHMSA-N> <http://identifiers.org/inchikey/KEEHJLBAOLGBJZ-WEDZBJJJSA-N> <http://identifiers.org/inchikey/LVCMXFSJTNPFHH-YUJSZCEWSA-N> <http://identifiers.org/inchikey/SIKFAVWPHMSCBL-QKLNHPSXSA-N> <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-UHFFFAOYSA-N> <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-UHFFFAOYSA-N> <http://identifiers.org/inchikey/MUTNCGKQJGXKEM-UHFFFAOYSA-N> <http://identifiers.org/inchikey/OGQICQVSFDPSEI-UHFFFAOYSA-N> <http://identifiers.org/inchikey/IQIBKLWBVJPOQO-UHFFFAOYSA-N> <http://identifiers.org/inchikey/RGGWFVJDHYDPGV-BOVRYGTNSA-N> <http://identifiers.org/inchikey/BGSGEOPBGIBLBS-CIGYHBHLSA-N> <http://identifiers.org/inchikey/QZKISTBYGXZBOE-WMBSQONYSA-N> <http://identifiers.org/inchikey/ZJWNTFRBIBFJFC-KEUMZJLDSA-N> <http://identifiers.org/inchikey/UXYMBRVBEUJGTO-VXKSIPEOSA-N> <http://identifiers.org/inchikey/JVNZTBXNNSQXJS-FGKSVAIXSA-N> <http://identifiers.org/inchikey/YOFBBAJVETYSCH-IWRFDTMXSA-N> <http://identifiers.org/inchikey/XTTUSBQFKZWUJV-JHYVTPCUSA-N> <http://identifiers.org/inchikey/RQANARBNMTXCDM-DKOHIBGUSA-N> <http://identifiers.org/inchikey/MRFBVQCSZMKBFY-UBFIAYEVSA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-NIKQCJNBSA-N> <http://identifiers.org/inchikey/IYHVRAMISWFIRU-GMBUFXMQSA-N> <http://identifiers.org/inchikey/QZKISTBYGXZBOE-JHYVTPCUSA-N> <http://identifiers.org/inchikey/OBODKGDXEIUEIH-DAWLFQHYSA-N> <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-CDMOMSTLSA-N> <http://identifiers.org/inchikey/AKJHMTWEGVYYSE-FXILSDISSA-N> <http://identifiers.org/inchikey/PLIUCYCUYQIBDZ-RMWYGNQTSA-N> <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-HWCYFHEPSA-N> <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-JPXMXQIXSA-N> <http://identifiers.org/inchikey/FOIVPCKZDPCJJY-JQIJEIRASA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-GQSKFBJNSA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-ZCEAMUHZSA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-IRVDFSNZSA-N> <http://identifiers.org/inchikey/LQAJUQDHCUNJJY-OVWFGJEDSA-N> <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-MKOSUFFBSA-N> <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-IOUUIBBYSA-N> <http://identifiers.org/inchikey/VYGQUTWHTHXGQB-SXFSSFKVSA-N> <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-IOUUIBBYSA-N> <http://identifiers.org/inchikey/QHNVWXUULMZJKD-OVSJKPMPSA-N> <http://identifiers.org/inchikey/MTGFYEHKPMOVNE-NEFMKCFNSA-N> <http://identifiers.org/inchikey/MTGFYEHKPMOVNE-RDMMYANXSA-N> <http://identifiers.org/inchikey/XHBHYZOZHVKBDH-GFSIGSNMSA-N> <http://identifiers.org/inchikey/NCIHLRCJOBKKAL-ZBSJWCJSSA-N> <http://identifiers.org/inchikey/XWCYDHJOKKGVHC-IOUUIBBYSA-N> <http://identifiers.org/inchikey/GGCUJPCCTQNTJF-FAOQNJJDSA-N> <http://identifiers.org/inchikey/YBLASMZMTCDCLQ-HRYGCDPOSA-N> <http://identifiers.org/inchikey/XTOYXKSKSDVOOD-CISKFWAASA-N> <http://identifiers.org/inchikey/QHNVWXUULMZJKD-IOUUIBBYSA-N> <http://identifiers.org/inchikey/OVBOQVAIYMSUDT-HRYGCDPOSA-N> <http://identifiers.org/inchikey/FJTNODQGSYTFKC-GTQBYYIBSA-N> <http://identifiers.org/inchikey/XEMSPUZLYVPKPX-SHGBQBHBSA-N> <http://identifiers.org/inchikey/XWCYDHJOKKGVHC-OVSJKPMPSA-N> <http://identifiers.org/inchikey/IOELQUUUYMBPSA-RMWYGNQTSA-N> <http://identifiers.org/inchikey/SYESMXTWOAQFET-YCNIQYBTSA-N> <http://identifiers.org/inchikey/DGCPGJKPROZYMN-RGKDZJHZSA-N> <http://identifiers.org/inchikey/KGUMXGDKXYTTEY-CJJLNRCZSA-N> <http://identifiers.org/inchikey/KGUMXGDKXYTTEY-FRCNGJHJSA-N> <http://identifiers.org/inchikey/IYIYMCASGKQOCZ-DJRRULDNSA-N> <http://identifiers.org/inchikey/HRIZQYUEJYDJLD-HRYGCDPOSA-N> <http://identifiers.org/inchikey/AKJHMTWEGVYYSE-UHFFFAOYSA-N> <http://identifiers.org/inchikey/KGUMXGDKXYTTEY-UHFFFAOYSA-N> <http://identifiers.org/inchikey/HQMNCQVAMBCHCO-UHFFFAOYSA-N> <http://identifiers.org/inchikey/QGNJRVVDBSJHIZ-UHFFFAOYSA-N> <http://identifiers.org/inchikey/FSLMGODKGHHERM-FRCNGJHJSA-N> <http://identifiers.org/inchikey/HQMNCQVAMBCHCO-DJRRULDNSA-N> <http://identifiers.org/inchikey/IHUNBGSDBOWDMA-UHFFFAOYSA-N> <http://identifiers.org/inchikey/IHUNBGSDBOWDMA-AQFIFDHZSA-N> <http://identifiers.org/inchikey/IHUNBGSDBOWDMA-UGOGCBOOSA-N> <http://identifiers.org/inchikey/IHUNBGSDBOWDMA-FZCLVFSMSA-N> <http://identifiers.org/inchikey/NAVMQTYZDKMPEU-UHFFFAOYSA-N> <http://identifiers.org/inchikey/WPWFMRDPTDEJJA-FAXVYDRBSA-N> <http://identifiers.org/inchikey/GGCUJPCCTQNTJF-FRCNGJHJSA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-SKVGZCNQSA-N> <http://identifiers.org/inchikey/QPRQNCDEPWLQRO-DAWLFQHYSA-N> }
+          ?c schema:inChIKey ?ik ;
+             rdfs:label ?name .
+          ?spectrum mb:compound ?c .
+        }
+      }
+      GROUP BY ?ik
+      ORDER BY DESC(?nSpectra)
+    result_count: 5
+
+  - query_number: 3
+    database: massbank
+    description: >-
+      Arithmetic verification for the Query 2 GROUP BY: independently count the
+      distinct retinoid InChIKeys that match a MassBank compound (-> 5, equal to
+      the number of grouped rows) and the total distinct spectra across them
+      (-> 44 = 28 + 7 + 4 + 3 + 2, confirming the per-compound counts sum
+      correctly).
+    query: |
+      PREFIX mb: <http://www.massbank.jp/ontology/>
+      PREFIX schema: <https://schema.org/>
+      SELECT (COUNT(DISTINCT ?ik) AS ?nRetinoidsWithSpectra) (COUNT(DISTINCT ?spectrum) AS ?nSpectraTotal)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/massbank> {
+          VALUES ?ik {
+            <http://identifiers.org/inchikey/NAVMQTYZDKMPEU-UHFFFAOYSA-N>
+            <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-YCNIQYBTSA-N>
+            <http://identifiers.org/inchikey/SHGAZHPCJJPHSC-UHFFFAOYSA-N>
+            <http://identifiers.org/inchikey/NCYCYZXNIZJOKI-OVSJKPMPSA-N>
+            <http://identifiers.org/inchikey/FPIPGXGPPPQFEQ-UHFFFAOYSA-N>
+          }
+          ?c schema:inChIKey ?ik .
+          ?spectrum mb:compound ?c .
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix chemrof: <https://w3id.org/chemrof/> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix mb: <http://www.massbank.jp/ontology/> .
+  @prefix schema: <https://schema.org/> .
+  @prefix mbr: <https://identifiers.org/massbank/> .
+  @prefix ik: <http://identifiers.org/inchikey/> .
+
+  obo:CHEBI_50859 rdfs:subClassOf obo:CHEBI_26537 .
+  # Database: ChEBI | Query: 1 | Comment: bexarotene is a member of the retinoid class (CHEBI:26537)
+  obo:CHEBI_50859 chemrof:inchi_key_string "NAVMQTYZDKMPEU-UHFFFAOYSA-N" .
+  # Database: ChEBI | Query: 1 | Comment: bexarotene's standard InChIKey - the structure key used to look up spectra
+  obo:CHEBI_15367 chemrof:inchi_key_string "SHGAZHPCJJPHSC-YCNIQYBTSA-N" .
+  # Database: ChEBI | Query: 1 | Comment: all-trans-retinoic acid's InChIKey (one of the 101 retinoid structures in scope)
+  mbr:MSBNK-BGC_Munich-RP013501 mb:compound _:c .
+  # Database: MassBank | Query: 2 | Comment: a reference spectrum whose measured compound is all-trans-retinoic acid
+  _:c schema:inChIKey ik:SHGAZHPCJJPHSC-YCNIQYBTSA-N .
+  # Database: MassBank | Query: 2 | Comment: the spectrum's compound carries the all-trans-retinoic acid InChIKey - matching Query 1, so this retinoid is in the list
+  _:c rdfs:label "Retinoic acid" .
+  # Database: MassBank | Query: 2 | Comment: MassBank's label for that compound
+
+exact_answer:
+  - "Bexarotene (InChIKey NAVMQTYZDKMPEU-UHFFFAOYSA-N)"
+  - "all-trans-retinoic acid (InChIKey SHGAZHPCJJPHSC-YCNIQYBTSA-N)"
+  - "retinoic acid, unspecified geometry (InChIKey SHGAZHPCJJPHSC-UHFFFAOYSA-N)"
+  - "all-trans-retinal (InChIKey NCYCYZXNIZJOKI-OVSJKPMPSA-N)"
+  - "retinol (InChIKey FPIPGXGPPPQFEQ-UHFFFAOYSA-N)"
+
+ideal_answer: |
+  Of the retinoid class - 115 members in the ChEBI subtree, 101 of them structurally defined by a standard InChIKey - only five have any reference tandem mass spectrum in the public spectral library, and together they account for just 44 spectra. Ranked by number of reference spectra they are: bexarotene, a synthetic RXR-agonist retinoid drug (28 spectra); all-trans-retinoic acid (7); retinoic acid recorded without specified double-bond geometry (4); all-trans-retinal (3); and retinol, i.e. vitamin A itself (2). The pattern is telling: reference-spectrum coverage is confined to the pharmacologically or nutritionally prominent parent retinoids plus one marketed drug, while the great majority of catalogued retinoids - the many oxidized (4-oxo, hydroxy), chain-modified, and glucuronidated metabolites, retinyl esters, and other synthetic analogues - have no reference spectrum at all. This is a coverage property of the current library holdings rather than a statement about which retinoids exist or are biologically important, and it marks a substantial reference-data gap for untargeted retinoid metabolomics.
+
+question_template_used: ontology compound-class coverage against a spectral library (ChEBI class getDescendants -> InChIKey set -> MassBank reference-spectrum presence)
+
+time_spent:
+  exploration: 45
+  formulation: 15
+  verification: 10
+  pubmed_test: 12
+  extraction: 15
+  documentation: 15
+  total: 112

--- a/benchmark/questions/question_069.yaml
+++ b/benchmark/questions/question_069.yaml
@@ -1,0 +1,261 @@
+id: question_069
+type: yes_no
+body: "Among the archaeal type strains preserved in the culture catalogue of Japan's NITE Biological Resource Center, the strains' species fall into several class-level ranks of the standard hierarchical classification of organisms. Is the class represented by the greatest number of distinct type strains a methanogenic (methane-producing) lineage?"
+
+inspiration_keyword:
+  keyword_id: KW-0484
+  name: Methanogenesis
+  category: Biological process
+
+togomcp_databases_used:
+  - nbrc
+  - taxonomy
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 8 minutes
+  method: |
+    Ran three programmatic PubMed searches attempting to establish which archaeal class is
+    most represented among the type strains of the collection (the fact the yes/no answer
+    turns on):
+    (1) "NBRC NITE Biological Resource Center archaeal type strains taxonomic class distribution"
+    (2) "archaea culture collection type strains Methanomicrobia Halobacteria most represented class"
+    (3) "diversity of archaeal strains preserved culture collections methanogens halophiles"
+  result: |
+    All three searches returned zero indexed articles. The published literature describes
+    individual archaeal taxa and reviews archaeal cultivation, but no study reports the
+    class-level breakdown of the archaeal type strains actually held in a specific culture
+    collection, still less which class is the single most represented. Because the top two
+    classes are separated by only three strains (methanogenic Methanomicrobia at 45 vs.
+    halophilic, non-methanogenic Halobacteria at 42), the yes/no answer cannot be guessed
+    from general knowledge of archaeal diversity — it is an aggregate over the collection's
+    current catalogue joined to the current taxonomic classification of each strain's species.
+  conclusion: PASS (cannot answer from literature; the yes/no hinges on a live join of the culture catalogue to the taxonomic hierarchy, and on a 3-strain margin)
+
+sparql_queries:
+  - query_number: 1
+    database: nbrc
+    description: >-
+      Scope query (culture catalogue only). Count the archaeal type strains and how many
+      carry a taxonomic cross-reference. Archaeal = organism category mccv:MCCV_000038 =
+      mccv:MCCV_000041; type strain = mccv:MCCV_000017 = 1 (bare integer). Anchored on
+      brso:BiologicalResource so equivalent-strain nodes are not miscounted.
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+
+      SELECT
+        (COUNT(DISTINCT ?strain)   AS ?archaealTypeStrains)
+        (COUNT(DISTINCT ?withTaxon) AS ?withTaxonLink)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000017 1 ;
+                  mccv:MCCV_000038 mccv:MCCV_000041 .
+          OPTIONAL {
+            ?strain mccv:MCCV_000065 ?taxon .
+            BIND(?strain AS ?withTaxon)
+          }
+        }
+      }
+    result_count: 1
+
+  - query_number: 2
+    database: taxonomy
+    description: >-
+      Cross-graph class distribution on the shared primary endpoint. For each archaeal type
+      strain, walk its species taxon (mccv:MCCV_000065) up the classification with
+      rdfs:subClassOf* to the ancestor whose tax:rank is tax:Class, then count distinct
+      strains per class. The most-represented class determines the yes/no answer.
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+
+      SELECT ?class ?id ?className (COUNT(DISTINCT ?strain) AS ?n)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000017 1 ;
+                  mccv:MCCV_000038 mccv:MCCV_000041 ;
+                  mccv:MCCV_000065 ?taxon .
+        }
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          ?taxon rdfs:subClassOf* ?class .
+          ?class tax:rank tax:Class ;
+                 rdfs:label ?className ;
+                 dcterms:identifier ?id .
+        }
+      }
+      GROUP BY ?class ?id ?className
+      ORDER BY DESC(?n)
+    result_count: 11
+
+  - query_number: 3
+    database: taxonomy
+    description: >-
+      Arithmetic verification. Count the distinct archaeal type strains that have any
+      class-ranked ancestor, to confirm the per-class counts of Query 2 sum to the total
+      (45+42+20+19+3+3+2+2+1+1+1 = 139) with no coverage gap and no double counting.
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT (COUNT(DISTINCT ?strain) AS ?totalWithClass)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000017 1 ;
+                  mccv:MCCV_000038 mccv:MCCV_000041 ;
+                  mccv:MCCV_000065 ?taxon .
+        }
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          ?taxon rdfs:subClassOf* ?class .
+          ?class tax:rank tax:Class .
+        }
+      }
+    result_count: 1
+
+  - query_number: 4
+    database: nbrc
+    description: >-
+      Evidence for the winning class. List representative archaeal type strains whose
+      species falls in class Methanomicrobia (taxon 224756), returning the catalogue
+      number, accepted name and species taxon IRI.
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?strain ?nbrcNo ?name ?taxon
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000017 1 ;
+                  mccv:MCCV_000038 mccv:MCCV_000041 ;
+                  mccv:MCCV_000010 ?nbrcNo ;
+                  skos:prefLabel ?name ;
+                  mccv:MCCV_000065 ?taxon .
+        }
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          ?taxon rdfs:subClassOf* ?class .
+          ?class tax:rank tax:Class ; rdfs:label "Methanomicrobia" .
+        }
+      }
+      ORDER BY ?name
+      LIMIT 5
+    result_count: 5
+
+rdf_triples: |
+  @prefix mccv:    <http://purl.jp/bio/10/mccv#> .
+  @prefix brso:    <http://purl.jp/bio/10/brso/> .
+  @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+  @prefix tax:     <http://ddbj.nig.ac.jp/ontologies/taxonomy/> .
+  @prefix taxon:   <http://identifiers.org/taxonomy/> .
+  @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix dcterms: <http://purl.org/dc/terms/> .
+  @prefix cul:     <http://purl.jp/bio/103/nite/nbrc/cultures/> .
+  @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:      <http://example.org/nbrc-taxa-analysis#> .
+
+  ex:archaealTypeStrainSet ex:totalArchaealTypeStrains "142"^^xsd:integer .
+  # Database: nbrc | Query: 1 | Comment: 142 archaeal type strains in the catalogue (mccv:MCCV_000038 = mccv:MCCV_000041 Archaea AND mccv:MCCV_000017 = 1 type strain), anchored on brso:BiologicalResource
+
+  ex:archaealTypeStrainSet ex:withTaxonomyLink "139"^^xsd:integer .
+  # Database: nbrc | Query: 1 | Comment: 139 of the 142 carry a species cross-reference (mccv:MCCV_000065); the remaining 3 have no taxon link and cannot be placed in a class
+
+  cul:00101707 a brso:BiologicalResource ;
+      mccv:MCCV_000017 1 ;
+      mccv:MCCV_000038 mccv:MCCV_000041 ;
+      skos:prefLabel "Methanocella paludicola" ;
+      mccv:MCCV_000010 "NBRC 00101707" ;
+      mccv:MCCV_000065 taxon:570267 .
+  # Database: nbrc | Query: 4 | Comment: Representative winning-class type strain — Methanocella paludicola (NBRC 00101707), a methanogen; its species taxon 570267 resolves to class Methanomicrobia
+
+  cul:00107633 a brso:BiologicalResource ;
+      skos:prefLabel "Methanococcoides burtonii" ;
+      mccv:MCCV_000065 taxon:29291 .
+  # Database: nbrc | Query: 4 | Comment: A second Methanomicrobia type strain — Methanococcoides burtonii (NBRC 00107633), also a methanogen, species taxon 29291
+
+  taxon:570267 rdfs:subClassOf* taxon:224756 .
+  # Database: taxonomy | Query: 2 | Comment: Lineage link placing Methanocella paludicola (570267) inside class Methanomicrobia (224756) via transitive rdfs:subClassOf
+
+  taxon:224756 a tax:Taxon ; tax:rank tax:Class ; rdfs:label "Methanomicrobia" ; dcterms:identifier 224756 ;
+      ex:nbrcArchaealTypeStrainCount "45"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Methanomicrobia (NCBI taxid 224756) — 45 distinct archaeal type strains, the greatest of any class; Methanomicrobia is a methanogenic (methane-producing) lineage, so the yes/no answer is YES
+
+  taxon:183963 a tax:Taxon ; tax:rank tax:Class ; rdfs:label "Halobacteria" ; dcterms:identifier 183963 ;
+      ex:nbrcArchaealTypeStrainCount "42"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Halobacteria (taxid 183963) — 42 type strains, the close runner-up (margin of 3); halophilic and NOT methanogenic, so had it led the answer would be NO
+
+  taxon:183924 a tax:Taxon ; tax:rank tax:Class ; rdfs:label "Thermoprotei" ; dcterms:identifier 183924 ;
+      ex:nbrcArchaealTypeStrainCount "20"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Thermoprotei (taxid 183924) — 20 type strains, third
+
+  taxon:183925 a tax:Taxon ; tax:rank tax:Class ; rdfs:label "Methanobacteria" ; dcterms:identifier 183925 ;
+      ex:nbrcArchaealTypeStrainCount "19"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Methanobacteria (taxid 183925) — 19 type strains, fourth; also a methanogenic class
+
+  taxon:183980 ex:nbrcArchaealTypeStrainCount "3"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Archaeoglobi (taxid 183980) — 3 type strains
+  taxon:183939 ex:nbrcArchaealTypeStrainCount "3"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Methanococci (taxid 183939) — 3 type strains, a methanogenic class
+  taxon:183967 ex:nbrcArchaealTypeStrainCount "2"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Thermoplasmata (taxid 183967) — 2 type strains
+  taxon:183968 ex:nbrcArchaealTypeStrainCount "2"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Thermococci (taxid 183968) — 2 type strains
+  taxon:171536 ex:nbrcArchaealTypeStrainCount "1"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Methanonatronarchaeia (taxid 171536) — 1 type strain, a methanogenic class
+  taxon:1643678 ex:nbrcArchaealTypeStrainCount "1"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Nitrososphaeria (taxid 1643678) — 1 type strain (the only non-Euryarchaeota class present)
+  taxon:183988 ex:nbrcArchaealTypeStrainCount "1"^^xsd:integer .
+  # Database: taxonomy | Query: 2 | Comment: Class Methanopyri (taxid 183988) — 1 type strain, a methanogenic class
+
+  ex:archaealTypeStrainSet ex:sumOfPerClassCounts "139"^^xsd:integer .
+  # Database: taxonomy | Query: 3 | Comment: Arithmetic check — 45+42+20+19+3+3+2+2+1+1+1 = 139 = the independently counted total with a class-ranked ancestor; every strain maps to exactly one class, so there is no coverage gap and no double counting
+
+exact_answer: "yes"
+
+ideal_answer: |
+  Yes. The archaeal class represented by the greatest number of distinct type strains in the
+  collection is Methanomicrobia — a methanogenic (methane-producing) lineage — with 45 type
+  strains, narrowly ahead of the halophilic, non-methanogenic class Halobacteria with 42. The
+  remaining classes trail well behind: Thermoprotei (20), Methanobacteria (19, also
+  methanogenic), Archaeoglobi (3), Methanococci (3, methanogenic), Thermoplasmata (2),
+  Thermococci (2), and one type strain each in Methanonatronarchaeia and Methanopyri (both
+  methanogenic) and in Nitrososphaeria. Of the 142 archaeal type strains in the catalogue,
+  139 carry a species cross-reference that can be placed in the taxonomic hierarchy; those 139
+  sum exactly across the eleven classes (45+42+20+19+3+3+2+2+1+1+1 = 139), confirming that each
+  strain falls in exactly one class with no gap or overlap, while the 3 strains without a
+  taxonomic link are unclassifiable to class. Methanogens are split here across five classes
+  (Methanomicrobia, Methanobacteria, Methanococci, Methanopyri, Methanonatronarchaeia), and
+  together with the easily cultivated halophiles of Halobacteria they dominate the archaeal
+  type-strain holdings because these lineages have long been amenable to pure culture. The
+  answer is genuinely data-dependent rather than recallable: Methanomicrobia leads Halobacteria
+  by only three strains, so the identity of the single most-represented class — and hence
+  whether it is a methanogenic one — must be computed from the current joined database state
+  and would flip with modest catalogue additions or ongoing reclassification of archaeal taxa.
+
+question_template_used: "Template 7 variant (Yes/No — is a computed maximum a member of a named functional class)"
+
+time_spent:
+  exploration: 25 minutes
+  formulation: 15 minutes
+  verification: 15 minutes
+  pubmed_test: 8 minutes
+  extraction: 15 minutes
+  documentation: 25 minutes
+  total: 103 minutes

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -256,5 +256,6 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 066 | P      | —      |
 | 067 | P      | —      |
 | 068 | P      | —      |
+| 069 | P      | —      |
 
-**Summary:** `P` = 68 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 68 / 68
+**Summary:** `P` = 69 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 69 / 69

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -253,5 +253,8 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 063 | P      | —      |
 | 064 | P      | —      |
 | 065 | P      | —      |
+| 066 | P      | —      |
+| 067 | P      | —      |
+| 068 | P      | —      |
 
-**Summary:** `P` = 65 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 65 / 65
+**Summary:** `P` = 68 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 68 / 68

--- a/togo_mcp/data/mie/nbrc.yaml
+++ b/togo_mcp/data/mie/nbrc.yaml
@@ -1,0 +1,618 @@
+schema_info:
+  title: NBRC (NITE Biological Resource Center culture catalogue)
+  description: |
+    Catalogue of microbial strains distributed by the NITE Biological Resource Center
+    (NBRC, Japan). Each record is a preserved biological resource (bacterium, archaeon,
+    filamentous fungus, yeast, alga, or bacteriophage) with its accepted scientific name,
+    NBRC catalogue number, organism category, type-strain status, recommended growth
+    temperature and medium, isolation source (habitat) and geographic origin, biosafety level, equivalent strain
+    numbers in other world culture collections, and links to NCBI Taxonomy, INSDC genomes
+    and PubMed. Primary uses: locating strains for order, taxonomy-to-strain lookup,
+    cultivation-condition and habitat/provenance mining, and cross-collection strain equivalence.
+  keywords:
+    - culture collection
+    - biological resource
+    - microbial strain
+    - nbrc
+    - nite
+    - bioresource
+    - bacteria
+    - archaea
+    - fungi
+    - yeast
+    - type strain
+    - isolation source
+    - growth temperature
+    - culture medium
+    - biosafety level
+  categories:
+    - microbe
+  endpoint: https://rdfportal.org/primary/sparql
+  base_uri: http://purl.jp/bio/103/nite/nbrc/
+  graphs:
+    - http://purl.jp/bio/103/nite/culture/
+  kw_search_tools: []
+  version:
+    mie_version: "2.0"
+    mie_created: "2026-07-02"
+    data_version: "RDF Portal snapshot 2026-07"
+    update_frequency: "Periodic (with NBRC catalogue releases)"
+  access:
+    backend: "Virtuoso (supports bif:contains)"
+
+critical_warnings: |
+  - GRAPH IS MANDATORY: every query must be scoped with
+    `GRAPH <http://purl.jp/bio/103/nite/culture/>`. The primary endpoint co-hosts ~40
+    datasets; without the graph clause queries mix NBRC with MeSH/GO/BacDive/MEO/etc. and
+    return wrong or huge results.
+  - STRING LITERALS ARE PLAIN — DO NOT ADD ^^xsd:string: string values (dcterms:identifier,
+    skos:prefLabel, mccv:MCCV_000010 strain no., mccv:MCCV_000012 name+author, mccv:MCCV_000027
+    attribution, mccv:MCCV_000030 isolation source, mccv:MCCV_000033 property note,
+    mccv:MCCV_000034 biosafety level, and the geography rdfs:label) are stored as PLAIN literals.
+    Virtuoso's DATATYPE() reports them as xsd:string, but an exact match written with the explicit
+    type — `mccv:MCCV_000034 "L1"^^xsd:string` or `VALUES ?x { "L1"^^xsd:string }` — returns 0
+    rows. Match with the PLAIN literal (`"L1"`) or compare via `STR(?x) = "L1"`. VALUES blocks are
+    the #1 silent-fail spot. (This is the reverse of the usual typed-string trap — verified
+    empirically on this endpoint.)
+  - NO ONTOLOGY LABELS IN THIS GRAPH: MCCV, MPO and brso terms carry NO rdfs:label in the
+    NBRC graph (e.g. `mccv:MCCV_000010 rdfs:label ?l` returns nothing). You MUST query by the
+    numeric IRIs; you cannot discover or filter predicates by human-readable name. The meaning of
+    each MCCV/MPO id is given in shape_expressions (sourced from the MCCV/MPO ontologies). (MEO
+    habitat and GAZ geography terms DO have labels, but in other graphs — see below.)
+  - MCCV_000001 IS POLYMORPHIC — DO NOT COUNT IT AS STRAINS: rdf:type mccv:MCCV_000001
+    (62,676) covers BOTH the 23,987 NBRC strain IRIs AND the ~38,689 equivalent-strain
+    designation blank nodes (other collections, reached via mccv:MCCV_000024). For the actual
+    NBRC holdings use `?s a brso:BiologicalResource` (23,987) or
+    `FILTER(STRSTARTS(STR(?s), "http://purl.jp/bio/103/nite/nbrc/cultures/"))`.
+  - MEDIA ARE LINK-ONLY STUBS: the culture-condition node's mccv:MCCV_000018 points to a
+    medium IRI (`.../nbrc/medium/<id>`, 817 distinct) but those IRIs carry NO triples anywhere
+    on the endpoint — there is no medium name or composition. Treat the medium IRI as an
+    opaque identifier only.
+  - TEMPERATURE LIVES ON A BLANK NODE, NOT ON THE STRAIN: growth temperature is reached via
+    `?strain sio:SIO_000216 [ a mpo:MPO_00102 ; sio:SIO_000300 ?degC ; sio:SIO_000221 obo:UO_0000027 ]`.
+    MPO_00102 is the single recorded cultivation (growth) temperature (on ~all strains); MPO_00103
+    and MPO_00104 are the two endpoints of a temperature range on the minority recorded with one.
+    Values are xsd:integer °C. A direct `?strain ?p ?temperature` triple does not exist.
+    NOTE: these numeric MPO ids are the snapshot's own; the published MPO ontology numbers the same
+    concepts differently (growth temperature = MPO_10008/…) — query with the ids documented here.
+  - MCCV_000072 AND SIO_000008 ARE POLYMORPHIC: a sample node (mccv:MCCV_000028) links via
+    mccv:MCCV_000072 to BOTH an isolation-source node (mccv:MCCV_000007) and a geographic-origin
+    node (mccv:MCCV_000008). On a source node, sio:SIO_000008 resolves to a MEO habitat IRI
+    (`http://purl.jp/bio/11/meo/MEO_*`); on a geography node it resolves to a GAZ gazetteer IRI
+    (`http://purl.obolibrary.org/obo/GAZ_*`). Filter on the child node's rdf:type to disambiguate.
+  - INSDC IRI USES A COLON: mccv:MCCV_000077 objects are `http://identifiers.org/insdc:<ACCESSION>`
+    (colon after "insdc", not a slash). Constructing the slash form joins to nothing.
+
+shape_expressions: |
+  PREFIX mccv:    <http://purl.jp/bio/10/mccv#>
+  PREFIX mpo:     <http://purl.jp/bio/10/mpo/>
+  PREFIX brso:    <http://purl.jp/bio/10/brso/>
+  PREFIX meo:     <http://purl.jp/bio/11/meo/>
+  PREFIX sio:     <http://semanticscience.org/resource/>
+  PREFIX obo:     <http://purl.obolibrary.org/obo/>
+  PREFIX dcterms: <http://purl.org/dc/terms/>
+  PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+  PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+  PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+
+  # ── NBRC strain (biological resource) ───────────────────────────────────────
+  # IRI: http://purl.jp/bio/103/nite/nbrc/cultures/<8-digit id>
+  # 23,987 instances (a [ brso:BiologicalResource ]). ALSO typed a [ mccv:MCCV_000001 ],
+  # but MCCV_000001 is polymorphic (see critical_warnings) — anchor on brso:BiologicalResource.
+  # xsd:string annotations below are what DATATYPE() reports; the literals are stored PLAIN, so
+  # exact matches must use the plain form ("L1"), NOT "L1"^^xsd:string (see critical_warnings).
+  <BiologicalResourceShape> {
+    a [ brso:BiologicalResource ] ;                 # the NBRC strain
+    a [ mccv:MCCV_000001 ] ;                         # generic "culture designation" (also on equiv. nodes)
+    rdfs:subClassOf [ brso:repository ] ;            # all strains; fixed
+    dcterms:identifier xsd:string ;                  # "NBRC_<id>" (internal id, underscore)
+    skos:prefLabel xsd:string ;                      # accepted scientific name, e.g. "Candida kefyr"
+    mccv:MCCV_000010 xsd:string ;                    # "culture collection number" — NBRC no., e.g. "NBRC 00000001"
+    mccv:MCCV_000012 xsd:string ;                    # "qualified species name" (name + author), e.g. "... (Nylander) Tibell"
+    mccv:MCCV_000017 xsd:integer ;                   # "is type strain": 1 = type strain (6,275) | 0 = not (17,712)
+    mccv:MCCV_000038 [ mccv:MCCV_000040~ ] ;         # "organism category by BRC" -> 6-value enum (see below)
+    mccv:MCCV_000073 @<GrowthConditionShape> ;       # "culture condition" -> growth medium
+    mccv:MCCV_000076 IRI ;                            # WFCC-CCINFO collection ref (wfcc.info/ccinfo/collection/by_id/825)
+    foaf:homepage IRI ;                              # NITE DBRP data-view page
+    mccv:MCCV_000034 xsd:string ? ;                  # "biosafety level": "L1"|"L2"|"L1*" (~100%, 23,986)
+    mccv:MCCV_000027 xsd:string ? ;                  # "history" — deposit/isolation history free text (~100%, 23,984)
+    mccv:MCCV_000046 xsd:integer ? ;                 # "is approved": 0|1 (92.3%)
+    mccv:MCCV_000065 IRI ? ;                          # "is a species" -> NCBI Taxonomy IRI (91.2%) identifiers.org/taxonomy/<taxid>
+    brso:organism @<OrganismShape> ? ;               # organism node -> taxon (91.2%)
+    mccv:MCCV_000028 @<SampleShape> ? ;              # "isolated from" -> sample (habitat + geography) (80.9%)
+    sio:SIO_000216 @<TemperatureMeasurementShape> * ; # growth-temperature measurement(s) (~100%, 23,983)
+    mccv:MCCV_000024 @<EquivalentStrainShape> * ;    # "other culture collection information" -> equiv strain (51.1%)
+    dcterms:references IRI * ;                        # PubMed IRIs identifiers.org/pubmed/<pmid> (30.8%)
+    mccv:MCCV_000077 IRI * ;                          # INSDC genome/nuc. accession identifiers.org/insdc:<acc> (8.2%)
+    mccv:MCCV_000033 xsd:string *                    # "application" note, e.g. "<compound>;production" (~12%)
+  }
+
+  # ── Organism-category enum (object of mccv:MCCV_000038 "organism category by BRC") ──
+  # 6 category IRIs; labels from the MCCV ontology (not present in the endpoint):
+  #   mccv:MCCV_000042 Fungi (10,140)     mccv:MCCV_000040 Bacteria (9,276)
+  #   mccv:MCCV_000043 Yeasts (3,692)     mccv:MCCV_000044 Algae (470)
+  #   mccv:MCCV_000041 Archaea (305)      mccv:MCCV_000045 Phages (104)
+
+  # ── Cultivation condition (blank node) ──────────────────────────────────────
+  # 23,987; reached via mccv:MCCV_000073 ("culture condition"). Typed mccv:MCCV_000005 ("Culture condition").
+  <GrowthConditionShape> {
+    a [ mccv:MCCV_000005 ] ;
+    mccv:MCCV_000018 IRI                             # "growth medium" IRI (LINK-ONLY STUB, no triples)
+  }
+
+  # ── Organism node (blank node) ──────────────────────────────────────────────
+  # reached via brso:organism. Typed sio:SIO_010000 ("organism").
+  <OrganismShape> {
+    a [ sio:SIO_010000 ] ;
+    obo:RO_0002162 IRI                              # in taxon -> identifiers.org/taxonomy/<taxid>
+  }
+
+  # ── Sample node (blank node) ────────────────────────────────────────────────
+  # reached via mccv:MCCV_000028 ("isolated from"). Typed mccv:MCCV_000006 ("Sample") + sio:SIO_001050.
+  # mccv:MCCV_000072 ("sampled from") is polymorphic -> Habitat and/or GeographicOrigin child nodes.
+  <SampleShape> {
+    a [ mccv:MCCV_000006 ] ;
+    a [ sio:SIO_001050 ] ;
+    mccv:MCCV_000072 ( @<IsolationSourceShape> OR @<GeographicOriginShape> ) *
+  }
+
+  # ── Habitat / isolation source (blank node) ─────────────────────────────────
+  # Typed mccv:MCCV_000007 ("Habitat"). sio:SIO_000008 -> MEO habitat IRI (labels in microbedbjp graph).
+  <IsolationSourceShape> {
+    a [ mccv:MCCV_000007 ] ;
+    mccv:MCCV_000030 xsd:string ? ;                 # "isolation source description", e.g. "buttermilk"
+    sio:SIO_000008 IRI ?                            # MEO habitat http://purl.jp/bio/11/meo/MEO_*
+  }
+
+  # ── Geographic origin / country (blank node) ────────────────────────────────
+  # Typed mccv:MCCV_000008. rdfs:label = country name; sio:SIO_000008 -> GAZ gazetteer IRI.
+  <GeographicOriginShape> {
+    a [ mccv:MCCV_000008 ] ;
+    rdfs:label xsd:string ? ;                       # country name, e.g. "Japan"
+    sio:SIO_000008 IRI ?                            # GAZ http://purl.obolibrary.org/obo/GAZ_*
+  }
+
+  # ── Growth-temperature measurement (blank node) ─────────────────────────────
+  # reached via sio:SIO_000216. Typed mpo:MPO_00102 (optimal) | MPO_00103 (min) | MPO_00104 (max).
+  <TemperatureMeasurementShape> {
+    a [ mpo:MPO_00102 ] ;                            # or MPO_00103 / MPO_00104
+    sio:SIO_000300 xsd:integer ;                    # value in degrees Celsius
+    sio:SIO_000221 [ obo:UO_0000027 ]               # unit = degree Celsius
+  }
+
+  # ── Equivalent strain in another collection (blank node) ────────────────────
+  # reached via mccv:MCCV_000024 ("other culture collection information"). Typed mccv:MCCV_000001 ("Culture").
+  <EquivalentStrainShape> {
+    a [ mccv:MCCV_000001 ] ;
+    dcterms:identifier xsd:string + ;               # other-collection strain no., e.g. "JCM 3699", "CBS 328"
+    mccv:MCCV_000025 IRI ?                          # "other culture collection URI" — catalogue record URL
+  }
+
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix mccv:    <http://purl.jp/bio/10/mccv#> .
+    @prefix mpo:     <http://purl.jp/bio/10/mpo/> .
+    @prefix brso:    <http://purl.jp/bio/10/brso/> .
+    @prefix sio:     <http://semanticscience.org/resource/> .
+    @prefix obo:     <http://purl.obolibrary.org/obo/> .
+    @prefix dcterms: <http://purl.org/dc/terms/> .
+    @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+    @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+    @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+    @prefix cul:     <http://purl.jp/bio/103/nite/nbrc/cultures/> .
+  entries:
+    - title: "NBRC strain 00113675 (Phaeocalicium polyporaeum) — central record"
+      description: A filamentous-fungus strain showing the core strain predicates, the
+        organism-category enum, biosafety level, WFCC ref, and the NCBI Taxonomy cross-reference.
+      rdf: |
+        cul:00113675 a brso:BiologicalResource , mccv:MCCV_000001 ;
+            rdfs:subClassOf brso:repository ;
+            dcterms:identifier "NBRC_00113675" ;                        # plain literal (see critical_warnings)
+            skos:prefLabel "Phaeocalicium polyporaeum" ;
+            mccv:MCCV_000010 "NBRC 00113675" ;
+            mccv:MCCV_000012 "Phaeocalicium polyporaeum (Nylander) Tibell" ;
+            mccv:MCCV_000038 mccv:MCCV_000042 ;                         # organism category by BRC: Fungi
+            mccv:MCCV_000034 "L1" ;                                     # biosafety level 1
+            mccv:MCCV_000065 <http://identifiers.org/taxonomy/2840244> ;
+            mccv:MCCV_000076 <http://www.wfcc.info/ccinfo/collection/by_id/825> ;
+            foaf:homepage <https://www.nite.go.jp/nbrc/dbrp/dataview?dataId=STNB0000000113675> .
+
+    - title: "Growth-temperature measurement scaffold (NBRC 00000001)"
+      description: Optimal cultivation temperature reached via the sio:SIO_000216 blank node
+        typed mpo:MPO_00102, carrying the value (sio:SIO_000300) and unit (sio:SIO_000221, °C).
+      rdf: |
+        cul:00000001 sio:SIO_000216 [
+            a mpo:MPO_00102 ;
+            sio:SIO_000300 24 ;
+            sio:SIO_000221 obo:UO_0000027 ] .
+
+    - title: "Isolation source + geographic origin (NBRC 00000008, Candida kefyr)"
+      description: The sample chain — mccv:MCCV_000028 -> sample -> mccv:MCCV_000072 branches to
+        an isolation-source node (free text + MEO habitat IRI) and a geographic-origin node
+        (country label + GAZ IRI).
+      rdf: |
+        cul:00000008 mccv:MCCV_000028 [
+            a mccv:MCCV_000006 , sio:SIO_001050 ;
+            mccv:MCCV_000072 [ a mccv:MCCV_000007 ;
+                               mccv:MCCV_000030 "buttermilk" ;
+                               sio:SIO_000008 <http://purl.jp/bio/11/meo/MEO_0000222> ] ,
+                             [ a mccv:MCCV_000008 ;
+                               rdfs:label "Netherlands" ;
+                               sio:SIO_000008 <http://purl.obolibrary.org/obo/GAZ_00001549> ] ] .
+
+sparql_query_examples:
+  - title: "Look up one NBRC strain by its culture IRI"
+    description: Direct IRI lookup returning the accepted name, catalogue number, biosafety
+      level and NITE data-view page — the cheapest possible query.
+    question: "What are the name, NBRC number and biosafety level of strain NBRC 00113675?"
+    complexity: basic
+    sparql: |
+      PREFIX mccv:    <http://purl.jp/bio/10/mccv#>
+      PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+      PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+      SELECT ?name ?nbrcNo ?biosafety ?homepage
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          <http://purl.jp/bio/103/nite/nbrc/cultures/00113675>
+              skos:prefLabel ?name ;
+              mccv:MCCV_000010 ?nbrcNo ;
+              foaf:homepage ?homepage .
+          OPTIONAL { <http://purl.jp/bio/103/nite/nbrc/cultures/00113675> mccv:MCCV_000034 ?biosafety }
+        }
+      }
+      LIMIT 10
+
+  - title: "List type strains of one organism category (archaea)"
+    description: Combine the organism-category enum (mccv:MCCV_000041 = Archaea) with the
+      type-strain flag (mccv:MCCV_000017 = 1, an xsd:integer — use the bare 1, not a string).
+      Both are structured — no text search.
+    question: "Which archaeal type strains does NBRC hold, and what are their scientific names?"
+    complexity: basic
+    sparql: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?strain ?name ?nbrcNo
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000038 mccv:MCCV_000041 ;   # Archaea
+                  mccv:MCCV_000017 1 ;                  # is type strain (integer 1)
+                  skos:prefLabel ?name ;
+                  mccv:MCCV_000010 ?nbrcNo .
+        }
+      }
+      ORDER BY ?name
+      LIMIT 20
+
+  - title: "Thermophilic strains by growth temperature (blank-node measurement)"
+    description: Walk the sio:SIO_000216 measurement scaffold to the optimal growth temperature
+      (mpo:MPO_00102) and its value (sio:SIO_000300), keeping strains grown at >= 50 degC.
+    question: "Which NBRC strains have an optimal growth temperature of 50 degrees Celsius or higher?"
+    complexity: intermediate
+    sparql: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX mpo:  <http://purl.jp/bio/10/mpo/>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX sio:  <http://semanticscience.org/resource/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?strain ?name ?tempC
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  skos:prefLabel ?name ;
+                  sio:SIO_000216 ?m .
+          ?m a mpo:MPO_00102 ;
+             sio:SIO_000300 ?tempC .
+          FILTER(?tempC >= 50)
+        }
+      }
+      ORDER BY DESC(?tempC)
+      LIMIT 20
+
+  - title: "Isolation source and MEO habitat for yeast strains"
+    description: Navigate the sample chain (mccv:MCCV_000028 -> sample -> mccv:MCCV_000072 ->
+      isolation-source node) to the free-text source and the structured MEO habitat IRI, for
+      strains of one organism category (yeasts).
+    question: "From what sources (and MEO habitats) were NBRC yeast strains isolated?"
+    complexity: intermediate
+    sparql: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX sio:  <http://semanticscience.org/resource/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?name ?source ?meoHabitat
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000038 mccv:MCCV_000043 ;      # yeasts
+                  skos:prefLabel ?name ;
+                  mccv:MCCV_000028/mccv:MCCV_000072 ?src .
+          ?src a mccv:MCCV_000007 ;                        # isolation-source node (not geography)
+               mccv:MCCV_000030 ?source .
+          OPTIONAL { ?src sio:SIO_000008 ?meoHabitat }
+        }
+      }
+      LIMIT 20
+
+  - title: "Equivalent strain numbers in other culture collections"
+    description: For one NBRC strain, list its designations in other world collections
+      (mccv:MCCV_000024 -> dcterms:identifier) with the catalogue URL (mccv:MCCV_000025).
+    question: "Under what strain numbers is NBRC 00000008 held in other culture collections?"
+    complexity: intermediate
+    sparql: |
+      PREFIX mccv:    <http://purl.jp/bio/10/mccv#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+
+      SELECT ?otherNumber ?catalogueURL
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          <http://purl.jp/bio/103/nite/nbrc/cultures/00000008>
+              mccv:MCCV_000024 ?equiv .
+          ?equiv dcterms:identifier ?otherNumber .
+          OPTIONAL { ?equiv mccv:MCCV_000025 ?catalogueURL }
+        }
+      }
+      LIMIT 20
+
+  - title: "Strains of a given NCBI taxon with genome accession (if any)"
+    description: Filter strains by their NCBI Taxonomy cross-reference (mccv:MCCV_000065) and
+      optionally surface INSDC genome accessions (mccv:MCCV_000077, identifiers.org/insdc:<acc>).
+    question: "Which NBRC strains map to NCBI taxon 1613 (Limosilactobacillus fermentum), and do any have a genome?"
+    complexity: advanced
+    sparql: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?strain ?nbrcNo ?genome
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000065 <http://identifiers.org/taxonomy/1613> ;
+                  mccv:MCCV_000010 ?nbrcNo .
+          OPTIONAL { ?strain mccv:MCCV_000077 ?genome }
+        }
+      }
+      LIMIT 20
+
+  - title: "Count strains by country of geographic origin"
+    description: Aggregate over the geographic-origin branch of the sample chain
+      (mccv:MCCV_000028 -> mccv:MCCV_000072 -> geography node -> rdfs:label = country).
+    question: "What are the most common countries of origin for NBRC strains?"
+    complexity: advanced
+    sparql: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?country (COUNT(DISTINCT ?strain) AS ?nStrains)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000028/mccv:MCCV_000072 ?geo .
+          ?geo a mccv:MCCV_000008 ;                       # geography node (not source)
+               rdfs:label ?country .
+        }
+      }
+      GROUP BY ?country
+      ORDER BY DESC(?nStrains)
+      LIMIT 15
+
+cross_database_queries:
+  shared_endpoint: primary
+  co_located_databases: [taxonomy, mesh, go, mondo, nando, bacdive, mediadive, brenda, hgnc, jpostdb, massbank]
+  examples:
+    - title: "NBRC isolation habitat -> MEO environment label"
+      description: |
+        Linking strategy:
+        - NBRC: the isolation-source node (mccv:MCCV_000007) carries sio:SIO_000008 -> a MEO
+          habitat IRI (http://purl.jp/bio/11/meo/MEO_*).
+        - MEO: the Metagenome/Microbial Ecology Ontology labels live on the same primary
+          endpoint but in the microbedbjp graph (http://rdfportal.org/dataset/microbedbjp).
+        - Direct IRI matching across the two graphs; no text search.
+      databases_used: [nbrc, meo]
+      complexity: advanced
+      sparql: |
+        PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+        PREFIX brso: <http://purl.jp/bio/10/brso/>
+        PREFIX sio:  <http://semanticscience.org/resource/>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?name ?meo ?habitatLabel
+        WHERE {
+          GRAPH <http://purl.jp/bio/103/nite/culture/> {
+            ?strain a brso:BiologicalResource ;
+                    skos:prefLabel ?name ;
+                    mccv:MCCV_000028/mccv:MCCV_000072 ?src .
+            ?src a mccv:MCCV_000007 ;
+                 sio:SIO_000008 ?meo .
+          }
+          GRAPH <http://rdfportal.org/dataset/microbedbjp> {
+            ?meo rdfs:label ?habitatLabel .
+          }
+        }
+        LIMIT 20
+      notes: |
+        - Linking via: MEO habitat IRI (http://purl.jp/bio/11/meo/MEO_*), shared across graphs.
+        - MEO term labels are NOT in the NBRC culture graph; they are in the microbedbjp graph.
+        - NCBI Taxonomy is also co-located (graph http://rdfportal.org/ontology/taxonomy); NBRC
+          taxon IRIs use the identifiers.org/taxonomy/<taxid> form via mccv:MCCV_000065.
+
+cross_references:
+  - pattern: mccv:MCCV_000065 and brso:organism / obo:RO_0002162
+    description: |
+      Two paths to NCBI Taxonomy. mccv:MCCV_000065 links the strain directly to a taxon IRI;
+      brso:organism -> organism node -> obo:RO_0002162 gives the same taxon. IRI form:
+      http://identifiers.org/taxonomy/<taxid>. Both present on ~91% of strains.
+    databases:
+      taxonomy:
+        - "NCBI Taxonomy: 21,870 / 23,987 strains (91.2%)"
+  - pattern: mccv:MCCV_000077
+    description: |
+      INSDC nucleotide / genome sequence accession as an IRI of the form
+      http://identifiers.org/insdc:<ACCESSION> (colon, not slash). Multi-valued.
+    databases:
+      sequence:
+        - "INSDC (DDBJ/ENA/GenBank): 1,957 / 23,987 strains (8.2%)"
+  - pattern: dcterms:references
+    description: |
+      Literature citations as PubMed IRIs (http://identifiers.org/pubmed/<pmid>). Multi-valued.
+    databases:
+      literature:
+        - "PubMed: 7,383 / 23,987 strains (30.8%)"
+  - pattern: mccv:MCCV_000024 / mccv:MCCV_000025
+    description: |
+      Equivalent strain designations in other world culture collections (JCM, CBS, ATCC, VKM,
+      IAM, MUCL, DBVPG, ...). The equivalent node carries dcterms:identifier (the other
+      collection's strain number) and mccv:MCCV_000025 (a URL to that collection's record).
+    databases:
+      culture_collection:
+        - "Other WFCC collections: 12,254 / 23,987 strains (51.1%)"
+  - pattern: mccv:MCCV_000076
+    description: |
+      WFCC-CCINFO reference for the NBRC collection itself
+      (http://www.wfcc.info/ccinfo/collection/by_id/825). Constant across strains.
+    databases:
+      culture_collection:
+        - "WDCM/WFCC CCINFO: 23,987 / 23,987 strains (100%)"
+  - pattern: sio:SIO_000008 (on isolation-source and geography nodes)
+    description: |
+      Structured habitat/geography. On an isolation-source node (mccv:MCCV_000007) it is a MEO
+      habitat IRI (http://purl.jp/bio/11/meo/MEO_*); on a geography node (mccv:MCCV_000008) it is
+      a GAZ gazetteer IRI (http://purl.obolibrary.org/obo/GAZ_*). MEO labels resolve in the
+      microbedbjp graph on the same endpoint.
+    databases:
+      environment:
+        - "MEO (Metagenome/Microbial Ecology Ontology): on isolation-source nodes"
+        - "GAZ (Gazetteer): on geographic-origin nodes"
+
+architectural_notes:
+  query_strategy:
+    - "FIRST: read this MIE; the NBRC ontology terms have no labels in the graph, so you must use the numeric MCCV/MPO IRIs documented here."
+    - "Always scope to GRAPH <http://purl.jp/bio/103/nite/culture/> (shared primary endpoint)."
+    - "Anchor NBRC holdings on `?s a brso:BiologicalResource` — never on mccv:MCCV_000001 (polymorphic)."
+    - "String equality uses the PLAIN literal (`\"L1\"`) or `STR(?x) = \"L1\"` — NOT `\"L1\"^^xsd:string`, which returns 0 rows here."
+    - "Organism category, biosafety level, and NCBI taxon are structured (enum IRI / typed literal / IRI) — no text search needed."
+    - "Priority: Specific IRIs (strain, taxon, category enum) > typed predicates > blank-node navigation > text search."
+  schema_design:
+    - "Central entity: brso:BiologicalResource (NBRC strain), 23,987; IRI .../nbrc/cultures/<8-digit id>."
+    - "Blank-node satellites off the strain: cultivation condition (mccv:MCCV_000073 -> medium stub), organism (brso:organism -> taxon), sample (mccv:MCCV_000028 -> isolation source + geography), growth-temperature (sio:SIO_000216), equivalent strains (mccv:MCCV_000024)."
+    - "Organism-category enum on mccv:MCCV_000038: 6 IRIs (fungi/bacteria/yeast/algae/archaea/phage), no labels in endpoint."
+    - "Temperature scaffold: sio:SIO_000216 -> [ a mpo:MPO_00102|00103|00104 ; sio:SIO_000300 <intC> ; sio:SIO_000221 obo:UO_0000027 ]."
+    - "mccv:MCCV_000072 and sio:SIO_000008 are polymorphic (source vs geography; MEO vs GAZ) — filter on child rdf:type."
+  performance:
+    - "GRAPH clause is the single most important filter on this 40-dataset endpoint."
+    - "Property paths like mccv:MCCV_000028/mccv:MCCV_000072 are fine when the subject is a typed strain; add LIMIT."
+    - "bif:contains (Virtuoso, indexed) is available for free-text fields (mccv:MCCV_000027 attribution, mccv:MCCV_000030 source) if ever needed; split property paths before it."
+  data_integration:
+    - "NCBI Taxonomy via mccv:MCCV_000065 / brso:organism (identifiers.org/taxonomy/)."
+    - "INSDC genomes via mccv:MCCV_000077 (identifiers.org/insdc:<acc> — colon form)."
+    - "PubMed via dcterms:references (identifiers.org/pubmed/)."
+    - "Cross-collection equivalence via mccv:MCCV_000024 (+ mccv:MCCV_000025 catalogue URLs)."
+    - "Habitat via MEO (microbedbjp graph); geography via GAZ."
+    - "Media (mccv:MCCV_000018) are opaque link-only stubs — no medium name/composition in the endpoint."
+    - "MCCV/MPO/brso term labels are absent from the graph; the meanings documented here come from the MCCV and MPO ontologies (organism categories Bacteria/Archaea/Fungi/Yeasts/Algae/Phages are ontology labels, confirmed against representative members)."
+    - "ONTOLOGY VERSION SKEW: some numeric ids in this snapshot differ from the current published MCCV/MPO ontologies — growth temperature uses mpo:MPO_00102/00103/00104 (the ontology numbers these MPO_1000x); organism category is mccv:MCCV_000038 (ontology defines the category class as MCCV_000039). Always query with the ids documented here (verified live)."
+    - "Growth temperature is present on ~100% of strains; a small minority carry a two-endpoint range (MPO_00103/MPO_00104) instead of a single value (MPO_00102)."
+    - "mccv:MCCV_000017 = is-type-strain (1 = type strain, 6,275; 0 = not) and mccv:MCCV_000046 = is-approved (0|1) are integer flags."
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0."
+    - "Fields where text search IS legitimate: mccv:MCCV_000027 (attribution/history) and mccv:MCCV_000030 (free-text isolation source) — genuine free text."
+    - "Everything else is structured: organism category (enum IRI), biosafety (typed literal), taxon/genome/PubMed (IRIs), habitat (MEO IRI), geography (country label + GAZ IRI)."
+
+data_statistics:
+  total_entities: 23987
+  verified_date: "2026-07-02"
+  verification_method: "Direct COUNT(DISTINCT ?s) on ?s a brso:BiologicalResource in GRAPH <http://purl.jp/bio/103/nite/culture/>; per-feature counts via COUNT(DISTINCT) on each predicate."
+  strains: 23987
+  type_strains: 6275
+  culture_designations_incl_equivalents: 62676
+  distinct_media_referenced: 817
+  organism_categories:
+    Fungi_MCCV_000042: 10140
+    Bacteria_MCCV_000040: 9276
+    Yeasts_MCCV_000043: 3692
+    Algae_MCCV_000044: 470
+    Archaea_MCCV_000041: 305
+    Phages_MCCV_000045: 104
+  coverage:
+    type_strain: "26.2% (6,275 / 23,987 are type strains; mccv:MCCV_000017 = 1)"
+    growth_temperature: "~100% (23,983 / 23,987)"
+    organism_category: "100% (23,987 / 23,987)"
+    ncbi_taxonomy_link: "91.2% (21,870 / 23,987)"
+    isolation_sample: "80.9% (19,411 / 23,987)"
+    equivalent_strain_other_collection: "51.1% (12,254 / 23,987)"
+    pubmed_reference: "30.8% (7,383 / 23,987)"
+    insdc_genome_accession: "8.2% (1,957 / 23,987)"
+    verified_date: "2026-07-02"
+
+anti_patterns:
+  - title: "Counting mccv:MCCV_000001 as the number of strains"
+    problem: "mccv:MCCV_000001 also types the equivalent-strain designation blank nodes, so it overcounts."
+    wrong_sparql: |
+      SELECT (COUNT(?s) AS ?n) WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> { ?s a <http://purl.jp/bio/10/mccv#MCCV_000001> }
+      }   # = 62,676, NOT the strain count
+    correct_sparql: |
+      SELECT (COUNT(?s) AS ?n) WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> { ?s a <http://purl.jp/bio/10/brso/BiologicalResource> }
+      }   # = 23,987 NBRC strains
+    explanation: "Anchor on brso:BiologicalResource (or the .../nbrc/cultures/ IRI prefix) for actual holdings."
+  - title: "Adding ^^xsd:string to a plain-literal match"
+    problem: "String values are stored as PLAIN literals; adding the explicit xsd:string type joins to nothing on this Virtuoso endpoint, even though DATATYPE() reports xsd:string."
+    wrong_sparql: |
+      ?s <http://purl.jp/bio/10/mccv#MCCV_000034> "L1"^^<http://www.w3.org/2001/XMLSchema#string> .   # 0 rows
+    correct_sparql: |
+      ?s <http://purl.jp/bio/10/mccv#MCCV_000034> "L1" .
+      # or: ?s mccv:MCCV_000034 ?bsl . FILTER(STR(?bsl) = "L1")
+    explanation: "Match string literals in the plain form, or compare via STR(); the explicit ^^xsd:string form silently returns nothing here. VALUES blocks are the most common place this bites."
+  - title: "Skipping schema check before text search"
+    problem: "Text-searching a scientific name or category instead of using the structured field."
+    wrong_sparql: |
+      ?name bif:contains "'archaea'"
+    correct_sparql: |
+      # organism category is a structured enum IRI:
+      ?strain <http://purl.jp/bio/10/mccv#MCCV_000038> <http://purl.jp/bio/10/mccv#MCCV_000041> .  # archaea
+    explanation: "Organism category, taxon, biosafety and habitat are all structured; read shape_expressions before reaching for bif:contains."
+  - title: "Reading temperature directly off the strain"
+    problem: "Growth temperature is on a blank node, not a direct property of the strain."
+    wrong_sparql: |
+      ?strain <http://purl.jp/bio/10/mpo/MPO_00102> ?tempC .      # 0 rows
+    correct_sparql: |
+      ?strain <http://semanticscience.org/resource/SIO_000216> ?m .
+      ?m a <http://purl.jp/bio/10/mpo/MPO_00102> ;
+         <http://semanticscience.org/resource/SIO_000300> ?tempC .
+    explanation: "Walk sio:SIO_000216 to the MPO measurement node, then read sio:SIO_000300 (value) and sio:SIO_000221 (unit)."
+
+common_errors:
+  - error: "Empty results for a valid-looking query"
+    causes:
+      - "GRAPH clause omitted — query hits the wrong/empty default graph on the shared endpoint."
+      - "Added ^^xsd:string to a string match (values are stored plain; the typed form returns 0)."
+      - "Filtered on mccv:MCCV_000001 or read temperature/medium directly off the strain."
+      - "INSDC IRI built with a slash instead of the colon form (identifiers.org/insdc:<acc>)."
+    solutions:
+      - "Add GRAPH <http://purl.jp/bio/103/nite/culture/> to every block."
+      - "Match strings with the plain literal or STR()-comparison — not ^^xsd:string."
+      - "Anchor on brso:BiologicalResource; walk blank nodes for temperature/medium/source."
+      - "Copy IRI forms verbatim from cross_references."
+  - error: "Strain count / statistics look inflated"
+    causes:
+      - "Counting mccv:MCCV_000001 (includes equivalent-strain nodes) instead of brso:BiologicalResource."
+      - "Not using COUNT(DISTINCT) over multi-valued predicates (equivalents, references, temperature)."
+    solutions:
+      - "Count brso:BiologicalResource; use COUNT(DISTINCT ?strain)."
+  - error: "Habitat/geography query returns the wrong node or no label"
+    causes:
+      - "mccv:MCCV_000072 returns both source and geography nodes; sio:SIO_000008 is MEO on one, GAZ on the other."
+      - "Looked for MEO labels in the NBRC graph (they are in the microbedbjp graph)."
+    solutions:
+      - "Filter the child node by rdf:type (mccv:MCCV_000007 source vs mccv:MCCV_000008 geography)."
+      - "Resolve MEO labels in GRAPH <http://rdfportal.org/dataset/microbedbjp>."

--- a/togo_mcp/data/resources/endpoints.csv
+++ b/togo_mcp/data/resources/endpoints.csv
@@ -29,3 +29,4 @@ brenda,https://rdfportal.org/primary/sparql,primary,sparql
 hgnc,https://rdfportal.org/primary/sparql,primary,sparql
 jpostdb,https://rdfportal.org/primary/sparql,primary,sparql
 massbank,https://rdfportal.org/primary/sparql,primary,sparql
+nbrc,https://rdfportal.org/primary/sparql,primary,sparql


### PR DESCRIPTION
Adds four benchmark questions and registers the NBRC database used by Q069.

## Contents (3 logical pieces on top of `main`)
1. **Questions 066–068** (`31050a6`) — factoid (UniProt + jPOSTdb), choice (UniProt + BRENDA), list (ChEBI + MassBank).
2. **NBRC MIE registration** (`77250b6`) — `togo_mcp/data/mie/nbrc.yaml` + one `endpoints.csv` row. Cherry-picked so the validator (which derives its accepted-DB set from `endpoints.csv`) accepts `nbrc`, and so the branch isn't a dangling reference.
3. **Question 069** (`7fde5f0`) — this session's work.

## Q069 — yes_no · `nbrc` + `taxonomy` · KW-0484 Methanogenesis
> Among the archaeal type strains in the NITE Biological Resource Center culture catalogue, is the class represented by the greatest number of distinct type strains a methanogenic lineage?

**Answer: yes.** Methanomicrobia (methanogenic) leads with 45 distinct type strains, narrowly ahead of non-methanogenic Halobacteria (42). Cross-graph join on the primary endpoint: NBRC strain → species taxon (`mccv:MCCV_000065`) → `rdfs:subClassOf*` → `tax:Class` ancestor.

- **Arithmetic-verified:** per-class counts 45+42+20+19+3+3+2+2+1+1+1 = 139 = independent `COUNT(DISTINCT)` of classifiable strains (of 142 archaeal type strains; 3 lack a taxon link). No gap, no overlap.
- **Necessity gates pass:** PubMed test 0/0/0 across three searches; the 3-strain margin makes the answer genuinely data-dependent, not recallable.
- First benchmark use of the `nbrc` database; a query shape (aggregate-by-`tax:Class`-ancestor) not used elsewhere.

## Tracker
total 68→69; yes_no 13→14; taxonomy 7→8; new `nbrc` block (1); two_plus 69/69 = 100%, three_plus 23/69 = 33.3%; KW-0484 appended. Full `verify_questions.py`: **0 errors**, no signature collisions.

## ⚠️ Merge sequencing note
The NBRC MIE (piece 2) also lives on the separate `mie/nbrc` branch (commit `83f2592`, same file content, different hash). If `mie/nbrc` is merged to `main` first, git will reconcile the identical additions, but reviewers should be aware the two PRs overlap on `nbrc.yaml` + the `endpoints.csv` row and sequence accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)