### PR TITLE
chore(docker): pin base image by digest for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a lightweight Python base image
-FROM docker.io/astral/uv:python3.12-bookworm-slim
+FROM docker.io/astral/uv:python3.12-bookworm-slim@sha256:5d275ca5f0da33c3368ac8fbb85fafabad023b3b8a7cff39a94ac0baecfd9a50
 
 # Install tzdata so the TZ env var (set in compose.yaml) resolves correctly
 # instead of silently falling back to UTC.


### PR DESCRIPTION
## Summary

Pin the `astral/uv` base image by digest so the build's last unpinned input is fixed:

```dockerfile
FROM docker.io/astral/uv:python3.12-bookworm-slim@sha256:5d275ca5f0da33c3368ac8fbb85fafabad023b3b8a7cff39a94ac0baecfd9a50
```

The readable tag is kept for humans; the digest is authoritative. This is the **exact base image the current prod build (`809e81b42988`) was built on**, so pinning changes nothing about what's deployed — it just prevents the mutable `python3.12-bookworm-slim` tag from drifting (newer `uv`, Python patch, or Debian packages) under the same commit on future rebuilds.

Together with `uv.lock --frozen` for dependencies, the same commit now produces the same image.

## Trade-off
A pinned digest never auto-updates. When a newer base is wanted, bump the `@sha256:` deliberately (a Renovate/Dependabot rule can open those PRs). That's the intended behavior — base updates become explicit rather than silent.

## Verification
- `./scripts/deploy.sh test` builds green against the pinned base (confirmed on vs94).
- `apt-get`/tzdata step unchanged (correct for bookworm-slim); only line 2 changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)