### PR TITLE
docs(intro): remove NBRC from the Available Databases list

### DIFF
--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1078,10 +1078,6 @@
         <div class="db-card-desc">Culture media database from DSMZ with 3,289 standardized recipes for bacteria, archaea, fungi, and microalgae, including ingredients and growth conditions.</div>
       </div>
       <div class="db-card">
-        <div class="db-card-name">NBRC</div>
-        <div class="db-card-desc">Culture catalogue of Japan's NITE Biological Resource Center: 23,987 preserved microbial strains (bacteria, archaea, fungi, yeasts, algae, phages) with cultivation conditions, isolation source and geographic origin, biosafety level, and links to NCBI Taxonomy, INSDC genomes, and PubMed.</div>
-      </div>
-      <div class="db-card">
         <div class="db-card-name">NANDO</div>
         <div class="db-card-desc">Japanese intractable (rare) disease ontology with 2,777 disease classes, multilingual labels, and cross-references to international disease ontologies.</div>
       </div>


### PR DESCRIPTION
Removes the **NBRC** `db-card` from the public landing page (`togo_mcp/data/docs/togomcp-intro.html`), per request.

Scope is deliberately limited to the intro page only — the `nbrc.yaml` MIE file and the `nbrc` row in `endpoints.csv` are left untouched, so NBRC remains a live served database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)