### PR TITLE
chore: cache-optimize Docker build, refresh base digest, add self-hosted Renovate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,4 @@ tmp/
 .DS_Store
 LICENSE.md
 
-togo_mcp.egg_info/
+togo_mcp.egg-info/

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,39 @@
+name: Renovate
+
+# Self-hosted Renovate — runs the Renovate CLI on a schedule and reads ./renovate.json.
+# No third-party GitHub App: the compute is this repo's Actions runner.
+# NOTE: scheduled runs only fire from the DEFAULT branch, so this file must be on main
+# to run on cron. Use the "Run workflow" button (workflow_dispatch) to trigger manually.
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'        # 02:00 UTC every Monday — this cron IS the cadence
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level (info | debug)
+        required: false
+        default: info
+
+permissions:
+  contents: write               # create/update branches
+  pull-requests: write          # open dependency PRs
+  issues: write                 # maintain the Dependency Dashboard issue
+
+# Never run two Renovate passes at once.
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Renovate
+        uses: renovatebot/github-action@v41   # Renovate self-updates this pin via the github-actions manager
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: 'false'         # renovate.json already exists — skip the onboarding PR
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a lightweight Python base image
-FROM docker.io/astral/uv:python3.12-bookworm-slim@sha256:5d275ca5f0da33c3368ac8fbb85fafabad023b3b8a7cff39a94ac0baecfd9a50
+FROM docker.io/astral/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
 
 # Install tzdata so the TZ env var (set in compose.yaml) resolves correctly
 # instead of silently falling back to UTC.
@@ -14,10 +14,16 @@ WORKDIR /app
 # Set TOGOMCP_DIR only if you need to override with external data.
 # ENV TOGOMCP_DIR=/app/togo_mcp/data
 
-# Copy the entire project into the container
-COPY . .
+# Install dependencies FIRST, in a layer keyed only on the lockfiles. This stays
+# cached across source-only changes — COPY . . below busts the project-install
+# layer, not this dependency layer, so deps don't reinstall on every code edit.
 # --frozen: install exactly what uv.lock pins; fail the build if the lock is
 # stale vs pyproject.toml instead of silently re-resolving to newer versions.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project
+
+# Copy the rest of the project, then install the package itself.
+COPY . .
 RUN uv sync --frozen
 # Expose the port your FastAPI/Uvicorn server listens on (adjust if needed)
 EXPOSE 8000

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "Container base image digest bumps — the reason this config exists. When the astral/uv base tag moves, Renovate opens ONE PR with the new @sha256 digest. Workflow: review it, run scripts/deploy.sh test on the host to validate the new base builds green, then promote with scripts/deploy.sh prod. Deliberately NOT automerged: production is deployed by hand and there is no CI build to gate on, so a human must run the test container first.",
+      "matchDatasources": ["docker"],
+      "groupName": "container base image",
+      "addLabels": ["docker"]
+    },
+    {
+      "description": "Group non-major Python dependency updates (fastmcp / httpx / pydantic / pyyaml) into a single PR to keep the noise down; majors still come as their own PR.",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python dependencies (non-major)"
+    }
+  ]
+}


### PR DESCRIPTION
Two related chores, one PR. No app code changes.

## 1. Docker build (`Dockerfile`, `.dockerignore`)
- **Layer-caching split** — `COPY pyproject.toml uv.lock` + `uv sync --frozen --no-install-project` (deps layer, cached unless the lockfiles change), then `COPY . .` + `uv sync --frozen` (project layer). Source-only edits (like MIE files) stop reinstalling dependencies. Behavior is identical; safe here (static version, no workspace members / local-path sources).
- **Refresh pinned base digest** — bump the `astral/uv:python3.12-bookworm-slim` digest from `5d275ca5…` (≈5 months stale, inherited from the host's old local image) to the current manifest, picking up Debian/uv patches. This is a real base change: **validate with `scripts/deploy.sh test` before promoting to prod.** Rollback digest if needed is `5d275ca5…` (what prod runs today).
- **`.dockerignore` fix** — `togo_mcp.egg_info/` → `togo_mcp.egg-info/` (setuptools writes a hyphen; the underscore never matched).

## 2. Self-hosted Renovate (`renovate.json`, `.github/workflows/renovate.yml`)
Turns silent base-image drift into reviewed, tested bump PRs — without installing the third-party Mend app. A weekly Actions cron runs the Renovate CLI (built-in `GITHUB_TOKEN`, scoped to this repo). Opens grouped PRs for the base-image digest and Python deps; **not automerged** (prod deploy is manual and gated by `deploy.sh test`).

**Activation (one-time, after this merges to `main`):**
1. *Settings → Actions → General →* enable **"Allow GitHub Actions to create and approve pull requests."**
2. Actions → **Renovate → Run workflow** for an immediate first pass (creates the Dependency Dashboard + any due PRs).

Scheduled runs only fire from the default branch, which is why the workflow needs to land on `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)