### PR TITLE
docs(intro): add NBRC database card to landing page

### DIFF
--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1074,6 +1074,10 @@
         <div class="db-card-desc">Culture media database from DSMZ with 3,289 standardized recipes for bacteria, archaea, fungi, and microalgae, including ingredients and growth conditions.</div>
       </div>
       <div class="db-card">
+        <div class="db-card-name">NBRC</div>
+        <div class="db-card-desc">Culture catalogue of Japan's NITE Biological Resource Center: 23,987 preserved microbial strains (bacteria, archaea, fungi, yeasts, algae, phages) with cultivation conditions, isolation source and geographic origin, biosafety level, and links to NCBI Taxonomy, INSDC genomes, and PubMed.</div>
+      </div>
+      <div class="db-card">
         <div class="db-card-name">NANDO</div>
         <div class="db-card-desc">Japanese intractable (rare) disease ontology with 2,777 disease classes, multilingual labels, and cross-references to international disease ontologies.</div>
       </div>


### PR DESCRIPTION
Adds the **NBRC** (NITE Biological Resource Center culture catalogue) card to the *Available Databases* section of the public landing page (`togomcp-intro.html`), reflecting the NBRC database onboarded in #105.

- Placed in the microbiology/culture cluster, after MediaDive (grouped by domain affinity, not appended).
- Description condensed from `togo_mcp/data/mie/nbrc.yaml`: 23,987 preserved microbial strains (bacteria, archaea, fungi, yeasts, algae, phages) with cultivation conditions, isolation source and geographic origin, biosafety level, and links to NCBI Taxonomy, INSDC genomes, and PubMed.
- Card count now **30**, matching the 30 non-`supercon` MIE files.
- HTML-only (routine catalog addition); hero endpoint, tools, preprint, and nav anchors untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)