### PR TITLE
deps: upgrade FastMCP to 3.4.3 + allow-list proxied vhosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@ TEST_PORT=8001
 # Optional: timezone for log timestamps (default: Asia/Tokyo)
 TZ=Asia/Tokyo
 
+# Optional: extra Host headers to accept (comma-separated). FastMCP >= 3.4.3
+# validates the Host header (DNS-rebinding protection) and rejects unknown hosts
+# with 421. The public vhosts (togomcp.rdfportal.org, test-togomcp.rdfportal.org)
+# are already allowed in code — set these ONLY to add internal names (e.g. the
+# container host) if the reverse proxy forwards a different Host than the vhost.
+# TOGOMCP_ALLOWED_HOSTS=vs94,vs94:8000
+# TOGOMCP_ALLOWED_HOSTS_TEST=vs94,vs94:8001
+
 # Optional: enable tool-call logging (JSONL, one record per MCP tool call).
 # Unset/empty = disabled (default). The compose.yaml bind-mounts ./logs and
 # ./logs-test on the host to /var/log/togomcp inside each container, so set

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,10 @@ services:
     environment:
       NCBI_API_KEY: ${NCBI_API_KEY}
       TZ: ${TZ:-Asia/Tokyo}
+      # Extra Host headers to accept (comma-separated). The public vhosts are
+      # allowed in code; set this only to add internal names (e.g. the container
+      # host) if the reverse proxy forwards a different Host. See .env.example.
+      TOGOMCP_ALLOWED_HOSTS: ${TOGOMCP_ALLOWED_HOSTS:-}
       TOGOMCP_QUERY_LOG: ${TOGOMCP_QUERY_LOG:-}
       # /stats dashboard HTTP Basic creds — unset = dashboard disabled (503).
       TOGOMCP_STATS_USER: ${TOGOMCP_STATS_USER:-}
@@ -26,6 +30,8 @@ services:
     environment:
       NCBI_API_KEY: ${NCBI_API_KEY}
       TZ: ${TZ:-Asia/Tokyo}
