### PR TITLE
docker: pin installs to uv.lock with --frozen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ WORKDIR /app
 
 # Copy the entire project into the container
 COPY . .
-RUN uv sync
+# --frozen: install exactly what uv.lock pins; fail the build if the lock is
+# stale vs pyproject.toml instead of silently re-resolving to newer versions.
+RUN uv sync --frozen
 # Expose the port your FastAPI/Uvicorn server listens on (adjust if needed)
 EXPOSE 8000
 
 # Command to run your MCP server
-CMD ["uv", "run", "togo-mcp-server"]
+CMD ["uv", "run", "--frozen", "togo-mcp-server"]


### PR DESCRIPTION
## Summary
Harden the Docker build so the deployed image can only ever install exactly what `uv.lock` pins.

- `RUN uv sync` → `RUN uv sync --frozen` (build time)
- `uv run togo-mcp-server` → `uv run --frozen togo-mcp-server` (runtime)

Plain `uv sync`/`uv run` silently re-resolve to newer versions when the lock drifts from `pyproject.toml`. `--frozen` turns that into a hard failure instead, keeping the deployed stack reproducibly at the verified **fastmcp 3.0.0 + mcp 1.26.0**.

## Context
Chasing an HTTP 421 "Misdirected Request" from the vs94 backend: a foreign `Host: togomcp.rdfportal.org` was rejected by the MCP SDK's DNS-rebinding middleware. Running current `main` code locally returns **200** for that same Host — the vs94 container is stale. The real fix is a rebuild from current source; this PR removes a foot-gun so future rebuilds can't silently pull a different mcp/fastmcp version than what was verified.

## Verification
- `uv lock --check` passes — lock is in sync with `pyproject.toml`, so `--frozen` won't break the build.
- Current code verified locally to return 200 (not 421) for the production Host header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)