### PR TITLE
benchmark(qa): add questions 071-075 (balanced 75-question milestone)

### DIFF
--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -96,39 +96,39 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 70
+total_questions: 75
 
 question_types:
   yes_no:
-    count: 14
-    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069']
-    status: 'ok'  # 14 uses - Q069 (most-represented NBRC archaeal type-strain class is methanogenic; nbrc+taxonomy)
+    count: 15
+    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069', '074']
+    status: 'ok'  # 15 uses - Q074 (von Willebrand disease designated as 3 NANDO entries each with distinct MONDO map; nando+mondo)
 
   factoid:
-    count: 14
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066']
-    status: 'ok'  # 14 uses - Q066 (LIM-domain family top phosphopeptide protein via jPOST)
+    count: 15
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066', '071']
+    status: 'ok'  # 15 uses - Q071 (IgE-binding-protein gene with most MSM/Ms variants; uniprot+ensembl+mogplus, first mogplus question)
 
   list:
-    count: 14
-    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068']
-    status: 'ok'  # 14 uses - Q068 (retinoids with MassBank reference spectra)
+    count: 15
+    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068', '073']
+    status: 'ok'  # 15 uses - Q073 (mouse strains carrying a Col19a1 missense variant; ensembl+mogplus)
 
   summary:
-    count: 14
-    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070']
-    status: 'ok'  # 14 uses - Q070 (Alport syndrome variant-interpretation landscape; medgen+clinvar+ncbigene) completes the balanced 70-question milestone (all five types at 14)
+    count: 15
+    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070', '075']
+    status: 'ok'  # 15 uses - Q075 (integrated fosfomycin profile: chemistry + drug status + AMR surveillance; amrportal+chebi+chembl) completes the balanced 75-question milestone (all five types at 15)
 
   choice:
-    count: 14
-    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067']
-    status: 'ok'  # 14 uses - Q067 (human prenyltransferase EC with widest BRENDA organism breadth)
+    count: 15
+    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067', '072']
+    status: 'ok'  # 15 uses - Q072 (most-represented cyanobacterial genus in NBRC holdings; nbrc+taxonomy)
 
 databases:
   uniprot:
-    count: 33
-    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067']
-    status: 'ok'  # At 49.3%, below 70% cap
+    count: 34
+    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067', '071']
+    status: 'ok'  # At 47.9% (34/71), below 70% cap
 
   rhea:
     count: 11
@@ -146,13 +146,13 @@ databases:
     status: 'ok'
 
   chembl:
-    count: 8
-    questions: ['005', '006', '007', '009', '021', '039', '041', '049']
+    count: 9
+    questions: ['005', '006', '007', '009', '021', '039', '041', '049', '075']
     status: 'ok'
 
   chebi:
-    count: 9
-    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068']
+    count: 10
+    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068', '075']
     status: 'ok'
 
   reactome:
@@ -161,9 +161,14 @@ databases:
     status: 'ok'
 
   ensembl:
-    count: 4
-    questions: ['007', '023', '037', '038']
+    count: 6
+    questions: ['007', '023', '037', '038', '071', '073']
     status: 'ok'
+
+  mogplus:
+    count: 2
+    questions: ['071', '073']
+    status: 'ok'  # mouse genome variation / MoG+; Q071 (factoid) + Q073 (list)
 
   glycosmos:
     count: 4
@@ -171,8 +176,8 @@ databases:
     status: 'ok'
 
   nando:
-    count: 2
-    questions: ['013', '042']
+    count: 3
+    questions: ['013', '042', '074']
     status: 'ok'
 
   medgen:
@@ -191,18 +196,18 @@ databases:
     status: 'ok'
 
   taxonomy:
-    count: 8
-    questions: ['014', '016', '018', '020', '034', '048', '050', '069']
+    count: 9
+    questions: ['014', '016', '018', '020', '034', '048', '050', '069', '072']
     status: 'ok'
 
   nbrc:
-    count: 1
-    questions: ['069']
-    status: 'ok'  # newly added life-science DB (NITE Biological Resource Center culture catalogue); first use Q069
+    count: 2
+    questions: ['069', '072']
+    status: 'ok'  # NITE Biological Resource Center culture catalogue; Q069 (yes_no) + Q072 (choice)
 
   mondo:
-    count: 3
-    questions: ['010', '025', '036']
+    count: 4
+    questions: ['010', '025', '036', '074']
     status: 'ok'
 
   ncbigene:
@@ -221,8 +226,8 @@ databases:
     status: 'ok'
 
   amrportal:
-    count: 3
-    questions: ['018', '034', '050']
+    count: 4
+    questions: ['018', '034', '050', '075']
     status: 'ok'
 
   pubmed:
@@ -277,15 +282,15 @@ databases:
 
 multi_database_metrics:
   two_plus_databases:
-    count: 70
-    percentage: 100.0  # 70/70 (Q070 is 3-DB: medgen + clinvar + ncbigene)
+    count: 75
+    percentage: 100.0  # 75/75 (Q075 is 3-DB: amrportal + chebi + chembl)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
-    count: 24
-    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070']
-    percentage: 34.3  # 24/70 (Q070 is 3-DB: medgen + clinvar + ncbigene)
+    count: 26
+    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070', '071', '075']
+    percentage: 34.7  # 26/75 (Q075 is 3-DB: amrportal + chebi + chembl)
     target: '>= 20%'
     status: 'excellent'
 
@@ -360,6 +365,11 @@ keywords_used:
   - 'KW-0845'  # Vitamin A (Q068)
   - 'KW-0484'  # Methanogenesis (Q069)
   - 'KW-0023'  # Alport syndrome (Q070)
