### PR TITLE
fix: log path must not crash startup; mount log dir in deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -93,9 +93,14 @@ env_args() {  # kind(test|prod) — prints podman -e args, one token per line
 recreate() {  # name port image kind
   local name=$1 port=$2 image=$3 kind=$4 eargs=()
   mapfile -t eargs < <(env_args "$kind")
+  # Bind-mount the log dir like compose does (main -> ./logs, test -> ./logs-test),
+  # so a TOGOMCP_QUERY_LOG path under /var/log/togomcp exists and persists.
+  local logdir="$REPO_ROOT/logs"; [[ "$kind" == test ]] && logdir="$REPO_ROOT/logs-test"
+  mkdir -p "$logdir"
   log "recreating '$name' on :$port from ${image}"
   podman rm -f "$name" >/dev/null 2>&1 || true
-  podman run -d --name "$name" -p "${port}:8000" "${eargs[@]}" "$image" >/dev/null
+  podman run -d --name "$name" -p "${port}:8000" -v "${logdir}:/var/log/togomcp" \
+    "${eargs[@]}" "$image" >/dev/null
 }
 
 smoke() {  # port host label  -> dies unless 200

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -441,15 +441,26 @@ class _ToolCallLogger(_Middleware):
         self._enabled = bool(log_path)
         self._log: logging.Logger | None = None
         if self._enabled:
-            handler = RotatingFileHandler(
-                log_path, maxBytes=50_000_000, backupCount=10, encoding="utf-8"
-            )
-            handler.setFormatter(logging.Formatter("%(message)s"))
-            log = logging.getLogger("togomcp.toolcalls")
-            log.setLevel(logging.INFO)
-            log.propagate = False
-            log.handlers = [handler]
-            self._log = log
+            try:
+                log_dir = os.path.dirname(log_path)
+                if log_dir:
+                    os.makedirs(log_dir, exist_ok=True)
+                handler = RotatingFileHandler(
+                    log_path, maxBytes=50_000_000, backupCount=10, encoding="utf-8"
+                )
+                handler.setFormatter(logging.Formatter("%(message)s"))
+                log = logging.getLogger("togomcp.toolcalls")
+                log.setLevel(logging.INFO)
+                log.propagate = False
+                log.handlers = [handler]
+                self._log = log
+            except OSError as exc:
+                # A logging misconfiguration must never stop the server booting.
+                logger.warning(
+                    "tool-call logging disabled: cannot open %s (%s)", log_path, exc
+                )
+                self._enabled = False
+                self._log = None
 
     @staticmethod
     def _client_ip() -> str | None:


### PR DESCRIPTION
## Summary
`./scripts/deploy.sh test` crashed the container on boot once deploy.sh started sourcing `.env` (#117): with `TOGOMCP_QUERY_LOG=/var/log/togomcp/*.jsonl` forwarded, `_ToolCallLogger` opened a `RotatingFileHandler` at that path, but `/var/log/togomcp/` doesn't exist unless the log volume is mounted → `FileNotFoundError` killed the whole server at import time (`Exited (1)`, smoke `000`).

## Root cause
Two gaps that only surfaced together:
1. The app opened the log file with no guarantee the directory exists, and any failure there propagates out of module import — taking down the server.
2. `deploy.sh` forwarded the query-log path but, unlike `compose.yaml`, never mounted `/var/log/togomcp`.

## Fixes
- **`togo_mcp/server.py`** — `os.makedirs()` the log file's parent, and on `OSError` fail soft to *logging disabled* with a `logger.warning` instead of crashing. A logging misconfig must never stop the MCP server booting.
- **`scripts/deploy.sh`** — bind-mount the log dir like compose (`main -> ./logs`, `test -> ./logs-test`, both `-> /var/log/togomcp`), creating the host dir first, so query-log paths exist and persist across recreation.

## Verification (local)
| Case | Result |
|---|---|
| nested/nonexistent log dir (the vs94 crash) | dir auto-created, server boots → **200** |
| unwritable path (`/proc/...`) | fails soft → **200** + "tool-call logging disabled" warning |
| `deploy.sh test` / `prod` | emits `-v .../logs-test:/var/log/togomcp` / `-v .../logs:/var/log/togomcp` |
| test suite | **83 passed** |

Follow-up to #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)