### PR TITLE
docker: ship uv.lock so --frozen builds work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 logs/
 logs-test/
 tmp/
-uv.lock
 .gitignore
 .DS_Store
 LICENSE.md


### PR DESCRIPTION
## Summary
`.dockerignore` excluded `uv.lock`, so the lockfile never reached the Docker build context. Two consequences:

- The old `RUN uv sync` had **no lockfile in context** → resolved dependencies fresh from `pyproject.toml` on every build → non-reproducible images. This is the mechanism by which the deployed container drifted away from the verified `fastmcp 3.0.0 + mcp 1.26.0` stack.
- The newly merged `RUN uv sync --frozen` (#112) then **failed hard**: `error: Unable to find lockfile at uv.lock, but --frozen was provided`.

This PR removes `uv.lock` from `.dockerignore` so the lockfile is shipped into the build and `--frozen` produces reproducible images.

## Context
Live diagnosis on the vs94 host traced a persistent HTTP 421 to the container running a **stale, freshly-resolved** image whose deps differed from source. Fixing #112 exposed this ignore rule as the real enabler of the drift.

## Verification
- `git ls-files uv.lock` → tracked; file is 250 KB and in sync (`uv lock --check` passes).
- With this change, `podman build --no-cache -t localhost/togo-mcp:latest .` proceeds past the `uv sync --frozen` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)