+  - 'KW-0389'  # IgE-binding protein (Q071)
+  - 'KW-0602'  # Photosynthesis (Q072)
+  - 'KW-0517'  # Myogenesis (Q073)
+  - 'KW-0852'  # von Willebrand disease (Q074)
+  - 'KW-0929'  # Antimicrobial (Q075)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_071.yaml
+++ b/benchmark/questions/question_071.yaml
@@ -1,0 +1,253 @@
+---
+id: question_071
+type: factoid
+body: >-
+  Among the mouse genes whose protein products are classified as IgE-binding
+  proteins, which single gene carries the largest number of recorded genomic
+  sequence variants in the Japanese wild-derived inbred mouse strain MSM/Ms,
+  and how many such variants are recorded for that strain?
+
+inspiration_keyword:
+  keyword_id: KW-0389
+  name: IgE-binding protein
+  category: Molecular function
+
+togomcp_databases_used:
+  - uniprot
+  - ensembl
+  - mogplus
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Two searches aimed at answering the question directly: (1) "MSM/Ms mouse
+    strain Ms4a2 Fcer2 IgE-binding protein gene sequence variants"; (2) "MSM/Ms
+    wild-derived mouse strain genome variation Fc epsilon receptor mast cell
+    genes strain-specific variants". Both intended to surface a per-gene,
+    per-strain variant tally.
+  result: |
+    Both queries returned 0 articles (total_count 0). No publication enumerates
+    how many genomic variants the MSM/Ms strain carries in each IgE-binding-protein
+    gene, and no source ranks these genes by MSM/Ms variant burden. The answer is
+    a count computed over the current mouse-variation callset joined to a UniProt
+    functional-keyword gene set and cannot be recovered from the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Reviewed mouse (taxon 10090) proteins classified with the keyword
+      "IgE-binding protein" (KW-0389), with their gene names and, where present,
+      the Ensembl gene cross-reference. Defines the gene set.
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+      PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?geneName ?ensGene
+      WHERE {
+        ?protein up:organism taxon:10090 ;
+                 up:classifiedWith keywords:389 ;
+                 up:reviewed 1 ;
+                 up:encodedBy ?g .
+        ?g skos:prefLabel ?geneName .
+        OPTIONAL {
+          ?protein rdfs:seeAlso ?tx .
+          ?tx up:database <http://purl.uniprot.org/database/Ensembl> ;
+              up:transcribedFrom ?ensGene .
+        }
+      }
+      ORDER BY ?geneName
+    result_count: 7
+
+  - query_number: 2
+    database: ensembl
+    description: >-
+      Resolve the two genes lacking a UniProt Ensembl cross-reference (Lgals3
+      MGI:96778, Iap MGI:96306) to their mouse Ensembl genes via the MGI
+      rdfs:seeAlso link. Lgals3 resolves to ENSMUSG00000050335; MGI:96306 (Iap)
+      has no mouse Ensembl gene.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      SELECT ?gene ?label ?mgi WHERE {
+        VALUES ?mgi { <http://identifiers.org/mgi/MGI:96778>
+                      <http://identifiers.org/mgi/MGI:96306> }
+        ?gene a <http://rdf.ebi.ac.uk/terms/ensembl/EnsemblGene> ;
+              rdfs:seeAlso ?mgi ;
+              rdfs:label ?label .
+        FILTER(STRSTARTS(STR(?gene),
+          "http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG"))
+      }
+    result_count: 1
+
+  - query_number: 3
+    database: mogplus
+    description: >-
+      Per-gene count of distinct variants carried by strain MSM/Ms (i.e. with a
+      genotype call for MSM_Ms) overlapping each of the six Ensembl-mapped
+      IgE-binding-protein genes. The strain anchor pins a single release cohort
+      (nrel = 1 for every gene), so no cross-release double-counting occurs.
+      Results: Ms4a2 (ENSMUSG00000024680) 86, Fcer2 (ENSMUSG00000005540) 69,
+      Lgals3 (ENSMUSG00000050335) 2, Fcgr4 (ENSMUSG00000059089) 1; Fcer1a
+      (ENSMUSG00000005339) and Fcer1g (ENSMUSG00000058715) return no rows (0).
+    query: |
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      PREFIX vcf: <http://genome-variation.org/resource/vcf#>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+
+      SELECT ?gene (COUNT(DISTINCT ?variant) AS ?n)
+             (COUNT(DISTINCT ?rel) AS ?nrel)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          VALUES ?gene {
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000005339>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000058715>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000005540>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000059089>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000024680>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000050335>
+          }
+          ?variant mogplus:overlaps_gene ?gene ;
+                   vcf:has_genotype_call ?call .
+          ?call med2rdf:sample
+                <http://identifiers.org/mogplus/bioresource/MSM_Ms> .
+          BIND(REPLACE(STR(?variant),
+            "^http://identifiers.org/mogplus/([^/]+)/.*$", "$1") AS ?rel)
+        }
+      }
+      GROUP BY ?gene
+      ORDER BY DESC(?n)
+    result_count: 4
+
+  - query_number: 4
+    database: mogplus
+    description: >-
+      Arithmetic-verification query (Rule 3) for query 3: a single
+      COUNT(DISTINCT ?variant) over the same six-gene set and strain. Returns
+      158, exactly matching the sum of the per-gene counts (86 + 69 + 2 + 1 = 158),
+      confirming no variant overlaps more than one of these genes.
+    query: |
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      PREFIX vcf: <http://genome-variation.org/resource/vcf#>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+
+      SELECT (COUNT(DISTINCT ?variant) AS ?total)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          VALUES ?gene {
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000005339>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000058715>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000005540>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000059089>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000024680>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000050335>
+          }
+          ?variant mogplus:overlaps_gene ?gene ;
+                   vcf:has_genotype_call ?call .
+          ?call med2rdf:sample
+                <http://identifiers.org/mogplus/bioresource/MSM_Ms> .
+        }
+      }
+    result_count: 1
+
+  - query_number: 5
+    database: mogplus
+    description: >-
+      Presence check confirming that Fcer1a and Fcer1g are in the callset even
+      though MSM/Ms carries none of their variants: distinct variants overlapping
+      each gene in the v3 cohort (any strain). Returns Fcer1a 40, Fcer1g 25.
+    query: |
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      SELECT ?gene (COUNT(DISTINCT ?variant) AS ?nv3any) WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          VALUES ?gene {
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000005339>
+            <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000058715>
+          }
+          ?variant mogplus:overlaps_gene ?gene .
+          FILTER(STRSTARTS(STR(?variant),
+            "http://identifiers.org/mogplus/v3/"))
+        }
+      } GROUP BY ?gene
+    result_count: 2
+
+rdf_triples: |
+  @prefix up: <http://purl.uniprot.org/core/> .
+  @prefix keywords: <http://purl.uniprot.org/keywords/> .
+  @prefix taxon: <http://purl.uniprot.org/taxonomy/> .
+  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix mogplus: <http://identifiers.org/mogplus/ontology#> .
+  @prefix gvo: <http://genome-variation.org/resource#> .
+  @prefix vcf: <http://genome-variation.org/resource/vcf#> .
+  @prefix med2rdf: <http://med2rdf.org/ontology/med2rdf#> .
+  @prefix brso: <http://purl.jp/bio/10/brso/> .
+  @prefix mogbs: <http://identifiers.org/mogplus/bioresource/> .
+  @prefix ensg: <http://rdf.ebi.ac.uk/resource/ensembl/> .
+
+  <http://purl.uniprot.org/uniprot/P20490> up:classifiedWith keywords:389 .
+  # Database: UniProt | Query: 1 | Comment: the reviewed mouse protein P20490 (Ms4a2, FcERI beta-subunit) is classified as an IgE-binding protein (KW-0389)
+  <http://purl.uniprot.org/uniprot/P20490> up:organism taxon:10090 .
+  # Database: UniProt | Query: 1 | Comment: P20490 is a Mus musculus protein, so its gene is in scope for the mouse-strain variant question
+  <http://purl.uniprot.org/uniprot/P20490> up:encodedBy _:gMs4a2 .
+  # Database: UniProt | Query: 1 | Comment: P20490 is encoded by the Ms4a2 gene (skos:prefLabel "Ms4a2")
+  ensg:ENSMUSG00000024680 rdfs:label "Ms4a2" .
+  # Database: Ensembl | Query: 1 | Comment: Ms4a2 maps to mouse Ensembl gene ENSMUSG00000024680, the coordinate-overlap key used by the variant resource
+  ensg:ENSMUSG00000050335 rdfs:seeAlso <http://identifiers.org/mgi/MGI:96778> .
+  # Database: Ensembl | Query: 2 | Comment: Lgals3 (no UniProt Ensembl xref) resolves to ENSMUSG00000050335 via its MGI:96778 link
+  mogbs:MSM_Ms a brso:BiologicalResource .
+  # Database: MoG+ | Query: 3 | Comment: MSM/Ms is one of the 62 genotyped mouse strains; it anchors the genotype-call join and pins a single release cohort
+  mogbs:MSM_Ms rdfs:label "MSM/Ms" .
+  # Database: MoG+ | Query: 3 | Comment: strain label confirming the anchor is the Japanese wild-derived strain MSM/Ms
+  <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C> a gvo:SNV .
+  # Database: MoG+ | Query: 3 | Comment: an example variant overlapping Ms4a2 on chromosome 19 (release v3) carried by MSM/Ms
+  <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C> mogplus:overlaps_gene ensg:ENSMUSG00000024680 .
+  # Database: MoG+ | Query: 3 | Comment: this variant's coordinate overlaps the Ms4a2 Ensembl gene, so it counts toward the Ms4a2 tally
+  <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C> vcf:has_genotype_call <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C/genotype/MSM_Ms> .
+  # Database: MoG+ | Query: 3 | Comment: the variant has a genotype call for MSM/Ms, i.e. the strain carries this locus
+  <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C/genotype/MSM_Ms> med2rdf:sample mogbs:MSM_Ms .
+  # Database: MoG+ | Query: 3 | Comment: the call links back to the MSM_Ms strain sample (the join predicate for the per-strain count)
+  <http://identifiers.org/mogplus/v3/19/GRCm39#11592954-T-C/genotype/MSM_Ms> vcf:genotype "1/1" .
+  # Database: MoG+ | Query: 3 | Comment: MSM/Ms is homozygous for the alternate allele here (a genuine non-reference call)
+
+exact_answer: "Ms4a2 (86 variants)"
+
+ideal_answer: |
+  Seven mouse genes encode reviewed proteins classified as IgE-binding proteins:
+  Fcer1a, Fcer1g, Fcer2, Fcgr4, Ms4a2, Lgals3 (galectin-3) and Iap. Ranking these
+  genes by the number of recorded genomic variants carried by the Japanese
+  wild-derived inbred strain MSM/Ms, Ms4a2 - the high-affinity IgE receptor
+  beta-subunit, mapped to mouse Ensembl gene ENSMUSG00000024680 on chromosome 19 -
+  ranks first with 86 distinct variants (loci where MSM/Ms has a non-reference
+  genotype call). Fcer2 follows with 69, then Lgals3 with 2 and Fcgr4 with 1.
+  MSM/Ms carries no variants overlapping Fcer1a or Fcer1g even though both genes
+  are represented in the callset (40 and 25 variants respectively across the
+  strain panel), meaning MSM/Ms matches the reference at those loci. Iap has no
+  corresponding mouse Ensembl gene and therefore no coordinate-mapped variants.
+  The four non-zero counts sum to 86 + 69 + 2 + 1 = 158, exactly matching an
+  independent distinct-variant total of 158, which confirms that no variant
+  overlaps more than one of these genes. Anchoring the count on the strain pins a
+  single release cohort, so the tallies are free of cross-release duplication.
+
+question_template_used: keyword_defined_gene_set_max_variant_count_by_strain
+
+time_spent:
+  exploration: 30
+  formulation: 15
+  verification: 10
+  pubmed_test: 12
+  extraction: 10
+  documentation: 20
+  total: 97

