### PR TITLE
chore(ci): bump workflow actions by hand; disable Renovate github-actions manager

### DIFF
--- a/.github/workflows/package-skills.yml
+++ b/.github/workflows/package-skills.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       skills: ${{ steps.list.outputs.skills }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: list
         name: List packageable skills as a JSON array
         run: |
@@ -49,7 +49,7 @@ jobs:
       matrix:
         skill: ${{ fromJson(needs.discover.outputs.skills) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build ${{ matrix.skill }}.skill
         env:
@@ -63,7 +63,7 @@ jobs:
           ls -la "dist/${SKILL}.skill"
 
       - name: Upload ${{ matrix.skill }}.skill as its own artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.skill }}.skill
           path: dist/${{ matrix.skill }}.skill
@@ -71,6 +71,6 @@ jobs:
 
       - name: Attach ${{ matrix.skill }}.skill to the Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/${{ matrix.skill }}.skill

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   ],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
+  "github-actions": {
+    "description": "Disabled on purpose. Renovate here runs on the repo's Actions runner with the default GITHUB_TOKEN, which GitHub forbids from pushing changes to files under .github/workflows/ (the 'workflows' scope cannot be granted to GITHUB_TOKEN). So these PRs can never be created and only produced failed 'remote rejected' pushes. Bump action versions in .github/workflows/*.yml by hand. To re-enable, give the Renovate workflow a PAT or GitHub-App token with 'workflows: write' (see renovate.yml).",
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
     "enabled": false
   },


### PR DESCRIPTION
## Why

The 3 pending GitHub Actions bumps on Dependency Dashboard #126 could never be opened by Renovate. Root cause (confirmed in the Renovate debug log):

```
[remote rejected] refusing to allow a GitHub App to create or update workflow
`.github/workflows/package-skills.yml` without `workflows` permission
```

Self-hosted Renovate runs on this repo's Actions runner with the default `GITHUB_TOKEN`, and **GitHub forbids `GITHUB_TOKEN` from pushing changes to files under `.github/workflows/`** — the `workflows` scope cannot be granted to it. So every attempt to create these branches failed at push time (`result: no-work`), regardless of the "Allow GitHub Actions to create and approve pull requests" setting (which is correctly enabled and still needed for non-workflow update PRs).

## What this does

- **Bump the three action majors by hand** in `.github/workflows/package-skills.yml`:
  - `actions/checkout` v4 → v7
  - `actions/upload-artifact` v4 → v7
  - `softprops/action-gh-release` v2 → v3
- **Disable the `github-actions` manager** in `renovate.json` (with an inline comment explaining the token limitation and how to re-enable via a PAT / GitHub-App token carrying `workflows: write`), so Renovate stops re-listing these and producing failed pushes.

Docker base-image and Python dependency updates are unaffected — those don't touch workflow files and are still handled by Renovate + `GITHUB_TOKEN`.

## Verification

- `renovate.json` validated as JSON; `package-skills.yml` validated as YAML.
- Target tags confirmed against upstream latest releases: checkout `v7.0.0`, upload-artifact `v7.0.1`, action-gh-release `v3.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)