### PR TITLE
chore(renovate): silence the vulnerability-alerts warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   ],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Container base image digest bumps — the reason this config exists. When the astral/uv base tag moves, Renovate opens ONE PR with the new @sha256 digest. Workflow: review it, run scripts/deploy.sh test on the host to validate the new base builds green, then promote with scripts/deploy.sh prod. Deliberately NOT automerged: production is deployed by hand and there is no CI build to gate on, so a human must run the test container first.",


### PR DESCRIPTION
Sets `vulnerabilityAlerts.enabled: false` in `renovate.json`.

Renovate's self-hosted run warned every time:

> ⚠️ WARN: Cannot access vulnerability alerts. Please ensure permissions have been granted.

The Actions `GITHUB_TOKEN` can't read Dependabot alerts (needs admin-enabled security features + a broader token), so the feature can't work at our access level and just nagged in the "Repository Problems" section of the Dependency Dashboard (#126). Disabling it stops the attempt and clears the warning. **Regular scheduled update PRs are unaffected** — this only turns off CVE-driven fast-tracking, which does little for our `>=`-range dependencies anyway.

Re-enable later if a `dbcls` admin turns on Dependabot alerts and supplies a token that can read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)