--- a/benchmark/questions/question_072.yaml
+++ b/benchmark/questions/question_072.yaml
@@ -1,0 +1,188 @@
+---
+id: question_072
+type: choice
+body: >-
+  Among the oxygenic photosynthetic bacteria (cyanobacteria) preserved in the
+  culture catalogue of Japan's NITE Biological Resource Center, which genus is
+  represented by the greatest number of distinct strains?
+
+choices:
+  - "Synechococcus"
+  - "Phormidium"
+  - "Chroococcidiopsis"
+  - "Leptolyngbya"
+
+inspiration_keyword:
+  keyword_id: KW-0602
+  name: Photosynthesis
+  category: Biological process
+
+togomcp_databases_used:
+  - nbrc
+  - taxonomy
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: >-
+    Two searches aimed at answering the question directly: (1) "NITE Biological
+    Resource Center cyanobacteria culture collection most represented genus";
+    (2) "Japanese culture collection cyanobacteria Palau seawater Synechococcus
+    Phormidium strain holdings genus diversity".
+  result: |
+    Both queries returned 0 articles. No publication reports the genus-level
+    composition of this collection's cyanobacterial holdings or states which
+    cyanobacterial genus it holds most of. The answer is a count over the live
+    catalogue joined to the taxonomic hierarchy and cannot be obtained from the
+    literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# NCBI Taxonomy phylum Cyanobacteriota = taxid 1117 (rank Phylum; equivalentName
+# "Oxygenic photosynthetic bacteria"). Clade membership resolved by cross-graph
+# rdfs:subClassOf* traversal in the co-located taxonomy graph — ALL descendant
+# taxa carried by NBRC strains are included (no sampling).
+
+sparql_queries:
+  - query_number: 1
+    database: taxonomy
+    description: >-
+      Ground the clade: confirm NCBI taxid 1117 is the phylum Cyanobacteriota
+      (rank Phylum), whose equivalentName is literally "Oxygenic photosynthetic
+      bacteria" - the anchor for the subtree membership test.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      SELECT ?label ?rank ?equivalentName
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          <http://identifiers.org/taxonomy/1117> rdfs:label ?label ;
+                                                 tax:rank ?rank .
+          OPTIONAL { <http://identifiers.org/taxonomy/1117>
+                     tax:equivalentName ?equivalentName }
+        }
+      }
+    result_count: 1
+
+  - query_number: 2
+    database: nbrc
+    description: >-
+      Per-genus count of distinct NBRC strains whose NCBI taxon lies within the
+      Cyanobacteriota phylum (cross-graph rdfs:subClassOf* to taxid 1117), then
+      up to the genus-rank ancestor. Results: Synechococcus 22, Phormidium 6,
+      Chroococcidiopsis 2, Leptolyngbya 2, Halotia 2, and seven genera with 1
+      each (Plectonema, Acaryochloris, Calothrix, Geitlerinema,
+      Thermosynechococcus, Cyanobacterium, Pseudanabaena).
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      SELECT ?genus ?genusLabel (COUNT(DISTINCT ?strain) AS ?n)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000065 ?taxon .
+        }
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          ?taxon rdfs:subClassOf* <http://identifiers.org/taxonomy/1117> .
+          ?taxon rdfs:subClassOf* ?genus .
+          ?genus tax:rank tax:Genus ;
+                 rdfs:label ?genusLabel .
+        }
+      }
+      GROUP BY ?genus ?genusLabel
+      ORDER BY DESC(?n)
+    result_count: 12
+
+  - query_number: 3
+    database: nbrc
+    description: >-
+      Arithmetic-verification query (Rule 3) for query 2: total distinct NBRC
+      strains within the Cyanobacteriota subtree. Returns 41, exactly matching
+      the sum of the per-genus counts (22+6+2+2+2+1+1+1+1+1+1+1 = 41), so every
+      strain maps to exactly one genus (no coverage gap, no overlap).
+    query: |
+      PREFIX mccv: <http://purl.jp/bio/10/mccv#>
+      PREFIX brso: <http://purl.jp/bio/10/brso/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT (COUNT(DISTINCT ?strain) AS ?total)
+      WHERE {
+        GRAPH <http://purl.jp/bio/103/nite/culture/> {
+          ?strain a brso:BiologicalResource ;
+                  mccv:MCCV_000065 ?taxon .
+        }
+        GRAPH <http://rdfportal.org/ontology/taxonomy> {
+          ?taxon rdfs:subClassOf* <http://identifiers.org/taxonomy/1117> .
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix tax:  <http://ddbj.nig.ac.jp/ontologies/taxonomy/> .
+  @prefix mccv: <http://purl.jp/bio/10/mccv#> .
+  @prefix brso: <http://purl.jp/bio/10/brso/> .
+  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  @prefix taxid: <http://identifiers.org/taxonomy/> .
+  @prefix cul: <http://purl.jp/bio/103/nite/nbrc/cultures/> .
+
+  taxid:1117 rdfs:label "Cyanobacteriota" .
+  # Database: taxonomy | Query: 1 | Comment: NCBI taxid 1117 is the cyanobacterial phylum, the clade anchor for the subtree membership test
+  taxid:1117 tax:rank tax:Phylum .
+  # Database: taxonomy | Query: 1 | Comment: 1117 is at phylum rank, so subClassOf* to it captures all cyanobacterial genera/species
+  taxid:1117 tax:equivalentName "Oxygenic photosynthetic bacteria" .
+  # Database: taxonomy | Query: 1 | Comment: the phylum's equivalent name is literally "oxygenic photosynthetic bacteria" - the tie to the Photosynthesis theme
+  taxid:1129 tax:rank tax:Genus .
+  # Database: taxonomy | Query: 2 | Comment: taxid 1129 (Synechococcus) is a genus-rank node, the grouping level for the count
+  taxid:1129 rdfs:label "Synechococcus" .
+  # Database: taxonomy | Query: 2 | Comment: the winning genus label
+  taxid:1129 rdfs:subClassOf taxid:1117 .
+  # Database: taxonomy | Query: 2 | Comment: Synechococcus lies within the Cyanobacteriota phylum (satisfies subClassOf* to 1117)
+  taxid:1131 rdfs:subClassOf taxid:1129 .
+  # Database: taxonomy | Query: 2 | Comment: species-level taxon "Synechococcus sp." (1131) descends from the genus Synechococcus (1129)
+  cul:00102692 a brso:BiologicalResource .
+  # Database: NBRC | Query: 2 | Comment: an NBRC strain record counted toward the Synechococcus total
+  cul:00102692 skos:prefLabel "Synechococcus sp. (class: Cyanophyceae)" .
+  # Database: NBRC | Query: 2 | Comment: its accepted scientific name places it in the Synechococcus genus
+  cul:00102692 mccv:MCCV_000065 taxid:1131 .
+  # Database: NBRC | Query: 2 | Comment: the strain's NCBI taxon link (Synechococcus sp., 1131), the join key into the taxonomy subtree
+  cul:00102692 mccv:MCCV_000038 mccv:MCCV_000044 .
+  # Database: NBRC | Query: 2 | Comment: NBRC files this cyanobacterium under organism category "Algae" (blue-green algae), not "Bacteria"
+
+exact_answer:
+  - "Synechococcus"
+
+ideal_answer: |
+  Restricting to the strains whose NCBI taxon falls within the cyanobacterial
+  phylum Cyanobacteriota (taxid 1117, whose equivalent name is "oxygenic
+  photosynthetic bacteria"), the NITE Biological Resource Center holds 41
+  cyanobacterial strains spanning 12 genera. Synechococcus dominates with 22
+  strains - more than half the total and over three times the next genus,
+  Phormidium (6); the remaining genera are minor (Chroococcidiopsis 2,
+  Leptolyngbya 2, Halotia 2, and Plectonema, Acaryochloris, Calothrix,
+  Geitlerinema, Thermosynechococcus, Cyanobacterium and Pseudanabaena with 1
+  strain each). The per-genus counts sum to exactly 41, matching the independent
+  total, so every strain maps to a single genus. These holdings are almost
+  entirely marine - most were isolated from seawater, ascidians and sponges
+  collected around Palau, the open sea and Japan - and the catalogue classifies
+  them under the "algae" (blue-green algae) organism category rather than as
+  bacteria. The most-represented cyanobacterial genus is therefore Synechococcus.
+
+question_template_used: choice_most_represented_genus_within_keyword_defined_clade_via_taxonomy_subtree
+
+time_spent:
+  exploration: 30
+  formulation: 12
+  verification: 8
+  pubmed_test: 10
+  extraction: 10
+  documentation: 18
+  total: 88

--- a/benchmark/questions/question_073.yaml
+++ b/benchmark/questions/question_073.yaml
@@ -1,0 +1,215 @@
+---
+id: question_073
+type: list
+body: >-
+  In the mouse gene Col19a1 (collagen type XIX, alpha-1 chain), a
+  single-nucleotide substitution on chromosome 1 at position 24,318,952 of the
+  GRCm39 assembly changes a G to an A, producing the missense change
+  p.Pro1046Leu. Which inbred and wild-derived mouse strains carry the alternate
+  (A) allele at this position?
+
+inspiration_keyword:
+  keyword_id: KW-0517
+  name: Myogenesis
+  category: Biological process
+
+togomcp_databases_used:
+  - ensembl
+  - mogplus
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: >-
+    Two searches aimed at answering the question directly: (1) "Col19a1 collagen
+    XIX Pro1046Leu missense variant mouse inbred strains MSM PWK genotype
+    carrier"; (2) "wild-derived mouse strains collagen type XIX Col19a1 coding
+    variant chromosome 1 which strains carry allele".
+  result: |
+    Both queries returned 0 articles. No publication reports the per-strain
+    genotype of this specific Col19a1 p.Pro1046Leu substitution or lists which
+    inbred/wild-derived strains carry the alternate allele. The answer is a
+    genotype enumeration over the live mouse-variation callset and cannot be
+    obtained from the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+sparql_queries:
+  - query_number: 1
+    database: ensembl
+    description: >-
+      Confirm the gene identity of the Ensembl mouse gene the variant overlaps:
+      ENSMUSG00000026141 is Col19a1 (collagen, type XIX, alpha 1), Mus musculus.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      SELECT ?label ?desc WHERE {
+        <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000026141>
+            a <http://rdf.ebi.ac.uk/terms/ensembl/EnsemblGene> ;
+            rdfs:label ?label ;
+            obo:RO_0002162 <http://ensembl.org/Mus_musculus> .
+        OPTIONAL { <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000026141>
+                   dcterms:description ?desc }
+      }
+    result_count: 1
+
+  - query_number: 2
+    database: mogplus
+    description: >-
+      Confirm the variant chr1:24318952 G>A is a single-nucleotide substitution
+      that overlaps the Col19a1 Ensembl gene and carries the missense annotation
+      p.Pro1046Leu (SnpEff HGVSp; VEP hgvsp is empty in this resource).
+    query: |
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      PREFIX gvo: <http://genome-variation.org/resource#>
+      PREFIX snpeff: <http://genome-variation.org/resource/snpeff#>
+      SELECT ?type ?ref ?alt ?hgvsp ?sym WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A>
+              a ?type ; gvo:ref ?ref ; gvo:alt ?alt ;
+              mogplus:overlaps_gene
+                <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000026141> ;
+              snpeff:has_annotation ?sa .
+          ?sa snpeff:hgvsp ?hgvsp ; snpeff:gene_name ?sym .
+        }
+      }
+    result_count: 1
+
+  - query_number: 3
+    database: mogplus
+    description: >-
+      List the strains carrying the alternate allele at this locus. The genomic
+      variant is recorded under two disjoint release cohorts (both variant IRIs
+      queried); each carrier has a homozygous-alternate (1/1) genotype call.
+      Returns 11 distinct strains: CHD/Ms, HMI/Ms, JF1/Ms, KJR, MSM/Ms, NJL/Ms,
+      SWN/Ms (7) plus CZECHII/EiJ, JF1/MsJ, MOLF/EiJ, PWK/PhJ (4).
+    query: |
+      PREFIX vcf: <http://genome-variation.org/resource/vcf#>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT DISTINCT ?strainLabel ?gt WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          VALUES ?variant {
+            <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A>
+            <http://identifiers.org/mogplus/v2.1/1/GRCm39#24318952-G-A>
+          }
+          ?variant vcf:has_genotype_call ?call .
+          ?call med2rdf:sample ?strain ; vcf:genotype ?gt .
+          ?strain rdfs:label ?strainLabel .
+        }
+      }
+      ORDER BY ?strainLabel
+    result_count: 11
+
+  - query_number: 4
+    database: mogplus
+    description: >-
+      Arithmetic-verification query (Rule 3) for query 3: total distinct carrier
+      strains and the per-cohort split. Returns total 11 = 7 (first release
+      cohort) + 4 (second, disjoint cohort), confirming no strain is counted
+      twice (the two cohorts share no strains).
+    query: |
+      PREFIX vcf: <http://genome-variation.org/resource/vcf#>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      SELECT
+        (COUNT(DISTINCT ?strain) AS ?totalCarriers)
+        (COUNT(DISTINCT ?v3s)  AS ?v3Carriers)
+        (COUNT(DISTINCT ?v21s) AS ?v21Carriers)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          VALUES ?variant {
+            <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A>
+            <http://identifiers.org/mogplus/v2.1/1/GRCm39#24318952-G-A>
+          }
+          ?variant vcf:has_genotype_call ?call .
+          ?call med2rdf:sample ?strain .
+          BIND(IF(STRSTARTS(STR(?variant),
+            "http://identifiers.org/mogplus/v3/"), ?strain, ?u) AS ?v3s)
+          BIND(IF(STRSTARTS(STR(?variant),
+            "http://identifiers.org/mogplus/v2.1/"), ?strain, ?u) AS ?v21s)
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix dcterms: <http://purl.org/dc/terms/> .
+  @prefix mogplus: <http://identifiers.org/mogplus/ontology#> .
+  @prefix gvo: <http://genome-variation.org/resource#> .
+  @prefix snpeff: <http://genome-variation.org/resource/snpeff#> .
+  @prefix vcf: <http://genome-variation.org/resource/vcf#> .
+  @prefix med2rdf: <http://med2rdf.org/ontology/med2rdf#> .
+  @prefix ensg: <http://rdf.ebi.ac.uk/resource/ensembl/> .
+  @prefix mogbs: <http://identifiers.org/mogplus/bioresource/> .
+
+  ensg:ENSMUSG00000026141 rdfs:label "Col19a1" .
+  # Database: Ensembl | Query: 1 | Comment: the Ensembl mouse gene the variant overlaps is Col19a1
+  ensg:ENSMUSG00000026141 dcterms:description "collagen, type XIX, alpha 1 [Source:MGI Symbol;Acc:MGI:1095415]" .
+  # Database: Ensembl | Query: 1 | Comment: Col19a1 encodes the alpha-1 chain of collagen type XIX (a myogenesis-associated collagen)
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> a gvo:SNV .
+  # Database: MoG+ | Query: 2 | Comment: the locus is a single-nucleotide substitution (chr1:24,318,952, GRCm39)
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> gvo:ref "G" .
+  # Database: MoG+ | Query: 2 | Comment: reference allele G
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> gvo:alt "A" .
+  # Database: MoG+ | Query: 2 | Comment: alternate allele A (the allele whose carriers are being listed)
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> mogplus:overlaps_gene ensg:ENSMUSG00000026141 .
+  # Database: MoG+ | Query: 2 | Comment: the variant's coordinate overlaps the Col19a1 gene
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> snpeff:has_annotation _:ann1 .
+  # Database: MoG+ | Query: 2 | Comment: the variant carries a SnpEff functional annotation
+  _:ann1 snpeff:hgvsp "p.Pro1046Leu" .
+  # Database: MoG+ | Query: 2 | Comment: the amino-acid change is a proline-to-leucine missense at codon 1046
+  <http://identifiers.org/mogplus/v3/1/GRCm39#24318952-G-A> vcf:has_genotype_call _:callMSM .
+  # Database: MoG+ | Query: 3 | Comment: a genotype call attached to the variant in the first release cohort
+  _:callMSM med2rdf:sample mogbs:MSM_Ms .
+  # Database: MoG+ | Query: 3 | Comment: MSM/Ms is one of the seven first-cohort strains carrying the alternate allele
+  _:callMSM vcf:genotype "1/1" .
+  # Database: MoG+ | Query: 3 | Comment: MSM/Ms is homozygous for the alternate (Leu) allele
+  <http://identifiers.org/mogplus/v2.1/1/GRCm39#24318952-G-A> vcf:has_genotype_call _:callPWK .
+  # Database: MoG+ | Query: 3 | Comment: the same genomic locus in the second (disjoint) release cohort
+  _:callPWK med2rdf:sample mogbs:PWK_PhJ .
+  # Database: MoG+ | Query: 3 | Comment: PWK/PhJ is one of the four second-cohort strains carrying the alternate allele
+
+exact_answer:
+  - "CHD/Ms"
+  - "HMI/Ms"
+  - "JF1/Ms"
+  - "KJR"
+  - "MSM/Ms"
+  - "NJL/Ms"
+  - "SWN/Ms"
+  - "CZECHII/EiJ"
+  - "JF1/MsJ"
+  - "MOLF/EiJ"
+  - "PWK/PhJ"
+
+ideal_answer: |
+  The Col19a1 chr1:24,318,952 G>A substitution (GRCm39), which changes proline
+  1046 of the collagen type XIX alpha-1 chain to leucine (p.Pro1046Leu), is
+  carried in the homozygous alternate state (genotype 1/1) by 11 distinct mouse
+  strains. Seven come from one genotyping panel - CHD/Ms, HMI/Ms, JF1/Ms, KJR,
+  MSM/Ms, NJL/Ms and SWN/Ms (predominantly Japanese wild-derived lines) - and
+  four from a second, non-overlapping panel: CZECHII/EiJ, JF1/MsJ, MOLF/EiJ and
+  PWK/PhJ (largely European and other wild-derived lines). Because the two panels
+  share no strains, the counts add without overlap (7 + 4 = 11). All carriers are
+  homozygous for the leucine allele, consistent with these being inbred lines
+  that diverge from the C57BL/6J reference (which defines the reference G/proline
+  allele and is not itself among the genotyped panels). No strain is heterozygous
+  at this position in the recorded calls.
+
+question_template_used: list_carrier_strains_of_a_specific_missense_variant_variant_anchored
+
+time_spent:
+  exploration: 40
+  formulation: 12
+  verification: 8
+  pubmed_test: 10
+  extraction: 12
+  documentation: 18
+  total: 100

