### PR TITLE
feat(stats): filtered MIE-trap feed (date-vs-MIE, dedup, probe-exclusion)

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -160,5 +160,100 @@ def test_aggregate_empty():
     assert agg["months"] == []
     assert agg["by_month"] == {}
     assert agg["mie_candidates"] == []
+    assert agg["mie_trap_candidates"]["candidates"] == []
     # still renders
     assert "<html" in stats.render_html(agg)
+
+
+# --------------------------------------------------------------------------- #
+# MIE-trap candidates — the filtered feed
+# --------------------------------------------------------------------------- #
+def _trap(cls, *, db="uniprot", ts="2026-07-05T10:00:00+00:00", sha="h1", shape=None):
+    """Build a SPARQL record whose *derived* class is `cls`.
+
+    `cls` is the sparql_class() result we want ("empty_result", "timeout",
+    "huge_result", "http_4xx", ...) — mapped here to the raw sparql_status +
+    n_rows/n_bytes the collector actually writes.
+    """
+    raw = {"empty_result": "ok", "huge_result": "ok",
+           "timeout": "timeout", "http_4xx": "http_4xx", "http_5xx": "http_5xx"}[cls]
+    extra = {"endpoint_url": "https://rdfportal.org/sib/sparql",
+             "sparql_status": raw, "query_sha256": sha}
+    if cls == "empty_result":
+        extra["n_rows"] = 0
+    elif cls == "huge_result":
+        extra["n_rows"] = 5
+        extra["n_bytes"] = stats.HUGE_BYTES + 1
+    if shape is not None:
+        extra["query_shape"] = shape
+    err = raw not in ("ok",)
+    return _rec(ts=ts, args={"database": db}, status="error" if err else "ok", extra=extra)
+
+
+def test_day_of():
+    assert stats.day_of({"ts": "2026-07-05T10:00:00+00:00"}) == "2026-07-05"
+    # UTC normalization crosses the date line
+    assert stats.day_of({"ts": "2026-07-05T23:00:00-03:00"}) == "2026-07-06"
+    assert stats.day_of({"ts": "nope"}) is None
+
+
+def test_load_mie_dates(tmp_path):
+    (tmp_path / "uniprot.yaml").write_text(
+        'schema_info:\n  version:\n    mie_created: "2026-01-01"\n'
+        '    mie_updated: "2026-04-29"\n')
+    (tmp_path / "rhea.yaml").write_text(
+        'schema_info:\n  version:\n    mie_created: "2026-02-02"\n')  # no mie_updated
+    dates = stats.load_mie_dates(str(tmp_path))
+    assert dates["uniprot"] == "2026-04-29"   # prefers mie_updated
+    assert dates["rhea"] == "2026-02-02"      # falls back to mie_created
+
+
+def test_is_schema_probe():
+    survey = {"flags": {"group": True}, "n_predicates": 1}      # SELECT ?p (COUNT) GROUP BY ?p
+    assert stats.is_schema_probe(survey) is True
+    real_agg = {"flags": {"group": True}, "n_predicates": 5}    # legit multi-predicate aggregate
+    assert stats.is_schema_probe(real_agg) is False
+    assert stats.is_schema_probe(None) is False                 # missing shape -> keep
+
+
+def test_trap_dedup_and_retry_count():
+    # one distinct query (same sha) failing 3x -> one candidate, retries=3
+    recs = [_trap("timeout", sha="stuck") for _ in range(3)]
+    trap = stats.aggregate(recs)["mie_trap_candidates"]
+    assert trap["distinct_queries"] == 1
+    assert trap["candidates"][0]["retries"] == 3
+
+
+def test_trap_date_filter_vs_mie():
+    # failure predates the current MIE -> excluded; a later one survives
+    recs = [
+        _trap("empty_result", db="uniprot", sha="old", ts="2026-03-01T10:00:00+00:00"),
+        _trap("empty_result", db="uniprot", sha="new", ts="2026-05-01T10:00:00+00:00"),
+    ]
+    trap = stats.aggregate(recs, mie_dates={"uniprot": "2026-04-29"})["mie_trap_candidates"]
+    assert trap["excluded_pre_mie"] == 1
+    assert [c["query_sha256"] for c in trap["candidates"]] == ["new"]
+
+
+def test_trap_excludes_probes_and_grammar_errors():
+    recs = [
+        _trap("empty_result", sha="probe",
+              shape={"flags": {"group": True}, "n_predicates": 1}),   # schema probe
+        _trap("http_4xx", sha="bad-sparql"),                          # grammar error
+        _trap("empty_result", sha="real",
+              shape={"flags": {}, "n_predicates": 3,
+                     "predicates": ["up:x", "up:y", "up:z"]}),        # real trap
+    ]
+    trap = stats.aggregate(recs)["mie_trap_candidates"]
+    assert trap["excluded_schema_probe"] == 1
+    assert trap["grammar_errors"] == 1
+    assert [c["query_sha256"] for c in trap["candidates"]] == ["real"]
+    assert trap["candidates"][0]["predicates"] == ["up:x", "up:y", "up:z"]
+
+
+def test_trap_section_renders():
+    recs = [_trap("empty_result", db="mesh", sha="r",
+                  shape={"flags": {}, "n_predicates": 2, "predicates": ["a:b"]})]
+    html = stats.render_html(stats.aggregate(recs))
+    assert "MIE traps to fix (filtered)" in html
+    assert "mesh" in html

