### PR TITLE
mie: audit-driven revision of 5 MIE files (v2.1→v2.2)

### DIFF
--- a/togo_mcp/data/mie/clinvar.yaml
+++ b/togo_mcp/data/mie/clinvar.yaml
@@ -31,8 +31,9 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_revised: "2026-07-06"
     data_version: "Release 2025.01"
     update_frequency: "Monthly"
   access:
@@ -57,6 +58,14 @@ critical_warnings: |
   - DCT:SOURCE CASE INCONSISTENCY: Both "MeSH" and "MESH" exist as dct:source values; likewise
     "HP" and "Human Phenotype Ontology" coexist. Use VALUES ?source { "MeSH" "MESH" } to
     avoid silently missing half the MeSH cross-references.
+
+  - DUPLICATE DISEASE BLANK NODES INFLATE COUNTS (SILENT): med2rdf:disease produces MULTIPLE
+    blank nodes on the same variant that point to the SAME disease (same dct:identifier), because
+    multiple SCV submissions each assert the trait. DISTINCT on the blank node (?dis) is useless —
+    each bnode is already unique. Measured: BRCA1 (gene/672) Pathogenic variants = 3,989 distinct
+    variants but a naive variant→disease→MedGen join returns 14,769 rows (~3.7x inflation) for only
+    45 distinct MedGen CUIs. For "how many variants relate to disease X" use COUNT(DISTINCT ?variant),
+    or GROUP BY ?variant then de-dup on dct:identifier — never COUNT(*) or COUNT(?dis).
 
 shape_expressions: |
   PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
@@ -332,7 +341,9 @@ sparql_query_examples:
 
       # Graph navigation: variant → med2rdf:disease → dct:references → TypeXref → dct:source/identifier
       # WARNING: "MeSH"/"MESH" both exist — use VALUES for both if querying MeSH
-      SELECT ?label ?source ?identifier ?seeAlso
+      # SELECT DISTINCT is REQUIRED: med2rdf:disease has duplicate blank nodes pointing to the same
+      # disease (see critical_warnings); without DISTINCT the (variant,source,id) rows inflate ~3.7x.
+      SELECT DISTINCT ?label ?source ?identifier ?seeAlso
       FROM <http://rdfportal.org/dataset/clinvar>
       WHERE {
         VALUES ?gene_uri { <http://ncbi.nlm.nih.gov/gene/672> }
@@ -351,41 +362,38 @@ sparql_query_examples:
       }
       LIMIT 100
 
-  - title: Multi-Submitter Variants Updated in 2024 (Advanced Filters + OPTIONAL)
-    description: Find well-evidenced variants with multiple submitters and recent updates.
-    question: Which BRCA1 variants have 3+ submitters updated since 2024?
+  - title: Somatic Oncogenicity Classification for a Cancer Gene (KRAS, non-germline branch)
+    description: |
+      Demonstrates the oncogenicity_classification and somatic_clinical_impact branches (NOT the
+      germline branch most examples use). KRAS hotspot variants are classified Oncogenic/Likely
+      oncogenic with Tier somatic impact — germline-only queries silently miss all of these.
+    question: What is the oncogenicity classification of KRAS variants, and their somatic clinical impact tier?
     complexity: advanced
     sparql: |
       PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
       PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
       PREFIX sio: <http://semanticscience.org/resource/>
-      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-      SELECT ?variant ?label ?type ?num_submitters ?last_updated ?significance ?review_status
+      # Oncogenicity/somatic branches — parallel to cvo:germline_classification, NOT the same node.
+      SELECT ?label ?oncogenicity ?somatic_impact
       FROM <http://rdfportal.org/dataset/clinvar>
       WHERE {
-        VALUES ?gene_uri { <http://ncbi.nlm.nih.gov/gene/672> }
+        VALUES ?gene_uri { <http://ncbi.nlm.nih.gov/gene/3845> }  # KRAS
         ?gene_bn med2rdf:gene ?gene_uri .
         ?classrec sio:SIO_000628 ?gene_bn .
         ?variant a cvo:VariationArchiveType ;
                  rdfs:label ?label ;
-                 cvo:variation_type ?type ;
-                 cvo:record_status "current" ;
                  cvo:record_type "classified" ;
-                 cvo:number_of_submitters ?num_submitters ;
-                 cvo:date_last_updated ?last_updated ;
                  cvo:classified_record ?classrec .
-        FILTER(?num_submitters >= 3)
-        FILTER(?last_updated >= "2024-01-01"^^xsd:date)
+        ?classrec cvo:classifications ?classi .
+        ?classi cvo:oncogenicity_classification ?onc .
+        ?onc cvo:description ?oncogenicity .
         OPTIONAL {
-          ?classrec cvo:classifications ?classi .
-          ?classi cvo:germline_classification ?germ .
-          ?germ cvo:description ?significance ;
-                cvo:review_status ?review_status .
+          ?classi cvo:somatic_clinical_impact ?sci .
+          ?sci cvo:description ?somatic_impact .
         }
       }
-      ORDER BY DESC(?num_submitters)
-      LIMIT 100
+      LIMIT 50
 
   - title: Exploratory Variant Search by Gene Symbol in Label (Text Search)
     description: Exploratory search for variants mentioning a gene symbol when specific gene IRI is not yet known.
@@ -514,6 +522,53 @@ cross_database_queries:
         - Performance: ~2-3s (Tier 1)
         - Gene ID conversion: ClinVar integer → ncbigene string (BIND required)
         - MIE files checked: clinvar, ncbigene
+
+    - title: "Golden path: gene → pathogenic variant → disease → MeSH → literature co-mention"
+      description: |
+        The full 5-stage biological chain across the ncbi endpoint. STAGE 1-2 (discovery, run
+        separately — a 4-graph single join TIMES OUT): use example query "Disease Cross-Reference
+        Pattern for BRCA1" to get the MedGen CUIs of a gene's Pathogenic variants (BRCA1 → e.g.
+        C0677776 "Hereditary breast ovarian cancer syndrome"). STAGES 3-5 (the runnable join below):
+        MedGen CUI → MeSH IRI (mo:mgconso) → PubTator gene+disease co-mention → PubMed title.
+
+        NON-OBVIOUS BRIDGE (two IRI transforms, both mandatory):
+        - MedGen mgconso MeSH IRI uses http://id.nlm.nih.gov/mesh/ ; PubTator oa:hasBody uses
+          http://identifiers.org/mesh/ — REPLACE("id.nlm.nih.gov/mesh/","identifiers.org/mesh/").
+        - (ClinVar→MedGen in stage 1-2 uses the www→no-www swap documented elsewhere.)
+      databases_used: [clinvar, medgen, pubtator, pubmed]
+      complexity: advanced
+      sparql: |
+        PREFIX mo:      <http://med2rdf/ontology/medgen#>
+        PREFIX oa:      <http://www.w3.org/ns/oa#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX dct:     <http://purl.org/dc/terms/>
+        PREFIX bibo:    <http://purl.org/ontology/bibo/>
+        PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+
+        # Stages 3-5. ?cui (here C0677776) comes from the ClinVar stage-1-2 discovery query.
+        SELECT DISTINCT ?ptMesh ?pmid ?title
+        WHERE {
+          GRAPH <http://rdfportal.org/dataset/medgen> {
+            ?concept dct:identifier "C0677776" ; mo:mgconso ?mgbn .
+            ?mgbn rdfs:seeAlso ?meshIRI .
+            FILTER(STRSTARTS(STR(?meshIRI), "http://id.nlm.nih.gov/mesh/"))
+          }
+          BIND(IRI(REPLACE(STR(?meshIRI), "id.nlm.nih.gov/mesh/", "identifiers.org/mesh/")) AS ?ptMesh)
+          GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+            ?gAnn dcterms:subject "Gene" ; oa:hasBody <http://identifiers.org/ncbigene/672> ;
+                  oa:hasTarget ?article .
+            ?dAnn dcterms:subject "Disease" ; oa:hasBody ?ptMesh ; oa:hasTarget ?article .
+          }
+          GRAPH <http://rdfportal.org/dataset/pubmed> {
+            ?article bibo:pmid ?pmid ; dct:title ?title .
+          }
+        }
+        LIMIT 10
+      notes: |
+        - The single 4-graph join (adding ClinVar stage 1-2) TIMES OUT — run stages 1-2 separately.
+        - mgconso→MeSH bridge REQUIRES the id.nlm.nih.gov/mesh → identifiers.org/mesh transform.
+        - Verified: C0677776 → mesh/D061325 → 15 BRCA1 breast/ovarian-cancer articles.
+        - MIE files checked: clinvar, medgen, pubtator, pubmed
 
 cross_references:
   - pattern: med2rdf:disease → dct:references → TypeXref (dct:source + dct:identifier + rdfs:seeAlso)
@@ -732,6 +787,38 @@ anti_patterns:
         ?v cvo:classified_record ?classrec .
       }
     explanation: "Use search APIs to discover gene IRIs; use those IRIs to query the full dataset."
+
+  - title: "Duplicate Disease Blank Nodes Inflating Counts"
+    problem: "Counting variant–disease relations with COUNT(*) or COUNT(?dis). med2rdf:disease has multiple blank nodes per variant pointing to the SAME disease (one per SCV submission), so rows inflate ~3.7x. DISTINCT on the blank node does nothing (each bnode is unique)."
+    wrong_sparql: |
+      # WRONG: 14,769 rows for only 3,989 BRCA1 Pathogenic variants (45 distinct diseases)
+      PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX sio: <http://semanticscience.org/resource/>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      SELECT (COUNT(*) AS ?n)
+      FROM <http://rdfportal.org/dataset/clinvar>
+      WHERE {
+        ?gene_bn med2rdf:gene <http://ncbi.nlm.nih.gov/gene/672> .
+        ?classrec sio:SIO_000628 ?gene_bn .
+        ?variant cvo:classified_record ?classrec ; med2rdf:disease ?dis .
+        ?dis dct:references ?ref . ?ref dct:source "MedGen" ; dct:identifier ?cui .
+      }
+    correct_sparql: |
+      # CORRECT: COUNT(DISTINCT ?variant) → 3,989; COUNT(DISTINCT ?cui) → 45
+      PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX sio: <http://semanticscience.org/resource/>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      SELECT (COUNT(DISTINCT ?variant) AS ?variants) (COUNT(DISTINCT ?cui) AS ?diseases)
+      FROM <http://rdfportal.org/dataset/clinvar>
+      WHERE {
+        ?gene_bn med2rdf:gene <http://ncbi.nlm.nih.gov/gene/672> .
+        ?classrec sio:SIO_000628 ?gene_bn .
+        ?variant cvo:classified_record ?classrec ; med2rdf:disease ?dis .
+        ?dis dct:references ?ref . ?ref dct:source "MedGen" ; dct:identifier ?cui .
+      }
+    explanation: "med2rdf:disease blank nodes duplicate per submission. Always COUNT(DISTINCT ?variant) or de-dup on dct:identifier — never COUNT(*)/COUNT(?dis)."
 
 common_errors:
   - error: "Cross-database MedGen query returns empty results"