--- a/benchmark/questions/question_074.yaml
+++ b/benchmark/questions/question_074.yaml
@@ -1,0 +1,184 @@
+---
+id: question_074
+type: yes_no
+body: >-
+  In Japan's system of designated intractable (rare) diseases, is von Willebrand
+  disease recorded as more than one separately designated disease entry, with
+  each of those entries additionally cross-referenced to a distinct term in the
+  standardized international disease ontology used to harmonize rare-disease
+  nomenclature (so that no two of the entries share the same international
+  identifier)?
+
+inspiration_keyword:
+  keyword_id: KW-0852
+  name: von Willebrand disease
+  category: Disease
+
+togomcp_databases_used:
+  - nando
+  - mondo
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: >-
+    Two searches aimed at answering the question directly: (1) "Japan designated
+    intractable disease von Willebrand disease notification number MONDO ontology
+    mapping classification forms"; (2) "von Willebrand disease subtypes
+    platelet-type acquired hereditary Japanese rare disease registry
+    designation".
+  result: |
+    Both queries returned 0 articles. No publication states how many separately
+    designated von Willebrand disease entries the Japanese intractable-disease
+    system recognizes, nor whether each maps to a distinct international
+    disease-ontology term. The answer requires enumerating the designated entries
+    and their cross-references in the live ontologies and cannot be obtained from
+    the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+sparql_queries:
+  - query_number: 1
+    database: nando
+    description: >-
+      Retrieve every designated von Willebrand disease entry in the Japanese
+      intractable-disease ontology (label contains "willebrand"; text search is
+      the sanctioned method for free-text disease names here) with its official
+      notification number and its MONDO cross-reference. Returns 3 entries:
+      Von Willebrand disease (NANDO:2200682, notif 39) -> MONDO_0024574;
+      Platelet-type von Willebrand disease (NANDO:2200668, notif 14) ->
+      MONDO_0008332; Acquired von Willebrand disease (NANDO:1200899, notif 288)
+      -> MONDO_0020460.
+    query: |
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX nando: <http://nanbyodata.jp/ontology/NANDO_>
+      SELECT ?id ?label ?notif ?mondo
+      FROM <http://nanbyodata.jp/ontology/nando>
+      WHERE {
+        ?disease a owl:Class ; rdfs:label ?label ; dct:identifier ?id .
+        FILTER(LANG(?label) = "en")
+        ?label bif:contains "'willebrand'" .
+        ?disease nando:hasNotificationNumber ?notif ;
+                 skos:closeMatch ?mondo .
+        FILTER(STRSTARTS(STR(?mondo), "http://purl.obolibrary.org/obo/MONDO_"))
+      }
+      ORDER BY ?id
+    result_count: 3
+
+  - query_number: 2
+    database: mondo
+    description: >-
+      Confirm the three MONDO cross-reference targets are distinct, active
+      (non-deprecated) disease classes, and read their labels: MONDO_0024574
+      "von Willebrand disease (hereditary or acquired)", MONDO_0008332
+      "platelet-type von Willebrand disease", MONDO_0020460 "acquired von
+      willebrand syndrome".
+    query: |
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?mondo ?label WHERE {
+        GRAPH <http://rdfportal.org/ontology/mondo> {
+          VALUES ?mondo {
+            <http://purl.obolibrary.org/obo/MONDO_0024574>
+            <http://purl.obolibrary.org/obo/MONDO_0008332>
+            <http://purl.obolibrary.org/obo/MONDO_0020460>
+          }
+          ?mondo a owl:Class ; rdfs:label ?label .
+          FILTER NOT EXISTS { ?mondo owl:deprecated true }
+        }
+      }
+      ORDER BY ?mondo
+    result_count: 3
+
+  - query_number: 3
+    database: nando
+    description: >-
+      Arithmetic-verification query (Rule 3): over the complete set of
+      von-Willebrand-named NANDO classes, count total entries, those that are
+      designated (have a notification number), and the number of DISTINCT MONDO
+      targets. Returns 3 = 3 = 3, confirming every entry is designated and each
+      maps to its own distinct MONDO term (no collapsing onto a shared identifier).
+    query: |
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX nando: <http://nanbyodata.jp/ontology/NANDO_>
+      SELECT (COUNT(DISTINCT ?disease) AS ?nEntries)
+             (COUNT(DISTINCT ?notifDisease) AS ?nDesignated)
+             (COUNT(DISTINCT ?mondo) AS ?nDistinctMondo)
+      FROM <http://nanbyodata.jp/ontology/nando>
+      WHERE {
+        ?disease a owl:Class ; rdfs:label ?label .
+        FILTER(LANG(?label) = "en")
+        ?label bif:contains "'willebrand'" .
+        OPTIONAL { ?disease nando:hasNotificationNumber ?n . BIND(?disease AS ?notifDisease) }
+        OPTIONAL { ?disease skos:closeMatch ?mondo .
+                   FILTER(STRSTARTS(STR(?mondo), "http://purl.obolibrary.org/obo/MONDO_")) }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix owl: <http://www.w3.org/2002/07/owl#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  @prefix nando: <http://nanbyodata.jp/ontology/NANDO_> .
+  @prefix nandop: <http://nanbyodata.jp/ontology/> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+
+  nando:2200682 nandop:hasNotificationNumber "39" .
+  # Database: NANDO | Query: 1 | Comment: "Von Willebrand disease" (inherited bleeding disorder) is a designated intractable disease, notification number 39
+  nando:2200682 skos:closeMatch obo:MONDO_0024574 .
+  # Database: NANDO | Query: 1 | Comment: it is cross-referenced to MONDO_0024574 (first of three distinct MONDO targets)
+  obo:MONDO_0024574 rdfs:label "von Willebrand disease (hereditary or acquired)" .
+  # Database: MONDO | Query: 2 | Comment: the target is an active MONDO disease class
+  nando:2200668 nandop:hasNotificationNumber "14" .
+  # Database: NANDO | Query: 1 | Comment: "Platelet-type von Willebrand disease" is separately designated, notification number 14
+  nando:2200668 skos:closeMatch obo:MONDO_0008332 .
+  # Database: NANDO | Query: 1 | Comment: it maps to a DIFFERENT MONDO term, MONDO_0008332
+  obo:MONDO_0008332 rdfs:label "platelet-type von Willebrand disease" .
+  # Database: MONDO | Query: 2 | Comment: a distinct, active MONDO disease class
+  nando:1200899 nandop:hasNotificationNumber "288" .
+  # Database: NANDO | Query: 1 | Comment: "Acquired von Willebrand disease" is separately designated, notification number 288
+  nando:1200899 skos:closeMatch obo:MONDO_0020460 .
+  # Database: NANDO | Query: 1 | Comment: it maps to a third, distinct MONDO term, MONDO_0020460
+  obo:MONDO_0020460 rdfs:label "acquired von willebrand syndrome" .
+  # Database: MONDO | Query: 2 | Comment: the third distinct, active MONDO disease class — so all three designations map to distinct identifiers (answer: yes)
+
+exact_answer: "yes"
+
+ideal_answer: |
+  Yes. Japan's designated-intractable-disease (Nanbyo) system records von
+  Willebrand disease not as a single entity but as three separately designated
+  disease entries, each with its own official notification number: classic Von
+  Willebrand disease (notification 39, an inherited bleeding disorder),
+  Platelet-type von Willebrand disease (notification 14) and Acquired von
+  Willebrand disease (notification 288). Each of the three is cross-referenced to
+  a different term in the international MONDO disease ontology - respectively
+  MONDO:0024574 "von Willebrand disease (hereditary or acquired)", MONDO:0008332
+  "platelet-type von Willebrand disease" and MONDO:0020460 "acquired von
+  Willebrand syndrome". All three MONDO targets are distinct, active
+  (non-deprecated) classes, so no two of the Japanese designations collapse onto
+  the same international identifier: the counts line up as three entries, three
+  designated, three distinct MONDO terms. The granular national designation of
+  von Willebrand disease is therefore fully preserved when mapped to the
+  international ontology.
+
+question_template_used: yes_no_entity_recorded_as_multiple_designated_entries_each_with_distinct_crossref
+
+time_spent:
+  exploration: 25
+  formulation: 12
+  verification: 8
+  pubmed_test: 10
+  extraction: 10
+  documentation: 15
+  total: 80

--- a/benchmark/questions/question_075.yaml
+++ b/benchmark/questions/question_075.yaml
@@ -1,0 +1,196 @@
+---
+id: question_075
+type: summary
+body: >-
+  Provide an integrated profile of the antibiotic fosfomycin, drawing together
+  (a) its chemical identity and molecular formula, (b) its clinical/regulatory
+  development status as a drug, and (c) what current global surveillance data
+  reveal about resistance to it - namely how frequently tested bacterial
+  isolates are found resistant, which bacterial species account for most of the
+  observed resistance, and the principal genetic determinants and molecular
+  mechanisms by which bacteria resist it.
+
+inspiration_keyword:
+  keyword_id: KW-0929
+  name: Antimicrobial
+  category: Molecular function
+
+togomcp_databases_used:
+  - amrportal
+  - chebi
+  - chembl
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Two searches aimed at reproducing the integrated quantified answer: (1)
+    "fosfomycin resistance surveillance number resistant isolates Klebsiella
+    pneumoniae fosA prevalence global genotype phenotype counts"; (2) "fosfomycin
+    resistance mechanisms fosA murA glpT uhpT bacterial species distribution
+    surveillance database summary".
+  result: |
+    Both queries returned 0 articles. The individual resistance mechanisms
+    (fosA/fosB enzymes, MurA target mutations, GlpT/UhpT uptake loss) are
+    discussed qualitatively in the primary literature, but no publication
+    provides this surveillance resource's specific quantified snapshot - the
+    resistant/susceptible tally, the per-species breakdown of resistant isolates,
+    and the per-determinant feature counts - integrated with the drug's chemical
+    identity and development status. The integrated numeric answer requires the
+    live databases.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+sparql_queries:
+  - query_number: 1
+    database: amrportal
+    description: >-
+      Global phenotypic susceptibility outcomes recorded for fosfomycin. Returns
+      susceptible 1282, resistant 95, intermediate 22 (records carrying a
+      resistance-phenotype value). The resistant total (95) is the reference for
+      the Rule-3 check against query 2.
+    query: |
+      PREFIX amr: <http://example.org/ebiamr#>
+      SELECT ?phenotype (COUNT(*) AS ?n)
+      FROM <http://rdfportal.org/dataset/amrportal>
+      WHERE {
+        ?s a amr:PhenotypeMeasurement ;
+           amr:antibioticName "fosfomycin" ;
+           amr:resistancePhenotype ?phenotype .
+      }
+      GROUP BY ?phenotype
+      ORDER BY DESC(?n)
+    result_count: 3
+
+  - query_number: 2
+    database: amrportal
+    description: >-
+      Species breakdown of the fosfomycin-resistant isolates. Returns Klebsiella
+      pneumoniae 72, Staphylococcus aureus 8, Escherichia coli 6, Acinetobacter
+      baumannii 3, Enterobacter cloacae 3, Pseudomonas aeruginosa 1, Enterobacter
+      asburiae 1, Enterobacter bugandensis 1. Rule-3 arithmetic: the per-species
+      counts sum to 72+8+6+3+3+1+1+1 = 95, exactly matching the resistant total
+      from query 1 (no coverage gap).
+    query: |
+      PREFIX amr: <http://example.org/ebiamr#>
+      SELECT ?organism (COUNT(*) AS ?n)
+      FROM <http://rdfportal.org/dataset/amrportal>
+      WHERE {
+        ?s a amr:PhenotypeMeasurement ;
+           amr:antibioticName "fosfomycin" ;
+           amr:resistancePhenotype "resistant" ;
+           amr:organism ?organism .
+      }
+      GROUP BY ?organism
+      ORDER BY DESC(?n)
+    result_count: 8
+
+  - query_number: 3
+    database: amrportal
+    description: >-
+      Genotypic fosfomycin-resistance determinants (amrClass "FOSFOMYCIN"),
+      ranked by number of recorded genome features. fosA is by far the most
+      common (16,555), followed by the transporter mutation uhpT_E350Q (4,814),
+      fosB (4,440) and the fosA variant fosA7 (3,100); MurA target substitutions
+      (murA_E291D 1,131; murA_G257D 1,055) and GlpT/UhpT uptake mutations
+      (glpT_A100V 699) also appear - spanning the three mechanistic categories
+      (enzymatic inactivation, target-site mutation, reduced uptake).
+    query: |
+      PREFIX amr: <http://example.org/ebiamr#>
+      SELECT ?gene (COUNT(*) AS ?n)
+      FROM <http://rdfportal.org/dataset/amrportal>
+      WHERE {
+        ?s a amr:GenotypeFeature ;
+           amr:amrClass "FOSFOMYCIN" ;
+           amr:amrElementSymbol ?gene .
+      }
+      GROUP BY ?gene
+      ORDER BY DESC(?n)
+      LIMIT 15
+    result_count: 15
+
+  - query_number: 4
+    database: chebi
+    description: >-
+      Chemical identity of fosfomycin: CHEBI:28915, molecular formula C3H7O4P.
+      ChEBI classifies it as a phosphonic acid bearing an epoxide group.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX chemrof: <https://w3id.org/chemrof/>
+      SELECT ?label ?formula WHERE {
+        GRAPH <http://rdf.ebi.ac.uk/dataset/chebi> {
+          <http://purl.obolibrary.org/obo/CHEBI_28915> rdfs:label ?label .
+          OPTIONAL { <http://purl.obolibrary.org/obo/CHEBI_28915>
+                     chemrof:generalized_empirical_formula ?formula }
+        }
+      }
+    result_count: 1
+
+  - query_number: 5
+    database: chembl
+    description: >-
+      Drug-development status of fosfomycin: molecule CHEMBL1757 with highest
+      development phase 4.0 (an approved drug).
+    query: |
+      PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?mol ?label ?phase WHERE {
+        GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> {
+          ?mol a cco:SmallMolecule ;
+               rdfs:label ?label ;
+               cco:highestDevelopmentPhase ?phase .
+          FILTER(LCASE(STR(?label)) = "fosfomycin")
+        }
+      }
+    result_count: 1
+
+rdf_triples: |
+  @prefix amr: <http://example.org/ebiamr#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix chemrof: <https://w3id.org/chemrof/> .
+  @prefix cco: <http://rdf.ebi.ac.uk/terms/chembl#> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix chembl: <http://rdf.ebi.ac.uk/resource/chembl/molecule/> .
+
+  obo:CHEBI_28915 rdfs:label "fosfomycin" .
+  # Database: ChEBI | Query: 4 | Comment: the chemical entity fosfomycin (CHEBI:28915)
+  obo:CHEBI_28915 chemrof:generalized_empirical_formula "C3H7O4P" .
+  # Database: ChEBI | Query: 4 | Comment: its molecular formula - a small phosphonic-acid / epoxide antibiotic
+  chembl:CHEMBL1757 cco:highestDevelopmentPhase 4.0 .
+  # Database: ChEMBL | Query: 5 | Comment: fosfomycin (CHEMBL1757) is an approved drug (highest development phase 4)
+  _:pheno1 a amr:PhenotypeMeasurement .
+  # Database: AMR Portal | Query: 1 | Comment: a phenotypic susceptibility test record (blank node; the resource stores all measurements as blank nodes)
+  _:pheno1 amr:antibioticName "fosfomycin" .
+  # Database: AMR Portal | Query: 1 | Comment: this record tests fosfomycin (1282 susceptible / 95 resistant / 22 intermediate across all such records)
+  _:pheno1 amr:resistancePhenotype "resistant" .
+  # Database: AMR Portal | Query: 2 | Comment: one of the 95 resistant results
+  _:pheno1 amr:organism "Klebsiella pneumoniae" .
+  # Database: AMR Portal | Query: 2 | Comment: Klebsiella pneumoniae accounts for 72 of the 95 resistant isolates - the dominant resistant species
+  _:geno1 a amr:GenotypeFeature .
+  # Database: AMR Portal | Query: 3 | Comment: a genotypic AMR feature record (blank node)
+  _:geno1 amr:amrClass "FOSFOMYCIN" .
+  # Database: AMR Portal | Query: 3 | Comment: classified under the FOSFOMYCIN resistance class
+  _:geno1 amr:amrElementSymbol "fosA" .
+  # Database: AMR Portal | Query: 3 | Comment: fosA - the most frequently recorded fosfomycin determinant (16,555 features), an enzymatic-inactivation gene
+
+exact_answer: ""
+
+ideal_answer: |
+  Fosfomycin (molecular formula C3H7O4P) is a small phosphonic-acid antibiotic carrying a reactive epoxide group, and it is an approved drug that has completed clinical development (highest development phase, 4). Current antimicrobial-resistance surveillance shows it remains largely effective: among the isolates with a recorded fosfomycin susceptibility result, 1,282 were susceptible, 95 resistant and 22 intermediate, so resistance is very much the minority outcome. That resistance is strongly concentrated in a single species - Klebsiella pneumoniae accounts for 72 of the 95 resistant isolates (about three-quarters), with Staphylococcus aureus (8), Escherichia coli (6) and a scattering of other Enterobacterales plus one Pseudomonas aeruginosa making up the rest (the per-species counts sum exactly to the 95 resistant total). At the genotypic level the recorded determinants span three complementary mechanisms: enzymatic inactivation, dominated by the fosfomycin-modifying gene fosA - by far the most frequently recorded determinant, at 16,555 genome features - together with fosB (4,440) and fosA variants such as fosA7 (3,100); target-site substitutions in the MurA enzyme that fosfomycin inhibits (for example murA_E291D and murA_G257D); and loss-of-uptake mutations in the GlpT and UhpT transporters that normally import the drug (for example uhpT_E350Q and glpT_A100V). In short, fosfomycin is an approved epoxide/phosphonic-acid antibiotic that is still broadly active in surveillance testing yet is opposed by a diversified resistance repertoire - numerically dominated by the fosA inactivating enzyme and clinically concentrated in Klebsiella pneumoniae.
+
+question_template_used: summary_integrated_antibiotic_profile_chemistry_drugstatus_resistance_surveillance
+
+time_spent:
+  exploration: 35
+  formulation: 12
+  verification: 8
+  pubmed_test: 12
+  extraction: 12
+  documentation: 20
+  total: 99

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -258,5 +258,10 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 068 | P      | —      |
 | 069 | P      | —      |
 | 070 | P      | —      |