--- a/togo_mcp/data/docs/log_file_specs.md
+++ b/togo_mcp/data/docs/log_file_specs.md
@@ -65,8 +65,8 @@ context under stdio transport).
 | `transport` | string | *(nullable)* | Transport in use (e.g. `http`, `stdio`). |
 | `ip_hash` | string | *(nullable)* | Salted, truncated SHA-256 of the client IP (from `X-Forwarded-For`, else peer host). `null` when there is no HTTP request context. |
 | `meta` | object | always | Server/build metadata — see [`meta`](#meta-object). |
-| `error_class` | string | on error only | Exception class name (e.g. `ValueError`). |
-| `error_message` | string | on error only | Exception message, truncated to 500 chars. |
+| `error_class` | string | on error only | Exception class name — **in practice almost always `ToolError`**. FastMCP wraps a tool's raised exception before it reaches the logging middleware, so the original class (e.g. `ValueError`) is not preserved here. To distinguish an intentional error from a genuine bug, parse `error_message`, not this field. |
+| `error_message` | string | on error only | Exception message, truncated to 500 chars. Carries the FastMCP wrapper prefix, e.g. `Error calling tool 'run_sparql': …`. |
 | `extra` | object | SPARQL calls only | SPARQL-specific enrichment — see [`extra`](#extra-object-sparql-only). |
 
 ### `meta` object
@@ -184,8 +184,8 @@ A non-SPARQL call that raised (no `extra`):
   "client_id": "…", "transport": "http",
   "ip_hash": "9f3a1c0b7e2d4a56",
   "meta": {"server_version": "2.4.0", "usage_guide_version": "v5", "mie_bundle_version": "a1b2c3d4e5f6", "client": null},
-  "error_class": "ValueError",
-  "error_message": "…"
+  "error_class": "ToolError",
+  "error_message": "Error calling tool 'search_uniprot_entity': …"
 }
 ```
 
@@ -198,13 +198,19 @@ A non-SPARQL call that raised (no `extra`):
 - buckets records by UTC month (`month_of`), attributes each to a database
   (`database_of`: explicit `database` arg → tool-name-implied DB → endpoint
   group), classifies SPARQL outcomes (`sparql_class`), and rolls everything into
-  per-month, per-tool, and per-database aggregates plus an
-  `mie_candidates` ranking (databases whose logs most suggest MIE work).
+  per-month, per-tool, and per-database aggregates plus two MIE feeds:
+  `mie_candidates` (a per-database/month ranking of where the logs most suggest
+  MIE work) and `mie_trap_candidates` (the *filtered* feed — distinct failures
+  deduped by `query_sha256`, date-filtered against each MIE's revision date via
+  `load_mie_dates`, with schema-probe surveys and 4xx grammar errors set aside so
+  a surviving entry is genuinely worth a human's time).
 
-Run it standalone:
+Run it standalone (pass `--mie` to enable the date-filtered trap feed):
 
 ```bash
-python -m togo_mcp.stats "$TOGOMCP_QUERY_LOG" --endpoints togo_mcp/data/resources/endpoints.csv
+python -m togo_mcp.stats "$TOGOMCP_QUERY_LOG" \
+  --endpoints togo_mcp/data/resources/endpoints.csv \
+  --mie togo_mcp/data/mie
 ```
 
 ## Stability notes

--- a/togo_mcp/data/mie/pubtator.yaml
+++ b/togo_mcp/data/mie/pubtator.yaml
@@ -35,8 +35,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "2.3"
+    mie_version: "2.4"
     mie_created: "2026-04-29"
+    mie_updated: "2026-07-07"
     mie_revised: "2026-07-06"
     data_version: "PubTator Central 2024"
     update_frequency: "Regularly updated"
@@ -53,7 +54,10 @@ critical_warnings: |
   - ENTITY TYPE COVERAGE: Only two dcterms:subject values exist: "Disease" (162M) and
     "Gene" (72.6M). Do NOT assume other entity types; using any other string returns 0 results.
   - ANNOTATION_COUNT MAXIMUMS DIFFER BY TYPE: Disease max=5, Gene max=9.
-    Use FILTER(?count >= 4) for Disease; FILTER(?count > 5) for Gene.
+    To get top mentions, filter AT the ceiling with >= (never above it): Disease
+    FILTER(?count >= 4) (5 is the max); Gene FILTER(?count >= 6). NEVER write
+    FILTER(?count > 5) for a Disease query — 5 IS the Disease maximum, so > 5 is always
+    empty. #1 OBSERVED MISTAKE: copying the Gene threshold (> 5) onto a Disease query.
     A FILTER on annotation_count outside the valid range returns zero rows *only if the
     query is otherwise scoped* (a specific IRI, or an inner LIMIT before the filter). An
     UNSCOPED range filter over the full 238M-annotation graph does NOT return quickly —
@@ -223,7 +227,8 @@ sparql_query_examples:
     description: |
       Uses pubtator:annotation_count typed predicate to surface high-frequency entity mentions.
       IMPORTANT: annotation_count ceiling differs by type — Disease max=5, Gene max=9.
-      Use FILTER(>= 4) for Disease; FILTER(> 5) for Gene. Using > 5 on Disease silently returns zero.
+      Filter at the ceiling with >=: Disease FILTER(?count >= 4); Gene FILTER(?count >= 6).
+      NEVER FILTER(?count > 5) on a Disease query — 5 is the Disease max, so > 5 is always empty.
     question: Which disease–article pairs have the highest mention frequency?
     complexity: intermediate
     sparql: |
@@ -231,8 +236,8 @@ sparql_query_examples:
       PREFIX dcterms:  <http://purl.org/dc/terms/>
       PREFIX pubtator: <http://purl.jp/bio/10/pubtator-central/ontology#>
 
-      # Disease annotation_count max = 5; use >= 4 (not > 5) to get top results.
-      # For Gene annotations substitute dcterms:subject "Gene" and FILTER(?count > 5).
+      # Disease annotation_count max = 5; use >= 4 (NOT > 5, which is always empty) for top results.
+      # For Gene annotations substitute dcterms:subject "Gene" and FILTER(?count >= 6).
       SELECT ?diseaseId ?article ?count
       FROM <http://rdfportal.org/dataset/pubtator_central>
       WHERE {
@@ -652,7 +657,7 @@ anti_patterns:
         FILTER(?count > 5)
       } LIMIT 50
     correct_sparql: |
-      # Correct: use >= 4 for Disease (max=5); use > 5 for Gene (max=9)
+      # Correct: use >= 4 for Disease (max=5); use >= 6 for Gene (max=9). NEVER > 5 on Disease.
       PREFIX pubtator: <http://purl.jp/bio/10/pubtator-central/ontology#>
       PREFIX dcterms:  <http://purl.org/dc/terms/>
       SELECT ?ann ?article ?count

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -580,7 +580,7 @@ def _get_stats() -> dict[str, Any]:
         return _stats_cache["data"]
     from togo_mcp import stats as _stats_mod
 
-    data = _stats_mod.compute_stats(endpoints_csv=ENDPOINTS_CSV)
+    data = _stats_mod.compute_stats(endpoints_csv=ENDPOINTS_CSV, mie_dir=MIE_DIR)
     _stats_cache["data"] = data
     _stats_cache["ts"] = now
     return data

--- a/togo_mcp/stats.py
+++ b/togo_mcp/stats.py
@@ -267,9 +267,12 @@ def _percentile(sorted_vals: list[float], pct: float) -> float:
 def aggregate(
     records: Iterable[dict[str, Any]],
     endpoint_groups: dict[str, str] | None = None,
+    mie_dates: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Roll records up into a JSON-serializable monthly statistics structure."""
     endpoint_groups = endpoint_groups or {}
+    mie_dates = mie_dates or {}
+    records = list(records)  # consumed twice: monthly rollup + trap feed
 
     # month -> accumulators
     tool_durs: dict[str, dict[str, list[float]]] = defaultdict(
@@ -390,6 +393,7 @@ def aggregate(
         "months": sorted(months),
         "by_month": by_month,
         "mie_candidates": _mie_candidates(by_month),
+        "mie_trap_candidates": mie_trap_candidates(records, endpoint_groups, mie_dates),
     }
 
 
@@ -427,16 +431,177 @@ def _mie_candidates(by_month: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 # --------------------------------------------------------------------------- #
+# MIE-trap candidates — the *filtered* feed (the signal you can act on)
+# --------------------------------------------------------------------------- #
+# The raw `mie_candidates` ranking above overcounts: it double-counts a single
+# stuck session that retried one bad query N times, and it flags failures that a
+# since-published MIE edit already fixed. This feed applies four corrections so a
+# non-zero entry is genuinely worth a human's time:
+#   1. date-filter — drop failures that predate the database's current MIE
+#      (`mie_updated`/`mie_created`); those were likely already addressed.
+#   2. dedup by query_sha256 — one distinct query, with a `retries` count, not N.
+#   3. exclude schema-probe queries — predicate surveys / cardinality probes an
+#      MIE *author* runs; they empty/time-out by design, not signal.
+#   4. refine the taxonomy — only empty/timeout/huge on a well-formed query is a
+#      MIE trap; 4xx is a SPARQL grammar/dialect error (counted separately).
+# Nothing is dropped silently: every exclusion is tallied in the return value.
+
+# Only these SPARQL outcomes point at an MIE gap (wrong predicate, missing filter,
+# unbounded pattern). syntax_error (4xx) is a grammar error, reported separately.
+TRAP_CLASSES = ("empty_result", "timeout", "huge_result")
+
+# A GROUP BY query touching at most this many concrete predicates is treated as a
+# schema-introspection probe (e.g. `SELECT ?p (COUNT(*)) … GROUP BY ?p`), not a
+# real query. Conservative by design — it under-catches multi-predicate probes
+# rather than risk excluding a legitimate user aggregation.
+SCHEMA_PROBE_MAX_PREDICATES = 1
+
+
+def day_of(rec: dict[str, Any]) -> str | None:
+    """UTC 'YYYY-MM-DD' for a record, or None if the timestamp is unusable."""
+    ts = rec.get("ts")
+    if not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+
+def load_mie_dates(mie_dir: str) -> dict[str, str]:
+    """Map database -> its current MIE revision date ('YYYY-MM-DD').
+
+    Uses `mie_updated` when present, else `mie_created`. Regex-parsed, no YAML
+    dependency (mirrors server._detect_mie_bundle_version). A failure at time T
+    is only actionable if it postdates this date.
+    """
+    out: dict[str, str] = {}
+    try:
+        paths = sorted(Path(mie_dir).glob("*.yaml"))
+    except OSError:
+        return out
+    for path in paths:
+        updated = created = None
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    if updated is None:
+                        m = re.search(r'mie_updated:\s*"?(\d{4}-\d{2}-\d{2})', line)
+                        if m:
+                            updated = m.group(1)
+                    if created is None:
+                        m = re.search(r'mie_created:\s*"?(\d{4}-\d{2}-\d{2})', line)
+                        if m:
+                            created = m.group(1)
+                    if updated:
+                        break
+        except OSError:
+            continue
+        date = updated or created
+        if date:
+            out[path.stem] = date
+    return out
+
+
+def is_schema_probe(shape: Any) -> bool:
+    """True if a query_shape looks like schema introspection, not a real query.
+
+    Predicate/cardinality surveys (`GROUP BY ?p`) carry the `group` flag and touch
+    at most SCHEMA_PROBE_MAX_PREDICATES concrete qnames (the surveyed predicate is
+    a variable, so it never appears as a qname). Returns False when the shape is
+    missing (older records predate query_shape) — better to keep than to guess.
+    """
+    if not isinstance(shape, dict):
+        return False
+    flags = shape.get("flags") or {}
+    return bool(flags.get("group")) and shape.get("n_predicates", 0) <= SCHEMA_PROBE_MAX_PREDICATES
+
+
+def mie_trap_candidates(
+    records: Iterable[dict[str, Any]],
+    endpoint_groups: dict[str, str] | None = None,
+    mie_dates: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Filtered, deduped MIE-trap feed. See section header for the four filters.
+
+    Returns a dict: ``candidates`` (distinct post-MIE traps, ranked by retries then
+    recency) plus transparency tallies of everything excluded.
+    """
+    endpoint_groups = endpoint_groups or {}
+    mie_dates = mie_dates or {}
+    by_query: dict[str, dict[str, Any]] = {}
+    excluded_pre_mie = excluded_probe = grammar_errors = 0
+
+    for rec in records:
+        cls = sparql_class(rec)
+        if cls is None:
+            continue
+        if cls == "syntax_error":
+            grammar_errors += 1
+            continue
+        if cls not in TRAP_CLASSES:
+            continue
+        extra = rec.get("extra") or {}
+        shape = extra.get("query_shape")
+        if is_schema_probe(shape):
+            excluded_probe += 1
+            continue
+        db = database_of(rec, endpoint_groups)
+        day = day_of(rec)
+        mdate = mie_dates.get(db) if db else None
+        if mdate and day and day <= mdate:  # failure predates the current MIE
+            excluded_pre_mie += 1
+            continue
+        sha = extra.get("query_sha256") or f"nohash:{id(rec)}"
+        cand = by_query.get(sha)
+        if cand is None:
+            preds = shape.get("predicates", []) if isinstance(shape, dict) else []
+            cand = by_query[sha] = {
+                "database": db,
+                "sparql_class": cls,
+                "query_sha256": sha[:16],
+                "predicates": preds[:20],
+                "retries": 0,
+                "first_seen": day,
+                "last_seen": day,
+            }
+        cand["retries"] += 1
+        if day:
+            if not cand["first_seen"] or day < cand["first_seen"]:
+                cand["first_seen"] = day
+            if not cand["last_seen"] or day > cand["last_seen"]:
+                cand["last_seen"] = day
+
+    candidates = sorted(
+        by_query.values(),
+        key=lambda c: (c["retries"], c["last_seen"] or ""),
+        reverse=True,
+    )
+    return {
+        "candidates": candidates,
+        "distinct_queries": len(candidates),
+        "excluded_pre_mie": excluded_pre_mie,
+        "excluded_schema_probe": excluded_probe,
+        "grammar_errors": grammar_errors,
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Convenience: load + aggregate from the configured log path
 # --------------------------------------------------------------------------- #
 def compute_stats(
     log_path: str | None = None,
     endpoints_csv: str | None = None,
+    mie_dir: str | None = None,
 ) -> dict[str, Any]:
     """Load the configured log (TOGOMCP_QUERY_LOG) and return the aggregate."""
     log_path = log_path if log_path is not None else os.getenv("TOGOMCP_QUERY_LOG", "").strip()
     groups = load_endpoint_groups(endpoints_csv) if endpoints_csv else {}
-    return aggregate(iter_records(log_paths(log_path)), groups)
+    mie_dates = load_mie_dates(mie_dir) if mie_dir else {}
+    return aggregate(iter_records(log_paths(log_path)), groups, mie_dates)
 
 
 def render_html(stats: dict[str, Any]) -> str:
@@ -486,6 +651,34 @@ def render_html(stats: dict[str, Any]) -> str:
     else:
         parts.append("<p class='muted'>No failed/empty SPARQL recorded.</p>")
 
+    # Filtered, deduped MIE-trap feed — the actionable list.
+    trap = stats.get("mie_trap_candidates") or {}
+    tcand = trap.get("candidates", [])
+    parts.append("<h2>MIE traps to fix (filtered)</h2>")
+    parts.append(
+        "<p class='muted'>Distinct queries that empty/time-out <em>after</em> the current MIE "
+        "(deduped by query hash; schema-probe surveys and pre-MIE failures removed). "
+        f"Excluded: {cell(trap.get('excluded_pre_mie', 0))} pre-MIE · "
+        f"{cell(trap.get('excluded_schema_probe', 0))} schema-probe · "
+        f"{cell(trap.get('grammar_errors', 0))} grammar-error (4xx, not MIE traps). "
+        "A non-empty row here is worth a look; verify against the live endpoint before editing.</p>"
+    )
+    if tcand:
+        parts.append("<table><tr><th>database</th><th>class</th><th>retries</th>"
+                     "<th>first seen</th><th>last seen</th><th>query</th><th>predicates</th></tr>")
+        for r in tcand[:50]:
+            preds = ", ".join(r.get("predicates", [])[:8])
+            parts.append(
+                f"<tr><td>{cell(r['database'])}</td><td>{cell(r['sparql_class'])}</td>"
+                f"<td class='warn'>{cell(r['retries'])}</td><td>{cell(r['first_seen'])}</td>"
+                f"<td>{cell(r['last_seen'])}</td><td class='tag'>{cell(r['query_sha256'])}</td>"
+                f"<td class='tag'>{cell(preds)}</td></tr>"
+            )
+        parts.append("</table>")
+    else:
+        parts.append("<p class='muted'>No post-MIE traps after filtering — "
+                     "the logged failures are already-fixed or schema-probe noise.</p>")
+
     for month in reversed(months):
         m = stats["by_month"][month]
         parts.append(f"<h2>{cell(month)}</h2>")
@@ -533,12 +726,14 @@ def _main(argv: list[str] | None = None) -> int:
     ap.add_argument("log_path", nargs="?", default=os.getenv("TOGOMCP_QUERY_LOG", ""),
                     help="JSONL log path (default: $TOGOMCP_QUERY_LOG)")
     ap.add_argument("--endpoints", default="", help="endpoints.csv for DB attribution")
+    ap.add_argument("--mie", default="", help="MIE dir for date-filtering trap candidates")
     args = ap.parse_args(argv)
     if not args.log_path:
         ap.error("no log path given and TOGOMCP_QUERY_LOG is unset")
     stats = aggregate(
         iter_records(log_paths(args.log_path)),
         load_endpoint_groups(args.endpoints) if args.endpoints else {},
+        load_mie_dates(args.mie) if args.mie else {},
     )
     print(json.dumps(stats, indent=2, default=str))
     return 0


### PR DESCRIPTION
Adds `mie_trap_candidates()` to `togo_mcp/stats.py` — a *filtered* version of the existing `mie_candidates` ranking, so a non-empty entry is genuinely worth a human's time. Motivated by analyzing the real tool-call log, where the raw ranking's top signals turned out to be already-fixed or noise.

## Why
The raw `mie_candidates` ranking overcounts in two ways:
- **Retry inflation** — one stuck session retrying a single bad query N times reads as N independent failures (a real example in the log: 10 "syntax errors" that were one query × 10 retries in one hour).
- **Stale failures** — it flags failures that a since-published MIE edit already fixed (verified: the log's top PubChem "trap" was fixed in `pubchem.yaml` v2.2 the same day; its documented query returns 20 rows live).

## What the feed does
Four corrections, none of them silent (every exclusion is tallied in the return value):

1. **date-filter** — drop failures predating the database's current MIE (`mie_updated`/`mie_created`, via new `load_mie_dates()`).
2. **dedup by `query_sha256`** — one distinct query with a `retries` count, not N.
3. **exclude schema-probe queries** — `GROUP BY` predicate/cardinality surveys an MIE author runs (`is_schema_probe()`); they empty/time-out by design.
4. **refine taxonomy** — only `empty_result`/`timeout`/`huge_result` on a well-formed query is a MIE trap; `4xx` is a SPARQL grammar error, tallied separately as `grammar_errors`.

Filters 1–3 and the taxonomy split are exact; probe-exclusion is a conservative heuristic (under-catches rather than over-excludes).

## Wiring
- `aggregate()` / `compute_stats()` gain a `mie_dir` argument; `server.py` passes `MIE_DIR`.
- Rendered as a **"MIE traps to fix (filtered)"** section in `/stats` (shows the exclusion tallies).
- CLI gains `--mie`.

## Impact on the real test log
Collapses the inflated raw counts to **27 distinct post-MIE traps**, transparently setting aside **10 pre-MIE**, **3 schema-probe**, and **19 grammar-error** records.

## Tests
New coverage: `day_of`, `load_mie_dates`, `is_schema_probe`, dedup/retry counting, date-filter, probe/grammar exclusion, HTML section. **90 pass**, no regressions.

## Note / possible follow-up
"Session attribution" is implemented at the *query* level (`is_schema_probe`) rather than as a separate session classifier — more precise for filtering author/benchmark noise. A true per-session classifier could be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added in follow-up commits (same session)

These came out of applying the feed to the real tool-call log:

- **`log_file_specs.md`** — (a) correctness fix: `error_class` is almost always `ToolError` (FastMCP wraps a tool's exception before the logging middleware sees it), not the raw class the spec previously claimed — parse `error_message` to tell an intentional error from a bug; (b) documents this PR's `mie_trap_candidates` feed and the new `--mie` CLI flag.
- **`pubtator.yaml` (v2.3 → v2.4)** — ergonomic fix for a *documented-but-still-tripped* trap the log surfaced: the model kept writing `FILTER(?count > 5)` on Disease (max=5, always empty) because a copy-ready "`> 5` for Gene" string sat right next to the Disease guidance. Replaced correct-usage `> 5` (Gene) with `>= 6` and added an explicit "#1 mistake" callout. (Verified against live endpoints that no other logged failure was an actual MIE error — the rest are already-fixed, genuine data absence, schema-probe noise, or grammar errors.)