### PR TITLE
docs: add CHANGELOG.md + reconcile package version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to TogoMCP are recorded here. The format is loosely based on
+[Keep a Changelog](https://keepachangelog.com/); releases are tagged in git
+(`v1.0.0`, `v1.0.1`, …). Entries under released versions are high-level
+summaries reconstructed from git history, not exhaustive.
+
+## [Unreleased]
+
+### Changed
+- **⚠️ Breaking (deployment): upgraded FastMCP 3.0 → 3.4.3.** FastMCP 3.4.3
+  ("The Fast and the Secure-ious") adds Host/Origin validation to Streamable HTTP
+  for DNS-rebinding protection. Its default allow-list is localhost only, so a
+  `0.0.0.0`-bound server behind a reverse proxy now returns
+  `421 Misdirected Request` for any request whose `Host` is a public vhost.
+  `main.py` allow-lists the public vhosts (`togomcp.rdfportal.org`,
+  `test-togomcp.rdfportal.org`); add internal names via `TOGOMCP_ALLOWED_HOSTS`.
+  (#115)
+
+### Added
+- `scripts/deploy.sh` — Podman deploy helper that enforces test-before-prod
+  promotion: prod only promotes the exact image already tested on the test
+  container, refuses unless the test container answers `200`, requires typing the
+  production hostname (fail-closed), and saves a rollback pointer. (#114)
+- `TOGOMCP_ALLOWED_HOSTS` / `TOGOMCP_ALLOWED_HOSTS_TEST` env vars, wired through
+  `compose.yaml` and documented in `.env.example`, to add hostnames to the
+  FastMCP Host allow-list without a rebuild. (#115)
+
+### Fixed
+- Reproducible Docker images. `uv.lock` is now shipped into the build context
+  (it had been excluded by `.dockerignore`) and installs use `uv sync --frozen`
+  / `uv run --frozen`. Previously each build re-resolved dependencies from PyPI,
+  silently floating the deployed FastMCP version — which is what let an unpinned
+  build pick up FastMCP 3.4.3 the day it shipped and cause a production 421.
+  (#112, #113)
+
+_Ongoing MIE database onboarding and revisions (e.g. mogplus, nbrc, jPOST) also
+land continuously; see git history for details._
+
+## [1.0.1] - 2026-05-07
+
+### Changed
+- REST-wrapper and catalog tools return graceful error payloads instead of
+  raising on bad input / upstream HTTP failures.
+- `find_databases` made the canonical, required database-discovery tool.
+
+### Added
+- jPOST database onboarding; `get_graph_list` extended with endpoint arguments.
+- MIE spec v2.1 (shape_expressions discipline, pre-publication audit phases) and
+  a corresponding MIE-file sweep.
+- Benchmark result batches (Opus 4.7) with prior runs archived.
+
+## [1.0.0] - 2026-03-07
+
+- First tagged release. FastMCP server exposing RDF Portal SPARQL plus selected
+  REST APIs (NCBI E-utilities, UniProt, ChEMBL, PDB, PubChem, Reactome, Rhea,
+  MeSH, TogoID), the bundled MIE files, and the SPARQL endpoint registry.
+
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/dbcls/togomcp/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/dbcls/togomcp/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "0.1.0"
+version = "1.1.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "0.1.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Introduces a `CHANGELOG.md` and reconciles the package version so that **pyproject version, git tags, and the changelog agree**.

## Changes
- **`CHANGELOG.md`** (Keep a Changelog style):
  - `[Unreleased]` — this session's infra hardening: ⚠️ FastMCP 3.0 → 3.4.3 + Host allow-list (#115), `scripts/deploy.sh` test-before-prod (#114), reproducible Docker builds via `uv.lock` + `--frozen` (#112, #113).
  - `[1.0.1]` / `[1.0.0]` — retroactive high-level summaries from git history (tag dates 2026-05-07 / 2026-03-07). Non-exhaustive, as noted in the file header.
- **`pyproject.toml`**: `version` `0.1.0` → **`1.1.0`**. It had drifted far behind the `v1.0.x` tags. Minor bump because the working tree contains post-1.0.1 features (deploy.sh, env knobs) with no consumer-facing API break — the FastMCP change is deployment config. `uv.lock` regenerated so `--frozen` builds stay consistent.

## Notes
- Separate from the code PRs by request. The #115 entry documents a PR still open; both will be on `main` together once merged.
- Version target `1.1.0` represents the next release (dev version); `CHANGELOG` keeps `[Unreleased]` until you actually tag it. Bump to `2.0.0` instead if you consider the FastMCP deployment break a major release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)