+| 071 | P      | —      |
+| 072 | P      | —      |
+| 073 | P      | —      |
+| 074 | P      | —      |
+| 075 | P      | —      |
 
 **Summary:** `P` = 70 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 70 / 70


### PR DESCRIPTION
## Summary
Extends the TogoMCP evaluation set from **70 → 75 questions**, keeping all five question types **balanced at 15 each**. Every question was generated with the `qa-generator` skill against the live RDF endpoints.

| Q | Type | Databases | Topic |
|---|------|-----------|-------|
| 071 | factoid | uniprot · ensembl · mogplus | IgE-binding-protein gene with the most variants in mouse strain MSM/Ms (**first mogplus question**) |
| 072 | choice | nbrc · taxonomy | most-represented cyanobacterial genus in the NBRC catalogue (*Synechococcus*) |
| 073 | list | ensembl · mogplus | mouse strains carrying the Col19a1 p.Pro1046Leu missense variant |
| 074 | yes_no | nando · mondo | von Willebrand disease as multiple designated NANDO entries, each mapped to a distinct MONDO term |
| 075 | summary | amrportal · chebi · chembl | integrated fosfomycin profile (chemistry + drug status + AMR surveillance) — completes the milestone |

## Validation
- `python benchmark/scripts/verify_questions.py` → **0 errors**; structural near-duplicate guard clean (unique keywords, no signature collisions).
- Each question: passed both necessity gates (training + PubMed, 2 queries each), the C01–C26 review, and **Rule-3 arithmetic** wherever a `GROUP BY` is present (e.g. 072: genus counts sum to 41; 073: 7+4=11 carriers; 075: per-species resistant counts sum to 95).
- All `result_count`, `rdf_triples`, and `ideal_answer` facts come from live query results.

## Tracker
Updates `coverage_tracker.yaml` (per-type/per-database counts, multi-database metrics — now 26/75 = 34.7% are 3+ DB, 100% are 2+ DB — and `keywords_used`) and the `togomcp_qa_prompt.md` progress tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)