--- a/togo_mcp/data/mie/medgen.yaml
+++ b/togo_mcp/data/mie/medgen.yaml
@@ -33,8 +33,9 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_revised: "2026-07-06"
     data_version: "Current NCBI release"
     update_frequency: "Monthly"
   access:
@@ -45,10 +46,14 @@ critical_warnings: |
     (mo:manifestation_of, mo:disease_has_associated_gene, mo:isa, mo:inverse_isa, etc.),
     NOT only through MGREL entities. Use direct properties for most queries; use MGREL
     only when provenance (dct:source, mo:suppress, mo:aui1/2) is needed.
-  - GENE STUB IRIs: Objects of mo:disease_has_associated_gene are MedGen CUI IRIs
-    (e.g. http://www.ncbi.nlm.nih.gov/medgen/C1333922) that are NOT loaded as ConceptID
-    instances in this dataset. Joining ?gene rdfs:label always returns empty. Return the
-    gene IRI as-is or cross-reference to NCBI Gene via togoid conversion.
+  - GENE STUB IRIs — AND HOW TO ACTUALLY RESOLVE THEM (corrected): Objects of
+    mo:disease_has_associated_gene are MedGen CUI IRIs (e.g. .../medgen/C1333922) NOT loaded as
+    ConceptID instances; ?gene rdfs:label always returns empty. CRITICAL: these stub gene CUIs also
+    do NOT convert in TogoID — togoid_countId(medgen,ncbigene, "C1333922,...") returns
+    {source:0, target:0}. To get NCBI Gene IDs, pass the DISEASE concept CUI (not the stub gene CUI)
+    to togoid_convertId(ids=["C0023467"], route="medgen,ncbigene") → 17 genes for AML (KRAS 3845,
+    NPM1 4869, RUNX1T1 861, ...). The medgen↔ncbigene TogoID route is a disease-CUI→gene aggregation,
+    unrelated to the intermediate stub CUIs.
   - MGSAT PROPERTY NAMES: MGSAT blank nodes use rdf:value (attribute value) and
     rdfs:label (attribute name). NOT mo:atn / mo:atv / mo:cui / mo:atui (old schema).
     Common rdfs:label values: GENESYMBOL, NCBI_OMIM, NCBI_ALTERNATE_ID, NEOPLASTIC_STATUS,
@@ -265,7 +270,9 @@ sparql_query_examples:
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
       # mo:disease_has_associated_gene objects are stub IRIs (no rdfs:label in MedGen).
-      # Return gene_iri for cross-referencing with NCBI Gene via togoid.
+      # To get NCBI Gene IDs, do NOT convert these stub CUIs (they yield source=0 in TogoID).
+      # Instead pass the DISEASE CUI to TogoID:
+      #   togoid_convertId(ids=["C0023467"], route="medgen,ncbigene") -> 17 genes (KRAS 3845, NPM1 4869, ...)
       SELECT ?disease_label ?gene_iri
       FROM <http://rdfportal.org/dataset/medgen>
       WHERE {
@@ -433,6 +440,49 @@ cross_database_queries:
         - URI pattern: www.ncbi.nlm.nih.gov (MedGen) -> ncbi.nlm.nih.gov (ClinVar)
         - MIE files read: medgen, clinvar
 
+    - title: "Golden path: MedGen disease → MeSH → PubTator gene co-mention → PubMed"
+      description: |
+        MedGen is the bridge in the gene→variant→disease→literature chain: its mo:mgconso maps a
+        disease CUI to a MeSH descriptor, which PubTator's Disease annotations use. Takes a MedGen
+        CUI + a target gene, returns PubMed articles co-mentioning both.
+
+        CRITICAL two-namespace MeSH bridge: MedGen mgconso emits http://id.nlm.nih.gov/mesh/ but
+        PubTator oa:hasBody uses http://identifiers.org/mesh/ — transform with
+        REPLACE("id.nlm.nih.gov/mesh/","identifiers.org/mesh/") or the join silently returns 0.
+      databases_used: [medgen, pubtator, pubmed]
+      complexity: advanced
+      sparql: |
+        PREFIX mo:      <http://med2rdf/ontology/medgen#>
+        PREFIX oa:      <http://www.w3.org/ns/oa#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX dct:     <http://purl.org/dc/terms/>
+        PREFIX bibo:    <http://purl.org/ontology/bibo/>
+        PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT DISTINCT ?ptMesh ?pmid ?title
+        WHERE {
+          GRAPH <http://rdfportal.org/dataset/medgen> {
+            ?concept dct:identifier "C0677776" ; mo:mgconso ?mgbn .
+            ?mgbn rdfs:seeAlso ?meshIRI .
+            FILTER(STRSTARTS(STR(?meshIRI), "http://id.nlm.nih.gov/mesh/"))
+          }
+          BIND(IRI(REPLACE(STR(?meshIRI), "id.nlm.nih.gov/mesh/", "identifiers.org/mesh/")) AS ?ptMesh)
+          GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+            ?gAnn dcterms:subject "Gene" ; oa:hasBody <http://identifiers.org/ncbigene/672> ;
+                  oa:hasTarget ?article .
+            ?dAnn dcterms:subject "Disease" ; oa:hasBody ?ptMesh ; oa:hasTarget ?article .
+          }
+          GRAPH <http://rdfportal.org/dataset/pubmed> {
+            ?article bibo:pmid ?pmid ; dct:title ?title .
+          }
+        }
+        LIMIT 10
+      notes: |
+        - The disease CUI (C0677776) can come from a ClinVar variant (see clinvar MIE golden-path).
+        - mgconso→MeSH bridge REQUIRES the id.nlm.nih.gov/mesh → identifiers.org/mesh transform.
+        - Verified: C0677776 → mesh/D061325 → 15 BRCA1 breast/ovarian-cancer articles.
+        - MIE files checked: medgen, pubtator, pubmed
+
 cross_references:
   - pattern: mo:mgconso blank nodes -> rdfs:seeAlso
     description: |
@@ -469,7 +519,7 @@ architectural_notes:
     - "Comprehensive: use ConceptID direct relationship properties (mo:manifestation_of etc.) -- faster than MGREL"
     - "Provenance queries: use MGREL (mo:cui1/cui2/rela/dct:source) only when source attribution is needed"
     - "Attributes: access via mo:mgsat blank nodes; rdfs:label = attr name, rdf:value = attr value"
-    - "Gene labels: mo:disease_has_associated_gene objects are stub IRIs -- use togoid to convert CUI to NCBI Gene IDs for cross-referencing"
+    - "Gene labels: mo:disease_has_associated_gene objects are stub IRIs -- pass the DISEASE CUI (not the stub gene CUI) to togoid route medgen,ncbigene for gene IDs"
     - "Text search: bif:contains (Virtuoso) for unstructured rdfs:label when no semantic type IRI covers the topic"
     - "Priority: Specific concept IRIs > Typed direct predicates > MGREL traversal > bif:contains"
 
@@ -498,7 +548,8 @@ architectural_notes:
     - "www.orpha.net/ORDO/Orphanet_* (Orphanet), purl.bioontology.org/ontology/SNOMEDCT/* (SNOMED)"
     - "ClinVar linkage: disease -> dct:references -> blank node -> rdfs:seeAlso -> MedGen URI"
     - "URI conversion for ClinVar: REPLACE(STR(?mg), 'www.ncbi', 'ncbi')"
-    - "Gene name resolution: use togoid to convert MedGen CUI stub IRIs to NCBI Gene IDs"
+    - "Gene name resolution: pass the DISEASE concept CUI (NOT the stub gene CUI, which gives
+       TogoID source=0) to togoid_convertId(route='medgen,ncbigene'), then query ncbigene"
 
   data_quality:
     - "skos:definition coverage: ~33.6% (78,578 / 233,939 concepts)"
@@ -665,9 +716,12 @@ common_errors:
     causes:
       - "Gene concept objects are stub IRIs not loaded as ConceptID instances in MedGen"
       - "Attempting ?gene rdfs:label always returns empty for these stub IRIs"
+      - "Passing the stub gene CUI to TogoID — it is not in the medgen dataset (returns source=0)"
     solutions:
       - "Return gene IRIs directly without joining on rdfs:label"
-      - "For gene names, use togoid to convert MedGen CUI stub IRIs to NCBI Gene IDs, then query ncbigene"
+      - "For NCBI Gene IDs, pass the DISEASE concept CUI (not the stub gene CUI) to
+         togoid_convertId(route='medgen,ncbigene') — e.g. C0023467 → 17 AML genes. Verified: stub
+         CUIs give togoid_countId source=0/target=0; the disease CUI gives source=1/target=17."
 
   - error: "Cross-database query (MedGen/ClinVar) returns no results"
     causes:

--- a/togo_mcp/data/mie/ncbigene.yaml
+++ b/togo_mcp/data/mie/ncbigene.yaml
@@ -32,8 +32,9 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_revised: "2026-07-06"
     data_version: "Release 2026.04"
     update_frequency: "Regular updates"
   access:
@@ -57,6 +58,13 @@ critical_warnings: |
     GRAPH clauses; placing BIND inside a GRAPH clause silently returns 0 results.
   - GRAPH CLAUSE MANDATORY: Omitting FROM or GRAPH clause causes cross-graph interference.
     Always specify FROM <http://rdfportal.org/dataset/ncbigene> or an explicit GRAPH.
