### PR TITLE
fix(ci): pin renovate action to an existing release tag (v46.1.18)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Renovate
-        uses: renovatebot/github-action@v41   # Renovate self-updates this pin via the github-actions manager
+        uses: renovatebot/github-action@v46.1.18   # exact release tag (no moving major tag is published); Renovate keeps this updated once running
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:


### PR DESCRIPTION
The self-hosted Renovate workflow failed at action resolution:

> Error: Unable to resolve action `renovatebot/github-action@v41`, unable to find version `v41`

`renovatebot/github-action` publishes only exact `vX.Y.Z` tags (no moving major like `v41`/`v46`), so the guessed `@v41` doesn't exist. Pinned to **`v46.1.18`** (current latest). Renovate will keep it updated via the github-actions manager once running.

Note: the failed run showed `PullRequests: write` on the token, so the create-PR permission looks granted — the next run should get past action resolution and actually attempt Renovate. If it then errors with "GitHub Actions is not permitted to create or approve pull requests," that's the org/repo Actions setting (admin-only) and we pivot to running Renovate from vs94 with your PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)