+      # Extra Host headers to accept (comma-separated). Public vhosts allowed in code.
+      TOGOMCP_ALLOWED_HOSTS: ${TOGOMCP_ALLOWED_HOSTS_TEST:-}
       TOGOMCP_QUERY_LOG: ${TOGOMCP_QUERY_LOG_TEST:-}
       # /stats dashboard HTTP Basic creds — unset = dashboard disabled (503).
       TOGOMCP_STATS_USER: ${TOGOMCP_STATS_USER_TEST:-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fastmcp>=3.0.0",
+    "fastmcp>=3.4.3",
     "httpx>=0.28.1",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/togo_mcp/main.py
+++ b/togo_mcp/main.py
@@ -4,6 +4,18 @@ from .api_tools import *
 from .togoid import togoid_mcp
 from .ncbi_tools import ncbi_mcp
 import asyncio
+import os
+
+# FastMCP >= 3.4.3 validates the Host header (DNS-rebinding protection) and 421s
+# any host not on the allow-list. The default list is localhost only, so the
+# public vhosts served through the reverse proxy must be added explicitly or every
+# proxied request is rejected. Operators can append internal names (e.g. the
+# container host) via TOGOMCP_ALLOWED_HOSTS="host1,host2" without editing source.
+_DEFAULT_ALLOWED_HOSTS = ["togomcp.rdfportal.org", "test-togomcp.rdfportal.org"]
+
+def _allowed_hosts() -> list[str]:
+    extra = os.environ.get("TOGOMCP_ALLOWED_HOSTS", "")
+    return _DEFAULT_ALLOWED_HOSTS + [h.strip() for h in extra.split(",") if h.strip()]
 
 async def setup():
     mcp.mount(togoid_mcp, "togoid")
@@ -11,7 +23,12 @@ async def setup():
 
 def run():
     asyncio.run(setup())
-    mcp.run(transport="http", host="0.0.0.0", port=8000)
+    mcp.run(
+        transport="http",
+        host="0.0.0.0",
+        port=8000,
+        allowed_hosts=_allowed_hosts(),
+    )
 
 def run_local():
     asyncio.run(setup())

--- a/uv.lock
+++ b/uv.lock
@@ -47,14 +47,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.5"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553, upload-time = "2025-10-02T13:36:09.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608, upload-time = "2025-10-02T13:36:07.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -446,33 +447,74 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.0.0"
+version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/92/cf0e921675af66534eb6dfffffa1871b5062f01650bcea63b62005a12f50/fastmcp-3.4.3.tar.gz", hash = "sha256:31e212ae9ff223876c6d7af2082e73f90bc692460e7a054568dfa88719f075ff", size = 28789252, upload-time = "2026-07-05T23:27:55.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/79/64000c2792743877baae152499a951c06a9c14b793309ac4ac06135f1ae7/fastmcp-3.4.3-py3-none-any.whl", hash = "sha256:bdf15277800586a033a6e1e95d20301cd508aaa872df3d508c956a2195de6c72", size = 8019, upload-time = "2026-07-05T23:27:53.241Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/fa/500f6362016c34fba01c6412bbfd53435dc75900abd1266d88e111e2e9c2/fastmcp_slim-3.4.3.tar.gz", hash = "sha256:e3e12ac1e87c5195fa59a1c3cd2d31b487a463c269089fb4020b7571cbb57b29", size = 588086, upload-time = "2026-07-05T23:27:33.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/4f/66765dfe4fe65b45e134e54ca46118d93189fb10cd8ecb635cf504b68552/fastmcp_slim-3.4.3-py3-none-any.whl", hash = "sha256:21ad50465494edb141eed76b177dc788e00e705a5df09b53a31efebeb4432a95", size = 761455, upload-time = "2026-07-05T23:27:32.547Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/be/beb5d3e485983b9dd122f3f74772bcceeb085ca824e11c52c14ba71cf21a/fastmcp-3.0.0.tar.gz", hash = "sha256:f3b0cfa012f6b2b50b877da181431c6f9a551197f466b0bb7de7f39ceae159a1", size = 16093079, upload-time = "2026-02-18T21:25:34.461Z" }
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/14/05bebaf3764ea71ce6fa9d3fcf870610bbc8b1e7be2505e870d709375316/fastmcp-3.0.0-py3-none-any.whl", hash = "sha256:561d537cb789f995174c5591f1b54f758ce3f82da3cd951ffe51ce18609569e9", size = 603327, upload-time = "2026-02-18T21:25:36.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -594,6 +636,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -1036,11 +1090,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -1363,15 +1417,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -1397,7 +1451,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.4.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1427,6 +1481,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Upgrades FastMCP 3.0.0 → **3.4.3** and adapts to its new Host-validation security feature (Option A: keep the protection, allow-list our vhosts).

### Why
FastMCP 3.4.3 ("The Fast and the Secure-ious", 2026-07-05) added Host/Origin validation to Streamable HTTP — [PR #4405 "Protect streamable HTTP from DNS rebinding"](https://github.com/PrefectHQ/fastmcp/pull/4405). Its default allow-list is localhost only (`127.0.0.1`, `localhost`, `::1`) plus the bind host; since we bind `0.0.0.0` (unspecified → excluded), **every request whose Host is a public vhost gets `421 Misdirected Request`.** This is the confirmed root cause of today's production 421 — an unpinned build floated onto 3.4.3 the morning it shipped.

### What
- `pyproject.toml`: `fastmcp>=3.0.0` → `>=3.4.3`; `uv.lock` regenerated (fastmcp 3.4.3, mcp stays 1.26.0, starlette 0.50.0 → 1.3.1).
- `main.py`: pass `allowed_hosts=[...]` to `mcp.run()`. Defaults to `togomcp.rdfportal.org` + `test-togomcp.rdfportal.org`; operators can append internal names via `TOGOMCP_ALLOWED_HOSTS="h1,h2"` with no rebuild.

### Verification (local, on 3.4.3)
| Host header | Result |
|---|---|
| `togomcp.rdfportal.org` / `test-togomcp.rdfportal.org` | **200** |
| `127.0.0.1:8000` (default localhost) | **200** |
| `TOGOMCP_ALLOWED_HOSTS` entries | **200** |
| `evil.example.com`, other vhosts | **421** (protection active) |

- MCP endpoint reachable (`/mcp/` → 307, unchanged).
- **All 83 tests pass** (starlette 1.3.1 caused no regression).

### ⚠️ Confirm before prod
1. **Exact public hostname(s).** The default list is `togomcp.rdfportal.org` / `test-togomcp.rdfportal.org`. If the real vhost differs (e.g. `mcp.rdfportal.org`), add it — a non-listed Host will 421.
2. **What Host the edge proxy forwards.** If the reverse proxy rewrites Host to an internal value, allow-list that via `TOGOMCP_ALLOWED_HOSTS`. Definitive check: after deploying to test via `scripts/deploy.sh test`, curl the real public **test** URL and confirm 200 before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)