+  - SPECIES MIXING IN PUBTATOR CO-MENTION JOINS: PubTator Gene annotations
+    (oa:hasBody → identifiers.org/ncbigene/*) are NOT species-restricted, so a disease–gene
+    co-mention join that reaches ncbigene will interleave human and model-organism orthologs of the
+    same symbol unless you filter. Measured: Alzheimer (mesh/D000544) gene co-mention top-15 included
+    4 mouse genes (App 11820, Tnf 21926, Il1b 16176, Il6 16193) alongside their human orthologs. When
+    joining PubTator to ncbigene, add ?geneId ncbio:taxid <http://identifiers.org/taxonomy/9606> (or
+    the target taxon) to restrict species — the co-mention itself carries no taxon.
 
 shape_expressions: |
   PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
@@ -363,37 +371,40 @@ cross_database_queries:
 
     - title: Gene-Literature Co-occurrence via PubTator
       description: |
-        Links genes to annotated publications using structured gene mention predicates.
+        Counts PubMed articles that mention a gene, via PubTator Gene annotations.
 
-        Linking strategy:
-        - NCBI Gene: dct:identifier yields gene ID as plain string
-        - PubTator: pubtator:ncbiGeneIdentifier links article annotations to gene IDs
-        - Direct string match; no URI conversion or text search required for gene linking
+        Linking strategy (CORRECTED v2.2 — the prior schema pubtator:ncbiGeneIdentifier /
+        pubtator:hasAnnotation / graph "pubtator" returns 0 rows; it does not exist):
+        - PubTator Gene annotations live in GRAPH <http://rdfportal.org/dataset/pubtator_central>,
+          typed dcterms:subject "Gene", with oa:hasBody → identifiers.org/ncbigene/{id}.
+        - That oa:hasBody IRI IS the ncbigene subject IRI — DIRECT IRI join, no string/dct:identifier.
+        - oa:hasTarget → PubMed article IRI (http://rdf.ncbi.nlm.nih.gov/pubmed/{pmid}).
+        - PubTator Gene annotations are NOT species-restricted; the ncbio:taxid filter here keeps it
+          to the intended human gene (see critical_warnings on species mixing).
       databases_used: [ncbigene, pubtator]
       complexity: intermediate
       sparql: |
         PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
-        PREFIX dct: <http://purl.org/dc/terms/>
-        PREFIX pubtator: <http://pubannotation.org/ontology/pubannotation.owl#>
+        PREFIX ncbio: <https://dbcls.github.io/ncbigene-rdf/ontology.ttl#>
+        PREFIX oa:   <http://www.w3.org/ns/oa#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
 
-        SELECT ?gene_symbol ?gene_id ?article ?pub_id
+        SELECT ?gene_symbol (COUNT(DISTINCT ?article) AS ?n_articles)
         WHERE {
           GRAPH <http://rdfportal.org/dataset/ncbigene> {
-            VALUES ?ncbi_gene { <http://identifiers.org/ncbigene/7157> }  # TP53
-            ?ncbi_gene dct:identifier ?gene_id ;
-                       rdfs:label ?gene_symbol .
+            VALUES ?gene { <http://identifiers.org/ncbigene/7157> }  # TP53
+            ?gene a insdc:Gene ; rdfs:label ?gene_symbol ;
+                  ncbio:taxid <http://identifiers.org/taxonomy/9606> .
           }
-          GRAPH <http://rdfportal.org/dataset/pubtator> {
-            ?annotation pubtator:ncbiGeneIdentifier ?gene_id .
-            ?article pubtator:hasAnnotation ?annotation .
-            ?article dct:identifier ?pub_id .
+          GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+            ?ann dcterms:subject "Gene" ; oa:hasBody ?gene ; oa:hasTarget ?article .
           }
         }
-        LIMIT 30
+        GROUP BY ?gene_symbol
       notes: |
-        - Linking via: dct:identifier (plain string) → pubtator:ncbiGeneIdentifier
-        - No URI conversion needed — shared string identifier
-        - Performance: ~3-5s (Tier 2)
+        - Linking via: ncbigene subject IRI = PubTator oa:hasBody IRI (direct, no conversion)
+        - Verified: TP53 (ncbigene/7157) → 273,965 co-mentioning articles
+        - Graph is pubtator_central (NOT "pubtator"); entity type via dcterms:subject "Gene"
         - MIE files checked: ncbigene, pubtator
 
 cross_references:
@@ -484,7 +495,9 @@ architectural_notes:
   data_integration:
     - "identifiers.org IRIs enable seamless cross-database linking without text matching"
     - "ClinVar integration: dct:identifier (string) → CONCAT URI conversion → med2rdf:gene"
-    - "PubTator integration: dct:identifier (string) → pubtator:ncbiGeneIdentifier direct match"
+    - "PubTator integration: ncbigene subject IRI (identifiers.org/ncbigene/{id}) = PubTator
+       oa:hasBody IRI in graph pubtator_central (dcterms:subject 'Gene') — direct IRI join, and add
+       ncbio:taxid to avoid cross-species mixing (NOT pubtator:ncbiGeneIdentifier, which does not exist)"
     - "miRBase integration: insdc:dblink with identifiers.org/mirbase/ prefix for miRNA genes"
     - "Cross-DB BIND must be placed BETWEEN GRAPH clauses, never inside a GRAPH block"
     - "Check MIE files for BOTH databases before writing any cross-database query"

--- a/togo_mcp/data/mie/pubtator.yaml
+++ b/togo_mcp/data/mie/pubtator.yaml
@@ -6,15 +6,19 @@ schema_info:
     linked to PubMed articles using MeSH disease identifiers, NCBI Gene IDs, and dbSNP rsIDs.
     Each Disease/Gene annotation records mention frequency within articles; variant annotations
     come from ClinVar/dbSNP and use blank nodes without dcterms:subject.
+    SCOPE: only Disease and Gene (dcterms:subject) plus Variant (blank-node) annotations are
+    present. The Chemical, Species, and CellLine entity types annotated by the upstream
+    PubTator3 service are NOT included in this RDF conversion — do not expect them here.
+    Provenance (dcterms:source) is recorded for only ~1.6% of annotations; the tool/pipeline
+    version generating the remaining Disease/Gene annotations is not distinguishable from the
+    RDF alone.
   keywords:
     - annotation
     - entity
     - article
     - gene
     - disease
-    - chemical
     - mutation
-    - species
     - text mining
     - named entity recognition
     - bioconcept
@@ -31,8 +35,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_revised: "2026-07-06"
     data_version: "PubTator Central 2024"
     update_frequency: "Regularly updated"
   access:
@@ -48,13 +53,34 @@ critical_warnings: |
   - ENTITY TYPE COVERAGE: Only two dcterms:subject values exist: "Disease" (162M) and
     "Gene" (72.6M). Do NOT assume other entity types; using any other string returns 0 results.
   - ANNOTATION_COUNT MAXIMUMS DIFFER BY TYPE: Disease max=5, Gene max=9.
-    Using FILTER(?count > 5) on Disease silently returns zero rows — not a query error.
     Use FILTER(?count >= 4) for Disease; FILTER(?count > 5) for Gene.
+    A FILTER on annotation_count outside the valid range returns zero rows *only if the
+    query is otherwise scoped* (a specific IRI, or an inner LIMIT before the filter). An
+    UNSCOPED range filter over the full 238M-annotation graph does NOT return quickly —
+    it TIMES OUT rather than returning zero. Always scope before filtering annotation_count.
   - ALWAYS USE LIMIT: 238M total annotations. Any query without LIMIT risks timeout.
     COUNT(*) queries without a GRAPH clause time out consistently.
+  - VARIANT SOURCE VALUES MUST INCLUDE "PubTator3": filtering variant annotations by
+    dcterms:source with VALUES { "ClinVar" "dbSNP" "dbGAP" } silently DROPS THE MAJORITY.
+    "PubTator3" is the plurality source both per-variant (e.g. rs429358: PubTator3=2818 /
+    91.1%, dbSNP=227, ClinVar=48, dbGAP=1) and corpus-wide (PubTator3 2,230,751 vs.
+    ClinVar+dbSNP+dbGAP 1,566,329 combined — 58.7% vs 41.3%). Always use
+    VALUES { "ClinVar" "dbSNP" "dbGAP" "PubTator3" }.
   - BLANK NODES FOR VARIANT ANNOTATIONS: Variant annotations use blank node subjects
     (nodeID:// pattern). They cannot be retrieved by IRI; filter by dcterms:source value
-    ("ClinVar", "dbSNP", "dbGAP") or by body IRI prefix (identifiers.org/dbsnp/).
+    ("ClinVar", "dbSNP", "dbGAP", "PubTator3") or by body IRI prefix (identifiers.org/dbsnp/).
+  - MESH IRI IS NOT A DIRECT JOIN KEY: oa:hasBody on Disease annotations mints
+    http://identifiers.org/mesh/D###### — this is PubTator's OWN identifiers.org form and
+    does NOT resolve in TogoMCP's `mesh` database. `mesh` lives on a DIFFERENT endpoint
+    (primary, not ncbi) and uses base http://id.nlm.nih.gov/mesh/. To join, rewrite the IRI:
+    BIND(URI(REPLACE(STR(?meshBody), "identifiers.org/mesh/", "id.nlm.nih.gov/mesh/")) AS ?meshIRI)
+    and reach `mesh` via a cross-endpoint SERVICE (see cross_database_queries). `mesh` is
+    NOT co-located with pubtator.
+  - GENE ANNOTATIONS ARE NOT SPECIES-RESTRICTED: oa:hasBody points to NCBI Gene IDs for
+    human AND model-organism orthologs of the same symbol (e.g. human APP=351 and mouse
+    App=11820 both surface for Alzheimer's disease) with NO taxon field on the annotation
+    itself. To restrict to one species, join ncbigene:taxid in the `ncbigene` graph and
+    filter to http://identifiers.org/taxonomy/9606 (human) — see cross_database_queries.
 
 shape_expressions: |
   PREFIX rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -219,10 +245,18 @@ sparql_query_examples:
       ORDER BY DESC(?count)
       LIMIT 100
 
-  - title: Top genes co-mentioned with a specific disease (aggregation)
-    description: Uses specific MeSH IRI for Alzheimer Disease (D000544) and aggregates gene co-occurrences across the corpus.
+  - title: Top genes co-mentioned with a specific disease (pre-bounded aggregation)
+    description: |
+      Uses the specific MeSH IRI for Alzheimer Disease (D000544) and aggregates gene
+      co-occurrences. The article set is pre-bounded with an inner SELECT DISTINCT ... LIMIT
+      subquery BEFORE joining to Gene annotations — this is what makes the query tractable.
+      NOTE: the naive form (joining Gene and Disease annotations on ?article without the inner
+      LIMIT) is timeout-prone even scoped to one disease IRI once the disease's article count
+      exceeds ~10^4-10^5; the pre-bounding caps the join. Results interleave human and
+      non-human orthologs (e.g. human APP=351 AND mouse App=11820) — add a species filter
+      (see cross_database_queries) to restrict to one taxon.
     question: What genes are most commonly mentioned alongside Alzheimer Disease?
-    complexity: intermediate
+    complexity: advanced
     sparql: |
       PREFIX oa:      <http://www.w3.org/ns/oa#>
       PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -230,21 +264,30 @@ sparql_query_examples:
       SELECT ?geneId (COUNT(DISTINCT ?article) AS ?cooccurrence)
       FROM <http://rdfportal.org/dataset/pubtator_central>
       WHERE {
+        {
+          SELECT DISTINCT ?article WHERE {
+            ?diseaseAnn dcterms:subject "Disease" ;
+                        oa:hasBody <http://identifiers.org/mesh/D000544> ;
+                        oa:hasTarget ?article .
+          }
+          LIMIT 5000
+        }
         ?geneAnn dcterms:subject "Gene" ;
                  oa:hasBody ?geneId ;
                  oa:hasTarget ?article .
-        ?diseaseAnn dcterms:subject "Disease" ;
-                    oa:hasBody <http://identifiers.org/mesh/D000544> ;
-                    oa:hasTarget ?article .
       }
       GROUP BY ?geneId
       ORDER BY DESC(?cooccurrence)
       LIMIT 50
 
-  - title: Variant annotations from ClinVar/dbSNP linked to a PubMed article
-    description: Retrieves blank-node variant annotations using dcterms:source VALUES — the only reliable predicate for this entity type (no dcterms:subject exists).
-    question: Which dbSNP variants are annotated in a given paper via ClinVar or dbSNP?
-    complexity: advanced
+  - title: Variant annotations from ClinVar/dbSNP/PubTator3 linked to a PubMed article
+    description: |
+      Retrieves blank-node variant annotations using dcterms:source VALUES — the only reliable
+      predicate for this entity type (no dcterms:subject exists). The VALUES list MUST include
+      "PubTator3": it is the majority source (58.7% corpus-wide), so omitting it silently drops
+      most variant annotations.
+    question: Which dbSNP variants are annotated in a given paper via ClinVar, dbSNP, or PubTator3?
+    complexity: intermediate
     sparql: |
       PREFIX oa:      <http://www.w3.org/ns/oa#>
       PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -256,7 +299,7 @@ sparql_query_examples:
              dcterms:source ?source ;
              oa:hasBody ?variantId ;
              oa:hasTarget <http://rdf.ncbi.nlm.nih.gov/pubmed/26467025> .
-        VALUES ?source { "ClinVar" "dbSNP" "dbGAP" }
+        VALUES ?source { "ClinVar" "dbSNP" "dbGAP" "PubTator3" }
       }
       LIMIT 100
 
@@ -299,7 +342,101 @@ cross_database_queries:
     - pubmed
     - ncbigene
     - medgen
+  not_co_located:
+    - "mesh — pubtator's oa:hasBody mints http://identifiers.org/mesh/ IRIs, but the `mesh`
+       database is on a DIFFERENT endpoint (primary, not ncbi) with base
+       http://id.nlm.nih.gov/mesh/. Joining requires an IRI rewrite AND a cross-endpoint
+       SERVICE call (see the MeSH-label example below) — it is not a same-endpoint GRAPH join."
   examples:
+    - title: Resolve PubTator disease MeSH IRIs to labels (cross-endpoint SERVICE)
+      description: |
+        pubtator (ncbi endpoint) mints http://identifiers.org/mesh/D###### on oa:hasBody, which
+        does NOT resolve in the `mesh` database (primary endpoint, base http://id.nlm.nih.gov/mesh/).
+        Rewrite the IRI with REPLACE, then reach `mesh` via SERVICE.
+
+        CRITICAL query-construction detail: the local pubtator triple pattern must be MATERIALIZED
+        in an inner subquery before the SERVICE call. A naive `?ann oa:hasBody ?meshBody . BIND(...)
+        SERVICE {...}` silently returns ZERO rows on Virtuoso because the SERVICE is dispatched
+        before ?meshBody is ground. The inner SELECT forces materialization first.
+      databases_used:
+        - pubtator
+        - mesh
+      complexity: advanced
+      sparql: |
+        PREFIX oa:      <http://www.w3.org/ns/oa#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?meshBody ?meshIRI ?label WHERE {
+          {
+            SELECT DISTINCT ?meshBody WHERE {
+              GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+                ?ann dcterms:subject "Disease" ;
+                     oa:hasBody ?meshBody ;
+                     oa:hasTarget <http://rdf.ncbi.nlm.nih.gov/pubmed/18935173> .
+              }
+            }
+          }
+          BIND(URI(REPLACE(STR(?meshBody), "identifiers.org/mesh/", "id.nlm.nih.gov/mesh/")) AS ?meshIRI)
+          SERVICE <https://rdfportal.org/primary/sparql> {
+            ?meshIRI rdfs:label ?label .
+          }
+        }
+        LIMIT 20
+      notes: |
+        - Linking via: oa:hasBody (identifiers.org/mesh/) → REPLACE → id.nlm.nih.gov/mesh/ (mesh base)
+        - Run from the ncbi endpoint (database: pubtator); SERVICE reaches primary for mesh labels.
+        - mesh rdfs:label returns both the descriptor name and the D-number string per subject.
+        - Inner subquery materialization is MANDATORY — without it Virtuoso returns 0 rows.
+        - MIE files checked: pubtator, mesh
+
+    - title: Human-only genes co-mentioned with a disease (species filter via ncbigene taxid)
+      description: |
+        Same disease-gene co-occurrence as the aggregation example, but restricted to Homo sapiens
+        by joining ncbigene:taxid in the `ncbigene` graph (co-located on the ncbi endpoint). Without
+        this filter, human and model-organism orthologs of the same symbol interleave (human APP=351
+        AND mouse App=11820 both appear for Alzheimer's). Article set is pre-bounded for tractability.
+      databases_used:
+        - pubtator
+        - ncbigene
+      complexity: advanced
+      sparql: |
+        PREFIX oa:       <http://www.w3.org/ns/oa#>
+        PREFIX dcterms:  <http://purl.org/dc/terms/>
+        PREFIX ncbigene: <https://dbcls.github.io/ncbigene-rdf/ontology.ttl#>
+        PREFIX rdfs:     <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?geneId ?symbol (COUNT(DISTINCT ?article) AS ?cooccurrence)
+        WHERE {
+          {
+            SELECT DISTINCT ?article WHERE {
+              GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+                ?diseaseAnn dcterms:subject "Disease" ;
+                            oa:hasBody <http://identifiers.org/mesh/D000544> ;
+                            oa:hasTarget ?article .
+              }
+            }
+            LIMIT 5000
+          }
+          GRAPH <http://rdfportal.org/dataset/pubtator_central> {
+            ?geneAnn dcterms:subject "Gene" ;
+                     oa:hasBody ?geneId ;
+                     oa:hasTarget ?article .
+          }
+          GRAPH <http://rdfportal.org/dataset/ncbigene> {
+            ?geneId ncbigene:taxid <http://identifiers.org/taxonomy/9606> ;
+                    rdfs:label ?symbol .
+          }
+        }
+        GROUP BY ?geneId ?symbol
+        ORDER BY DESC(?cooccurrence)
+        LIMIT 15
+      notes: |
+        - Linking via: oa:hasBody → identifiers.org/ncbigene/ IRI (direct subject match in ncbigene)
+        - Species filter: ncbigene:taxid = taxonomy/9606; swap for another taxon IRI as needed.
+        - Same-endpoint join (ncbi) — no SERVICE required; use endpoint_name: ncbi for cross-graph.
+        - MIE files checked: pubtator, ncbigene
+
     - title: PubTator gene annotations enriched with PubMed titles
       description: |
         Integrates PubTator Gene annotations with PubMed article metadata using pre-filtering.
@@ -390,9 +527,14 @@ cross_references:
       Variant annotations (blank nodes) link to dbSNP rsIDs.
     databases:
       diseases:
-        - "MeSH: 100% coverage via http://identifiers.org/mesh/D######"
+        - "MeSH: 100% coverage via http://identifiers.org/mesh/D###### — but this is PubTator's
+           OWN identifiers.org minting and is NOT the join key the `mesh` database accepts. `mesh`
+           uses base http://id.nlm.nih.gov/mesh/ on a different endpoint (primary). To join, rewrite:
+           BIND(URI(REPLACE(STR(?meshBody), \"identifiers.org/mesh/\", \"id.nlm.nih.gov/mesh/\")) AS ?meshIRI)
+           and use a cross-endpoint SERVICE (see cross_database_queries)."
       genes:
-        - "NCBI Gene: 100% coverage via http://identifiers.org/ncbigene/######"
+        - "NCBI Gene: 100% coverage via http://identifiers.org/ncbigene/###### — direct subject
+           match in the co-located `ncbigene` graph (same ncbi endpoint), no rewrite needed."
       variants:
         - "dbSNP: 100% of variant annotations via http://identifiers.org/dbsnp/rs######"
 
@@ -429,13 +571,24 @@ architectural_notes:
     - "Cross-database queries require explicit GRAPH clauses for each dataset"
     - "Pre-filter with bif:contains INSIDE the PubMed GRAPH block before joining PubTator (99.9997% reduction)"
     - "Aggregations: pre-filter to a specific disease/gene IRI before GROUP BY to avoid timeout"
+    - "Disease/gene co-occurrence aggregations without an inner LIMIT on the pre-filtered article
+       set are timeout-prone EVEN when scoped to a single disease IRI, once that disease's article
+       count exceeds ~10^4-10^5 (Alzheimer's D000544 fails ~2/3 of runs naive; add an inner
+       SELECT DISTINCT ?article ... LIMIT N subquery before joining Gene annotations)"
     - "CRITICAL: split property paths before bif:contains on Virtuoso (do not chain /)"
 
   data_integration:
-    - "identifiers.org/mesh/ IRIs align with MeSH RDF vocabulary"
-    - "identifiers.org/ncbigene/ IRIs are direct subject matches in the NCBI Gene RDF graph"
+    - "identifiers.org/mesh/ IRIs are PubTator's own minting and do NOT resolve in the `mesh`
+       database (base http://id.nlm.nih.gov/mesh/, on the primary endpoint); rewrite via REPLACE
+       + cross-endpoint SERVICE to join — mesh is NOT co-located with pubtator"
+    - "identifiers.org/ncbigene/ IRIs are direct subject matches in the NCBI Gene RDF graph;
+       ncbigene:taxid there is the only way to resolve species for a PubTator gene annotation"
     - "identifiers.org/dbsnp/ IRIs align with dbSNP variant identifiers"
     - "Shares the NCBI endpoint with PubMed, NCBI Gene, ClinVar, and MedGen"
+    - "GOLDEN PATH (gene→variant→disease→literature): a ClinVar/MedGen disease reaches PubTator
+       Disease annotations via MeSH, but MedGen mgconso emits id.nlm.nih.gov/mesh/ while PubTator
+       oa:hasBody uses identifiers.org/mesh/ — transform with
+       REPLACE('id.nlm.nih.gov/mesh/','identifiers.org/mesh/'). Full verified example: clinvar/medgen MIEs."
 
   data_quality:
     - "Only 1.59% of annotations (3,797,080) carry a dcterms:source provenance field"
@@ -511,6 +664,65 @@ anti_patterns:
         FILTER(?count >= 4)
       } LIMIT 50
     explanation: "Disease max=5, Gene max=9. Check critical_warnings before writing annotation_count filters."
+
+  - title: "Unscoped annotation_count Range Filter Times Out"
+    problem: |
+      A FILTER on annotation_count without a narrowing IRI or an inner LIMIT does NOT return quickly
+      with zero rows — it TIMES OUT scanning the full 238M-annotation graph. This is a distinct failure
+      mode from the wrong-threshold case above: there the (scoped) query returns 0 fast; here the
+      (unscoped) query hangs.
+    wrong_sparql: |
+      # Times out: range filter over the entire Disease population, nothing else to bound it.
+      PREFIX pubtator: <http://purl.jp/bio/10/pubtator-central/ontology#>
+      PREFIX dcterms:  <http://purl.org/dc/terms/>
+      SELECT ?ann ?count
+      FROM <http://rdfportal.org/dataset/pubtator_central>
+      WHERE {
+        ?ann dcterms:subject "Disease" ;
+             pubtator:annotation_count ?count .
+        FILTER(?count > 5)
+      } LIMIT 5
+    correct_sparql: |
+      # Scope first (specific disease IRI), THEN filter — returns immediately.
+      PREFIX pubtator: <http://purl.jp/bio/10/pubtator-central/ontology#>
+      PREFIX oa:       <http://www.w3.org/ns/oa#>
+      PREFIX dcterms:  <http://purl.org/dc/terms/>
+      SELECT ?article ?count
+      FROM <http://rdfportal.org/dataset/pubtator_central>
+      WHERE {
+        ?ann dcterms:subject "Disease" ;
+             oa:hasBody <http://identifiers.org/mesh/D003920> ;
+             oa:hasTarget ?article ;
+             pubtator:annotation_count ?count .
+        FILTER(?count >= 4)
+      } LIMIT 50
+    explanation: "annotation_count filters must be applied AFTER scoping to a specific IRI (or an inner LIMIT). An unscoped range filter over 238M annotations times out rather than returning fast."
+
+  - title: "Incomplete Variant Source VALUES List Drops the Majority"
+    problem: "Filtering variant annotations with VALUES {\"ClinVar\" \"dbSNP\" \"dbGAP\"} silently omits \"PubTator3\", the plurality source (58.7% corpus-wide, 91.1% for some variants). The query runs and returns rows — just a small minority of the real matches."
+    wrong_sparql: |
+      # Silently drops all PubTator3-sourced variant annotations (the majority).
+      PREFIX oa:      <http://www.w3.org/ns/oa#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      SELECT ?variantId ?source
+      FROM <http://rdfportal.org/dataset/pubtator_central>
+      WHERE {
+        ?ann oa:hasBody ?variantId ; dcterms:source ?source ;
+             oa:hasTarget <http://rdf.ncbi.nlm.nih.gov/pubmed/26467025> .
+        VALUES ?source { "ClinVar" "dbSNP" "dbGAP" }
+      } LIMIT 100
+    correct_sparql: |
+      # Include "PubTator3" — the plurality source.
+      PREFIX oa:      <http://www.w3.org/ns/oa#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      SELECT ?variantId ?source
+      FROM <http://rdfportal.org/dataset/pubtator_central>
+      WHERE {
+        ?ann oa:hasBody ?variantId ; dcterms:source ?source ;
+             oa:hasTarget <http://rdf.ncbi.nlm.nih.gov/pubmed/26467025> .
+        VALUES ?source { "ClinVar" "dbSNP" "dbGAP" "PubTator3" }
+      } LIMIT 100
+    explanation: "\"PubTator3\" is the majority dcterms:source for variant annotations. Any VALUES list that omits it silently loses most of the data — see critical_warnings."
 
   - title: "Text Search When Structured Predicate Exists"
     problem: "Using FILTER(CONTAINS()) on dcterms:subject when it is a typed literal with known exact values."

--- a/togo_mcp/data/mie/uniprot.yaml
+++ b/togo_mcp/data/mie/uniprot.yaml
@@ -44,11 +44,23 @@ schema_info:
     - http://sparql.uniprot.org/journal
     - http://sparql.uniprot.org/obsolete
     - http://rdfportal.org/dataset/rhea
+  # CO-HOSTED datasets on the SAME sib endpoint (NOT UniProt-owned). These are queryable in the
+  # default-graph union, which is the source of the §1 COUNT-inflation trap AND the new direct
+  # cross-database joins (see cross_database_queries). Always scope with GRAPH/FROM.
+  co_hosted_graphs:
+    - "http://rdfportal.org/dataset/oma  — OMA orthology (584M triples). Re-types 337,813 reviewed
+       UniProt accessions as up:Protein with the SAME IRI -> COUNT(*) inflation trap; use COUNT(DISTINCT)."
+    - "http://id.nlm.nih.gov/mesh  — MeSH (18.3M triples); join target for up:Disease rdfs:seeAlso."
+    - "http://bgee.org  — Bgee expression (6.76B triples); join via the purl.uniprot.org/bgee/ENSG...
+       rdfs:seeAlso xref + IRI transform (see cross_database_queries)."
+    - "http://purl.jp/bio/11/goa  — EMPTY STUB (151 triples), NOT real GOA data. Do not build on it."
+    - "~30 shared ontology graphs (rdfportal.org/ontology/{cl,mondo,hp,uberon,efo,pro,so,go,...})."
   kw_search_tools:
     - search_uniprot_entity
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2026-04-29"
+    mie_revised: "2026-07-06"
     data_version: "Release 2024_06"
     update_frequency: "Monthly"
   access:
@@ -57,6 +69,18 @@ schema_info:
 # Critical warnings: schema pathologies, IRI traps, mandatory performance filters.
 # Read before writing any query — each item here causes silent failures or timeouts.
 critical_warnings: |
+  - USE COUNT(DISTINCT) FOR PROTEIN COUNTS — NOT FROM-SCOPING (silent inflation, wrong positive
+    number): `a up:Protein` is asserted for reviewed proteins across THREE graphs — uniprot (574,627),
+    the co-hosted OMA graph (337,813 re-typings of the SAME purl.uniprot.org/uniprot/ IRIs), and
+    obsolete (14,432). So `SELECT (COUNT(*) ...) { ?p a up:Protein ; up:reviewed 1 }` over the default
+    union returns 926,872 — inflated. The CORRECT fix is COUNT(DISTINCT ?p) → 589,059. Do NOT "fix" it
+    with FROM <http://sparql.uniprot.org/uniprot>: that returns 574,627, silently DROPPING the 14,432
+    reviewed entries whose up:reviewed lives in the `obsolete` graph (589,059 = 574,627 current +
+    14,432 obsolete). FROM <uniprot> is correct only when you specifically want CURRENT (non-obsolete)
+    entries. Nothing signals either error — this is worse than an empty result.
+  - EMPTY STUB GRAPH: http://purl.jp/bio/11/goa contains only 151 triples (a void/placeholder), NOT
+    real GOA annotation data despite its name. Do not query it expecting GO annotations — GO terms
+    live on up:classifiedWith (OBO IRIs) in the uniprot graph.
   - MANDATORY FILTER: Always add up:reviewed 1 — omitting it queries ~244M entries
     instead of 589K and causes all COUNT queries to time out.
   - GO NAMESPACE TRAP: up:classifiedWith uses OBO IRIs
@@ -78,6 +102,7 @@ critical_warnings: |
 
 shape_expressions: |
   PREFIX up: <http://purl.uniprot.org/core/>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   PREFIX dcterms: <http://purl.org/dc/terms/>
   PREFIX faldo: <http://biohackathon.org/resource/faldo#>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -96,7 +121,8 @@ shape_expressions: |
     up:sequence @<IsoformShape> * ;         # Canonical + alternate isoforms
     up:recommendedName @<NameShape> ? ;     # Expert-curated name (Swiss-Prot)
     up:submittedName @<NameShape> * ;       # Auto-submitted name (TrEMBL)
-    up:annotation @<AnnotationShape> * ;    # ~50 annotation subtypes (see below)
+    up:annotation @<AnnotationShape> * ;    # ~50 subtypes; see specialized NaturalVariantShape,
+                                            # DiseaseAnnotationShape below for structured predicates
     up:classifiedWith IRI * ;               # GO IRIs (OBO ns) AND UniProt keyword IRIs
     up:enzyme IRI * ;                       # EC number IRIs: http://purl.uniprot.org/enzyme/X.X.X.X
     rdfs:seeAlso IRI *                      # Cross-refs to 200+ databases (PDB, HGNC, etc.)
@@ -116,11 +142,22 @@ shape_expressions: |
     skos:altLabel xsd:string *    # Synonyms (e.g. "P53")
   }
 
-  # Isoforms — IRI pattern: http://purl.uniprot.org/isoforms/P04637-N
-  # up:Simple_Sequence = canonical; up:Modified_Sequence = alternate isoforms
+  # Isoforms / sequence records — IRI pattern: http://purl.uniprot.org/isoforms/P04637-N
+  # NOTE: isoform IRIs do NOT always share the parent accession prefix — a readthrough/fusion
+  # isoform can carry a different accession (e.g. P01308 up:sequence -> isoforms/F8WCM5-1).
   <IsoformShape> {
-    a [ up:Simple_Sequence up:Modified_Sequence ] ;
-    skos:altLabel xsd:string *    # Isoform name(s)
+    a [ up:Simple_Sequence ] ;      # canonical sequence (574,627 on reviewed proteins)
+    a [ up:Modified_Sequence ] ? ;  # alternate isoform (41,333) — Simple XOR Modified per node
+    a [ up:External_Sequence ] ? ;  # ~0.37% (2,121) — readthrough/external; can CO-occur with Simple
+    a [ up:Unknown_Sequence ] ? ;   # ~0.05% (275)
+    rdf:value xsd:string ;          # THE AMINO-ACID SEQUENCE STRING — 100% of canonical sequences
+    up:mass xsd:integer ;           # molecular mass in Daltons (INTEGER)
+    up:md5Checksum xsd:string ;     # MD5 of the sequence (change detection)
+    up:modified xsd:date ;          # sequence last-modified date (xsd:date, e.g. 1986-07-21)
+    up:version xsd:integer ;        # sequence version (INTEGER)
+    up:precursor xsd:integer ? ;    # 1 = precursor/proprotein flag (INTEGER flag, like up:reviewed)
+    skos:prefLabel xsd:string ? ;   # isoform number as a string (e.g. "1")
+    skos:altLabel xsd:string *      # isoform name(s)
   }
 
   # Base annotation shape — ~50 typed subtypes, all inheriting from up:Annotation
@@ -131,6 +168,39 @@ shape_expressions: |
     a [ up:Annotation ] ;          # Typed to a specific subtype
     rdfs:comment xsd:string ? ;    # Free-text description of the annotation
     up:range @<PositionRangeShape> ?  # FALDO position (domains, PTMs, variants, SSE)
+  }
+
+  # Natural variant — a specialization of AnnotationShape with STRUCTURED predicates.
+  # 106,543 on reviewed proteins. Do NOT rely on rdfs:comment alone for variants.
+  <NaturalVariantShape> {
+    a [ up:Natural_Variant_Annotation ] ;
+    up:substitution xsd:string ;         # RESULTING residue, single uppercase letter (xsd:string;
+                                         # plain match "T" works — SPARQL 1.1 string = xsd:string)
+    up:range @<PositionRangeShape> ? ;   # FALDO position of the variant
+    rdfs:comment xsd:string ? ;          # free-text (e.g. "in LFS; ...")
+    rdfs:seeAlso IRI ? ;                 # dbSNP rsID (purl.uniprot.org/dbsnp/rs...) — ~65.9% (70,237)
+    skos:related @<DiseaseShape> ?       # linked disease resource — ~39.4% (41,966); NOT universal
+  }
+
+  # Disease annotation — a specialization carrying a STRUCTURED disease-resource link (not only comment)
+  # 8,698 Disease_Annotation nodes on reviewed proteins; 7,250 (83.3%) carry up:disease.
+  <DiseaseAnnotationShape> {
+    a [ up:Disease_Annotation ] ;
+    rdfs:comment xsd:string ? ;          # free-text disease involvement note
+    up:disease @<DiseaseShape> ?         # 83.3% — structured link to a up:Disease resource
+  }
+
+  # up:Disease resource (graph: http://sparql.uniprot.org/diseases). Reached via up:disease
+  # (annotation-level) or skos:related (variant-level). Its rdfs:seeAlso is the cross-endpoint
+  # bridge to MeSH / MedGen / OMIM (all co-hosted or IRI-resolvable — see cross_database_queries).
+  <DiseaseShape> {
+    a [ up:Disease ] ;
+    skos:prefLabel xsd:string ;          # e.g. "Li-Fraumeni syndrome"
+    skos:altLabel xsd:string * ;         # synonyms
+    up:mnemonic xsd:string ? ;           # e.g. "LFS"
+    rdfs:comment xsd:string ? ;          # disease description
+    rdfs:seeAlso IRI *                   # -> id.nlm.nih.gov/mesh/D..., purl.uniprot.org/medgen/C...,
+                                         #    purl.uniprot.org/mim/... (filter by prefix to pick one)
   }
 
   # FALDO position annotation — begin and end positions within sequence
@@ -194,26 +264,27 @@ sample_rdf_entries:
           ] .
 
 sparql_query_examples:
-  - title: Reviewed Human Proteins (Direct Organism IRI Lookup)
-    description: Direct lookup of reviewed human proteins using specific taxonomy IRI and recommended name.
-      Note — UniProt proteins do not have rdfs:label; use up:recommendedName/up:fullName for names.
-    question: What reviewed Swiss-Prot human proteins exist?
+  - title: Get the amino-acid sequence of a protein (rdf:value on the canonical Simple_Sequence)
+    description: |
+      Retrieves the raw amino-acid sequence string via up:sequence -> up:Simple_Sequence -> rdf:value,
+      plus molecular mass. This is THE most basic UniProt data need and had no example before v2.2.
+      Canonical sequence = the up:Simple_Sequence node; rdf:value carries the letters.
+    question: What is the amino-acid sequence and mass of human insulin (P01308)?
     complexity: basic
     sparql: |
       PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-      SELECT DISTINCT ?protein ?mnemonic ?fullName
+      SELECT ?sequence ?mass (STRLEN(?sequence) AS ?length)
       WHERE {
-        ?protein a up:Protein ;
-                 up:mnemonic ?mnemonic ;
-                 up:reviewed 1 ;
-                 up:organism <http://purl.uniprot.org/taxonomy/9606> .
-        OPTIONAL {
-          ?protein up:recommendedName ?rn .
-          ?rn up:fullName ?fullName .
-        }
+        VALUES ?protein { uniprot:P01308 }
+        ?protein up:sequence ?seq .
+        ?seq a up:Simple_Sequence ;
+             rdf:value ?sequence ;
+             up:mass ?mass .
       }
-      LIMIT 20
+      LIMIT 5
 
   - title: Proteins with Kinase Activity (GO IRI VALUES)
     description: Retrieve proteins classified with specific Gene Ontology molecular function terms.
@@ -224,7 +295,10 @@ sparql_query_examples:
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX obo: <http://purl.obolibrary.org/obo/>
 
+      # FROM scopes to the current uniprot graph (excludes obsolete + OMA-retyped duplicates); with
+      # SELECT DISTINCT it is doubly safe. For a total COUNT use COUNT(DISTINCT ?p) — see critical_warnings.
       SELECT DISTINCT ?protein ?mnemonic
+      FROM <http://sparql.uniprot.org/uniprot>
       WHERE {
         VALUES ?goTerm {
           obo:GO_0004674  # protein serine/threonine kinase activity
@@ -273,6 +347,7 @@ sparql_query_examples:
       PREFIX up: <http://purl.uniprot.org/core/>
 
       SELECT DISTINCT ?protein ?mnemonic ?ecNumber
+      FROM <http://sparql.uniprot.org/uniprot>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;
@@ -282,26 +357,33 @@ sparql_query_examples:
       }
       LIMIT 25
 
-  - title: Disease-Associated Human Proteins with Gene Names
-    description: Retrieve human proteins with disease annotations and their gene symbols, using
-      annotation type filter (up:Disease_Annotation) and gene encoding typed predicate.
-    question: Which human proteins are associated with genetic diseases and what are their gene names?
+  - title: Disease-linked natural variants of a protein (substitution + dbSNP + disease name)
+    description: |
+      Retrieves natural-variant annotations with their structured predicates: up:substitution (the
+      resulting residue), the linked disease (skos:related -> up:Disease -> skos:prefLabel), and the
+      dbSNP rsID (rdfs:seeAlso). Both the disease link (~39.4%) and dbSNP link (~65.9%) are optional.
+    question: Which natural variants of TP53 are linked to a named disease, with substitution and dbSNP ID?
     complexity: intermediate
     sparql: |
       PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT DISTINCT ?protein ?mnemonic ?geneName ?diseaseComment
+      SELECT ?substitution ?diseaseLabel ?dbsnp
       WHERE {
-        ?protein a up:Protein ;
-                 up:reviewed 1 ;
-                 up:organism <http://purl.uniprot.org/taxonomy/9606> ;
-                 up:mnemonic ?mnemonic ;
-                 up:encodedBy ?gene ;
-                 up:annotation ?annot .
-        ?gene skos:prefLabel ?geneName .
-        ?annot a up:Disease_Annotation ;
-               rdfs:comment ?diseaseComment .
+        VALUES ?protein { uniprot:P04637 }
+        ?protein up:annotation ?annot .
+        ?annot a up:Natural_Variant_Annotation ;
+               up:substitution ?substitution .
+        OPTIONAL {
+          ?annot skos:related ?disease .
+          ?disease skos:prefLabel ?diseaseLabel .
+        }
+        OPTIONAL {
+          ?annot rdfs:seeAlso ?dbsnp .
+          FILTER(STRSTARTS(STR(?dbsnp), "http://purl.uniprot.org/dbsnp/"))
+        }
       }
       LIMIT 25
 
@@ -360,6 +442,9 @@ cross_database_queries:
   shared_endpoint: sib
   co_located_databases:
     - rhea
+    - oma
+    - mesh
+    - bgee
   examples:
     - title: Human Enzymes with Catalyzed Reactions from Rhea (UniProt-Rhea via EC IRIs)
       description: |
@@ -399,47 +484,123 @@ cross_database_queries:
         - Performance: ~2-3s — reviewed=1 and organism filter reduce UniProt by 99%
         - MIE files checked: uniprot, rhea
 
-    - title: Human Enzymes with Reactions and GO Biological Process (Three-Way)
+    - title: Human disease proteins joined to their MeSH descriptor label (UniProt→Disease→MeSH)
       description: |
-        Three-way integration: UniProt reviewed human proteins → Rhea reactions → GO labels.
+        Joins reviewed human proteins carrying a disease annotation to the MeSH descriptor label —
+        all on the same sib endpoint, direct IRI join, NO TogoID bridge.
 
         Linking strategy:
-        - UniProt ↔ Rhea: via EC number IRIs (up:enzyme = rhea:ec)
-        - UniProt ↔ GO: via up:classifiedWith OBO IRIs
-        - GO labels from http://sparql.uniprot.org/go graph
+        - up:annotation -> up:Disease_Annotation -> up:disease -> up:Disease resource (diseases graph)
+        - up:Disease rdfs:seeAlso -> http://id.nlm.nih.gov/mesh/D...  (filter by prefix)
+        - MeSH descriptor rdfs:label in the co-hosted http://id.nlm.nih.gov/mesh graph (direct match)
       databases_used:
         - uniprot
-        - rhea
-      complexity: advanced
+        - mesh
+      complexity: intermediate
       sparql: |
         PREFIX up: <http://purl.uniprot.org/core/>
-        PREFIX rhea: <http://rdf.rhea-db.org/>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-        SELECT DISTINCT ?protein ?mnemonic ?reaction ?goLabel
+        SELECT ?protein ?mnemonic ?diseaseLabel ?meshLabel
         WHERE {
           GRAPH <http://sparql.uniprot.org/uniprot> {
             ?protein a up:Protein ;
                      up:reviewed 1 ;
                      up:organism <http://purl.uniprot.org/taxonomy/9606> ;
                      up:mnemonic ?mnemonic ;
-                     up:enzyme ?ecNumber ;
-                     up:classifiedWith ?goTerm .
-            FILTER(STRSTARTS(STR(?goTerm), "http://purl.obolibrary.org/obo/GO_"))
+                     up:annotation ?annot .
+            ?annot a up:Disease_Annotation ; up:disease ?disease .
           }
-          GRAPH <http://sparql.uniprot.org/go> {
-            ?goTerm rdfs:label ?goLabel .
+          GRAPH <http://sparql.uniprot.org/diseases> {
+            ?disease skos:prefLabel ?diseaseLabel ; rdfs:seeAlso ?meshIRI .
+            FILTER(STRSTARTS(STR(?meshIRI), "http://id.nlm.nih.gov/mesh/"))
           }
-          GRAPH <http://rdfportal.org/dataset/rhea> {
-            ?reaction rdfs:subClassOf rhea:Reaction ;
-                      rhea:status rhea:Approved ;
-                      rhea:ec ?ecNumber .
+          GRAPH <http://id.nlm.nih.gov/mesh> {
+            ?meshIRI rdfs:label ?meshLabel .
           }
         }
-        LIMIT 25
+        LIMIT 15
       notes: |
-        - Linking via: EC IRIs (structured) and OBO GO IRIs (structured)
-        - Performance: ~4-6s — organism filter reduces UniProt join by 95%
-        - MIE files checked: uniprot, rhea
+        - Linking via: up:Disease rdfs:seeAlso -> MeSH descriptor IRI (direct, co-hosted graph)
+        - No TogoID needed — mesh is co-hosted on the sib endpoint
+        - MIE files checked: uniprot, mesh
+
+    - title: OMA cross-references for a UniProt protein (UniProt↔OMA, direct IRI join)
+      description: |
+        Maps a UniProt accession to its OMA entry and OMA's own cross-references (Ensembl protein,
+        RefSeq) — a direct same-endpoint join, NO TogoID bridge.
+        - OMA entry lscr:xrefSwissProt -> the SAME purl.uniprot.org/uniprot/ IRI (direct match)
+        - OMA entry carries lscr:xrefEnsemblProtein, lscr:xrefNCBIRefSeq, rdfs:label
+        NOTE: full cross-species ORTHOLOG-GROUP traversal uses OMA's orth: cluster ontology and is
+        NOT shown here (not verified this pass); this example is the confirmed xref-mapping join.
+      databases_used:
+        - uniprot
+        - oma
+      complexity: intermediate
+      sparql: |
+        PREFIX up: <http://purl.uniprot.org/core/>
+        PREFIX lscr: <http://purl.org/lscr#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+
+        SELECT ?omaEntry ?omaLabel ?ensemblProtein ?refseq
+        WHERE {
+          GRAPH <http://sparql.uniprot.org/uniprot> {
+            uniprot:P04637 a up:Protein ; up:reviewed 1 .
+          }
+          GRAPH <http://rdfportal.org/dataset/oma> {
+            ?omaEntry lscr:xrefSwissProt uniprot:P04637 ;
+                      rdfs:label ?omaLabel .
+            OPTIONAL { ?omaEntry lscr:xrefEnsemblProtein ?ensemblProtein }
+            OPTIONAL { ?omaEntry lscr:xrefNCBIRefSeq ?refseq }
+          }
+        }
+        LIMIT 10
+      notes: |
+        - Linking via: OMA lscr:xrefSwissProt -> same UniProt IRI (381,038 such triples in OMA)
+        - This co-location is ALSO the §1 COUNT-inflation trap — join opportunity and hazard share a cause
+        - MIE files checked: uniprot, oma
+
+    - title: Tissues where a protein is expressed via Bgee (UniProt↔Bgee, xref + IRI transform)
+      description: |
+        Joins a protein to Bgee gene-expression anatomy terms. UniProt carries a Bgee-specific xref
+        (purl.uniprot.org/bgee/ENSG...) whose Ensembl gene ID is transformed into Bgee's own gene IRI
+        (omabrowser.org/ontology/oma#GENE_ENSG...) with STRAFTER/CONCAT — a same-endpoint join.
+
+        Linking strategy:
+        - up:sequence? no — rdfs:seeAlso -> purl.uniprot.org/bgee/<ENSG-id>  (94.1% of human reviewed)
+        - BIND transform -> omabrowser.org/ontology/oma#GENE_<ENSG-id>  (Bgee gene IRI)
+        - Bgee genex:isExpressedIn -> anatomical entity -> rdfs:label
+        NOTE: genex:isExpressedIn is the flattened presence view; the richer per-condition
+        genex:Expression structure (stage × confidence) was not traced this pass.
+      databases_used:
+        - uniprot
+        - bgee
+      complexity: advanced
+      sparql: |
+        PREFIX up: <http://purl.uniprot.org/core/>
+        PREFIX genex: <http://purl.org/genex#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT DISTINCT ?anatLabel
+        WHERE {
+          GRAPH <http://sparql.uniprot.org/uniprot> {
+            <http://purl.uniprot.org/uniprot/P04637> rdfs:seeAlso ?bgeeRef .
+            FILTER(STRSTARTS(STR(?bgeeRef), "http://purl.uniprot.org/bgee/"))
+            BIND(IRI(CONCAT("http://omabrowser.org/ontology/oma#GENE_",
+                            STRAFTER(STR(?bgeeRef), "bgee/"))) AS ?bgeeGene)
+          }
+          GRAPH <http://bgee.org> {
+            ?bgeeGene genex:isExpressedIn ?anatEntity .
+            ?anatEntity rdfs:label ?anatLabel .
+          }
+        }
+        LIMIT 15
+      notes: |
+        - Linking via: rdfs:seeAlso bgee xref -> IRI transform -> Bgee gene IRI (no TogoID)
+        - Coverage: 19,216/20,431 human reviewed proteins (94.1%) carry a bgee xref
+        - MIE files checked: uniprot, bgee
 
 cross_references:
   - pattern: rdfs:seeAlso
@@ -483,6 +644,39 @@ cross_references:
       reactions:
         - "Rhea: ~22% of reviewed proteins (enzymatic)"
 
+  - pattern: "up:annotation/up:disease → up:Disease/rdfs:seeAlso"
+    description: |
+      Disease annotations carry a STRUCTURED disease-resource link (up:disease, 83.3% of
+      Disease_Annotation nodes), not just rdfs:comment. The up:Disease resource then seeAlso-links to
+      MeSH (co-hosted, direct join), MedGen and OMIM. Filter the seeAlso object by IRI prefix.
+    databases:
+      disease:
+        - "MeSH: http://id.nlm.nih.gov/mesh/D###### — co-hosted on sib, direct join (no bridge)"
+        - "MedGen: http://purl.uniprot.org/medgen/C#######"
+        - "OMIM/MIM: http://purl.uniprot.org/mim/######"
+
+  - pattern: "Natural_Variant_Annotation rdfs:seeAlso / skos:related"
+    description: |
+      Variant annotations link to dbSNP (rdfs:seeAlso, ~65.9%) and to a disease resource
+      (skos:related, ~39.4%). Distinguish the dbSNP seeAlso by its prefix.
+    databases:
+      variants:
+        - "dbSNP: http://purl.uniprot.org/dbsnp/rs###### (~65.9% of natural variants)"
+      disease:
+        - "up:Disease (variant-level): skos:related -> purl.uniprot.org/diseases/### (~39.4%)"
+
+  - pattern: "rdfs:seeAlso (OMA / Bgee, co-hosted on sib)"
+    description: |
+      Two co-hosted datasets join directly on the sib endpoint with no TogoID bridge:
+      OMA re-uses the same UniProt IRIs (reverse: OMA lscr:xrefSwissProt -> UniProt); Bgee is reached
+      via a UniProt-minted xref plus a string transform of the Ensembl gene ID.
+    databases:
+      orthology:
+        - "OMA: OMA entry lscr:xrefSwissProt -> the same purl.uniprot.org/uniprot/ IRI (reverse link)"
+      expression:
+        - "Bgee: rdfs:seeAlso -> purl.uniprot.org/bgee/<ENSG> (94.1% of human reviewed); transform to
+           omabrowser.org/ontology/oma#GENE_<ENSG> to reach the http://bgee.org graph"
+
 architectural_notes:
   query_strategy:
     - "MANDATORY FIRST STEP: get_MIE_file('uniprot') and read critical_warnings + shape_expressions"
@@ -497,21 +691,38 @@ architectural_notes:
     - "FALDO ontology used for all sequence position features (domains, PTMs, variants, SSE)"
     - "Catalytic activity: indirect 3-hop scaffold up:annotation/up:catalyticActivity/up:catalyzedReaction"
     - "Gene encoding: up:encodedBy -> up:Gene -> skos:prefLabel (symbol), skos:altLabel (synonyms)"
-    - "Isoforms: up:sequence links to Simple_Sequence (canonical) and Modified_Sequence (alternates)"
+    - "Isoforms: up:sequence -> Simple_Sequence (canonical) / Modified_Sequence (alternates), plus
+       rare External_Sequence / Unknown_Sequence; the sequence STRING is rdf:value on that node"
+    - "Natural variants: up:Natural_Variant_Annotation carries up:substitution (residue), rdfs:seeAlso
+       (dbSNP), skos:related (disease) — richer than the generic rdfs:comment AnnotationShape"
+    - "Diseases: up:Disease_Annotation -> up:disease -> up:Disease (skos:prefLabel, up:mnemonic,
+       rdfs:seeAlso to MeSH/MedGen/OMIM); two-tier disease linking (annotation-level up:disease vs
+       variant-level skos:related — different predicates, different granularity, do not conflate)"
     - "GO terms: OBO IRI namespace only — http://purl.obolibrary.org/obo/GO_XXXXX"
     - "Keywords: http://purl.uniprot.org/keywords/NNN — same up:classifiedWith predicate as GO"
 
   performance:
     - "CRITICAL: up:reviewed 1 must appear in every query (99.8% row reduction)"
+    - "COUNT protein queries with COUNT(DISTINCT ?p) — the co-hosted OMA graph re-types UniProt IRIs as
+       up:Protein (adds 337,813 rows), so unscoped COUNT(*) inflates to 926,872 vs true 589,059. Do NOT
+       use FROM <uniprot> as the fix: it drops the 14,432 reviewed entries in the obsolete graph (574,627)"
     - "Taxonomy lineage is pre-computed flat subClassOf — single-hop, never transitive (*)"
     - "For bif:contains: always split property paths before the text node (Virtuoso requirement)"
     - "Cross-database: apply restrictive filters within each GRAPH block before the join"
     - "Always add LIMIT to every query"
 
   data_integration:
-    - "SIB endpoint hosts both UniProt and Rhea — direct GRAPH clause joins, no ID bridging needed"
+    - "sib endpoint now co-hosts UniProt + Rhea + OMA + MeSH + Bgee — all joinable via direct GRAPH
+       clauses, NO ID bridging needed (see cross_database_queries for all four)"
     - "Linking UniProt ↔ Rhea: up:enzyme EC IRIs = rhea:ec EC IRIs (exact same IRI namespace)"
-    - "Cross-database to PDB, ChEMBL, Ensembl: use togoid_convertId() to bridge via accessions"
+    - "Linking UniProt ↔ MeSH: up:disease -> up:Disease rdfs:seeAlso -> id.nlm.nih.gov/mesh/ (co-hosted)"
+    - "Linking UniProt ↔ OMA: OMA lscr:xrefSwissProt reuses the same purl.uniprot.org/uniprot/ IRIs
+       (this reuse is also the §1 COUNT-inflation trap — use COUNT(DISTINCT ?p) for protein counts)"
+    - "Linking UniProt ↔ Bgee: rdfs:seeAlso purl.uniprot.org/bgee/<ENSG> + string transform to
+       omabrowser.org/ontology/oma#GENE_<ENSG> (94.1% of human reviewed) — no TogoID needed"
+    - "OMA orthology + Bgee expression no longer require togoid_convertId — the old note to that
+       effect is superseded. TogoID is still the route for PDB/ChEMBL/Ensembl accession bridging."
+    - "http://purl.jp/bio/11/goa is an EMPTY STUB (151 triples) — not a usable GOA integration point"
 
   data_quality:
     - "Swiss-Prot (reviewed=1) has expert-curated annotations; TrEMBL is automated and incomplete"
@@ -526,12 +737,29 @@ architectural_notes:
 
 data_statistics:
   total_proteins: ~244000000
-  reviewed_proteins: 589059
+  reviewed_proteins: 589059          # via COUNT(DISTINCT ?p) = 574,627 current (uniprot graph) + 14,432
+                                     # obsolete graph. Unscoped COUNT(*) gives 926,872 (OMA re-typing); FROM
+                                     # <uniprot> gives only 574,627 (drops obsolete). See critical_warnings.
   human_reviewed_proteins: 20431
   disease_annotated_reviewed: 5835
   reviewed_with_gene_name: 549969
-  verified_date: "2026-04-29"
-  verification_method: "Direct COUNT queries on reviewed proteins; all 7 SPARQL examples live-tested"
+  verified_date: "2026-07-06"
+  verification_method: "GRAPH/FROM-scoped or DISTINCT COUNT queries on reviewed proteins; all 7 SPARQL
+    examples and 4 cross-DB examples live-tested on the sib endpoint"
+  version_label_note: "data_version 'Release 2024_06' could not be re-derived from the endpoint (no
+    version-metadata predicate found); core counts reproduce exactly, consistent with no major churn"
+
+  sequence_and_annotation_counts:   # verified 2026-07-06, FROM-scoped to the uniprot graph
+    canonical_sequences_simple: 574627      # up:Simple_Sequence on reviewed; 100% carry rdf:value
+    alternate_sequences_modified: 41333
+    external_sequences: 2121
+    unknown_sequences: 275
+    natural_variant_annotations: 106543
+    natural_variants_with_disease: 41966    # skos:related — 39.4%
+    natural_variants_with_dbsnp: 70237      # rdfs:seeAlso dbSNP — 65.9%
+    disease_annotations: 8698
+    disease_annotations_with_up_disease: 7250   # 83.3%
+    human_reviewed_with_bgee_xref: 19216        # 94.1% of 20,431
 
   coverage:
     reviewed_with_function: "~80%"
@@ -567,6 +795,28 @@ anti_patterns:
       for genuinely unstructured free-text fields like rdfs:comment on annotation nodes.
       Always read shape_expressions and inspect example entities before using text search.
 
+  - title: Protein COUNT Inflated by Co-hosted OMA (and split across the obsolete graph)
+    problem: |
+      Counting up:Protein with COUNT(*) over the default union. `a up:Protein` is asserted for reviewed
+      proteins in THREE graphs — uniprot (574,627), OMA (337,813 re-typings of the same IRIs), obsolete
+      (14,432) — so COUNT(*) returns 926,872, not the true 589,059. A wrong POSITIVE number, no error.
+    wrong_sparql: |
+      # WRONG: unscoped, no DISTINCT — OMA re-typing adds 337,813 duplicate rows
+      PREFIX up: <http://purl.uniprot.org/core/>
+      SELECT (COUNT(*) AS ?n) WHERE { ?p a up:Protein ; up:reviewed 1 . }
+      # → 926,872 (inflated)
+    correct_sparql: |
+      # CORRECT: COUNT(DISTINCT ?p) — robust regardless of how many graphs re-type the IRI
+      PREFIX up: <http://purl.uniprot.org/core/>
+      SELECT (COUNT(DISTINCT ?p) AS ?n) WHERE { ?p a up:Protein ; up:reviewed 1 . }
+      # → 589,059 (correct; = 574,627 current + 14,432 obsolete)
+    explanation: |
+      Do NOT "fix" this with FROM <http://sparql.uniprot.org/uniprot> — that returns 574,627, silently
+      dropping the 14,432 reviewed proteins whose up:reviewed lives in the obsolete graph. COUNT(DISTINCT
+      ?p) is the only robust fix for total reviewed proteins; FROM <uniprot> is correct only when you
+      specifically want CURRENT (non-obsolete) entries. Row-level SELECT DISTINCT queries are unaffected
+      but fragile — a rewrite to COUNT(*) reintroduces the inflation.
+
   - title: Querying Without Reviewed Filter
     problem: Omitting up:reviewed 1 queries ~244M TrEMBL entries; COUNT queries time out.
     wrong_sparql: |
@@ -575,14 +825,17 @@ anti_patterns:
                  up:organism <http://purl.uniprot.org/taxonomy/9606> .
       }
     correct_sparql: |
-      SELECT (COUNT(*) as ?count) WHERE {
+      # up:reviewed 1 AND COUNT(DISTINCT) — plain COUNT(*) here returns 40,209 (OMA re-typing) not 20,431
+      PREFIX up: <http://purl.uniprot.org/core/>
+      SELECT (COUNT(DISTINCT ?protein) as ?count) WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;
                  up:organism <http://purl.uniprot.org/taxonomy/9606> .
       }
     explanation: |
-      up:reviewed 1 reduces scope from ~244M to 589K (99.8% reduction). Mandatory
-      for all quality queries. The value is an integer, not a boolean or string.
+      up:reviewed 1 reduces scope from ~244M to 589K (99.8% reduction) and is mandatory (integer, not
+      boolean/string). Use COUNT(DISTINCT ?protein): the co-hosted OMA graph re-types UniProt IRIs as
+      up:Protein, so a bare COUNT(*) even with reviewed+organism inflates (40,209 vs true 20,431).
 
   - title: Circular Reasoning with Search Results
     problem: Using protein IRIs sampled from a bif:contains text search as the scope of a comprehensive functional count.


### PR DESCRIPTION
Audit-driven revision of 5 MIE files, all bumped to `mie_version: 2.2` / `mie_revised: 2026-07-06`. **Every finding was re-verified against the live SPARQL endpoints before writing**, and Phase-5 validation caught two issues the audits themselves missed.

## Files
| File | Highlights |
|---|---|
| **pubtator** | MeSH `identifiers.org`-vs-native join trap + cross-endpoint SERVICE example; `PubTator3` is the majority variant source (VALUES fix); annotation_count timeout-vs-empty; pre-bounded aggregation; cross-species gene mixing + taxid-filtered example |
| **uniprot** | OMA COUNT-inflation (926,872 vs 589,059); sequence-string + isoform predicates; NaturalVariant/Disease shapes; MeSH/OMA/Bgee direct joins; `goa` empty-stub |
| **clinvar** | `med2rdf:disease` duplicate-blank-node inflation (~3.7×); KRAS somatic/oncogenicity example; gene→variant→disease→MeSH→literature golden path |
| **medgen** | Corrected TogoID guidance (pass the disease CUI, not stub gene CUIs); golden-path bridge example |
| **ncbigene** | Species-mixing warning; **fixed a broken PubTator cross-DB example** (nonexistent predicates/graph → 0 rows) |

## Corrections beyond the audit notes
- **uniprot §1:** the audit proposed `FROM <uniprot>` as the OMA-inflation fix — but that returns 574,627, silently dropping the 14,432 reviewed entries in the `obsolete` graph. Corrected to `COUNT(DISTINCT ?p)` = 589,059, and fixed a pre-existing anti-pattern whose `COUNT(*)` now inflated (40,209 vs 20,431).
- **NCBI §5:** the MedGen→PubTator bridge additionally needs an `id.nlm.nih.gov/mesh/` → `identifiers.org/mesh/` transform (the audit omitted it); added and re-verified (→ 15 BRCA1 articles).
- **ncbigene:** the prior `pubtator:ncbiGeneIdentifier` / graph `pubtator` example returned 0 rows; rewritten to `oa:hasBody` in `pubtator_central` (verified TP53 = 273,965 articles).

## Validation
- All 5 YAMLs parse; each 7 examples at the 2/3/2 distribution
- Every new/changed SPARQL example, cross-DB query, and anti-pattern `correct_sparql` executed live
- Statistics/coverage figures and TogoID routes verified via `run_sparql` / `togoid_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)