### PR TITLE
benchmark: add questions 076-080 (balanced 80-question milestone)

### DIFF
--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -1,4 +1,30 @@
 # Coverage Tracker for TogoMCP Evaluation Dataset
+# Updated after Question 080 added (2026-07-10): list | rhea + chebi (2 databases; KW-0174 Coenzyme M biosynthesis)
+# Q080: list the 19 approved reactions with free coenzyme M (CHEBI:58319); methanogenesis + aerobic epoxyalkane pathway
+# Changes: list count 15->16 (Q080 added); rhea 11->12, chebi 10->11
+# BALANCED 80-QUESTION MILESTONE REACHED — all five types now at 16 (yes_no/factoid/list/summary/choice)
+# two_plus stays 100% (80/80); three_plus stays 27 (Q080 is 2-DB); percentage 34.2->33.75% (27/80)
+# Updated after Question 079 added (2026-07-10): yes_no | uniprot + hgnc (2 databases; KW-0490 MHC I)
+# Q079: are all reviewed human MHC class I genes on one chromosome? NO — 9 proteins across chr6 (7 HLA), chr15 (B2M), chr1 (MR1)
+# Changes: yes_no count 15->16 (Q079 added); uniprot 35->36, hgnc 5->6
+# Four of five types now at 16 (choice/factoid/summary/yes_no); ONLY list still at 15 -> one more list question reaches the balanced 80 milestone
+# two_plus stays 100% (79/79); three_plus stays 27 (Q079 is 2-DB); percentage 34.6->34.2% (27/79)
+# Updated after Question 078 added (2026-07-10): choice | jpostdb + taxonomy (2 databases; KW-1267 Proteomics identification)
+# Q078: 3rd most-represented source organism in the jPOST reanalysis database (after human/mouse) = African green monkey
+#   (Chlorocebus sabaeus, taxid 60711, 30 datasets; Vero-cell/SARS-CoV-2 driver); 7 species partition all 853 datasets
+# Changes: choice count 15->16 (Q078 added); jpostdb 3->4, taxonomy 9->10
+# two_plus stays 100% (78/78); three_plus stays 27 (Q078 is 2-DB); percentage 35.1->34.6% (27/78)
+# Updated after Question 077 added (2026-07-10): factoid | ensembl + mco (2 databases; KW-0158 Chromosome)
+# Q077: highest protein-coding gene density among mouse nuclear chromosomes on GRCm39 = chromosome 7
+#   (2034 genes / 144.995 Mb = 14.03 genes/Mb); Ensembl gene counts normalised by MCO chromosome lengths
+# Changes: factoid count 15->16 (Q077 added); ensembl 6->7, mco NEW (count 1); FIRST use of mco (was the last uncovered DB)
+# ALL registry databases now covered (hco covered by Q076, mco by Q077)
+# two_plus stays 100% (77/77); three_plus stays 27 (Q077 is 2-DB); percentage 35.5->35.1% (27/77)
+# Updated after Question 076 added (2026-07-10): summary | uniprot + hgnc + hco (3 databases; KW-0371 Homeobox)
+# Q076: cytogenetic distribution of 248 reviewed human homeobox genes across 154 bands on GRCh38;
+#   tied largest clusters 7p15.2 (HOXA+EVX1, 12) and 2q31.1 (HOXD+DLX1/DLX2+EVX2, 12); Giemsa stains + coordinates from HCO
+# Changes: summary count 15->16 (Q076 added); uniprot 34->35, hgnc 4->5, hco NEW (count 1); FIRST use of hco (was uncovered)
+# three_plus_databases: 26->27 (Q076 is 3-DB); percentage 34.7->35.5%; two_plus stays 100% (76/76)
 # Updated after Question 033 keyword revision (2026-02-24): replaced Gas vesicle with S-layer
 # Q033 was: uniprot + bacdive (gas vesicle genera KW-0304 with anaerobic BacDive strains; Cereibacter, Geotalea, Streptomyces, Thiocapsa)
 # Q033 now: uniprot + bacdive (S-layer genera KW-0701 exclusively anaerobic in BacDive; 7 genera: Acetivibrio, Methanocaldococcus, Methanococcus, Methanosarcina, Methanothermococcus, Methanothermus, Thermoanaerobacter)
@@ -96,43 +122,43 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 75
+total_questions: 80
 
 question_types:
   yes_no:
-    count: 15
-    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069', '074']
-    status: 'ok'  # 15 uses - Q074 (von Willebrand disease designated as 3 NANDO entries each with distinct MONDO map; nando+mondo)
+    count: 16
+    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069', '074', '079']
+    status: 'ok'  # 16 uses - Q079 (are all reviewed human MHC class I genes on one chromosome? no — chr6/chr15/chr1; uniprot+hgnc)
 
   factoid:
-    count: 15
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066', '071']
-    status: 'ok'  # 15 uses - Q071 (IgE-binding-protein gene with most MSM/Ms variants; uniprot+ensembl+mogplus, first mogplus question)
+    count: 16
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066', '071', '077']
+    status: 'ok'  # 16 uses - Q077 (mouse nuclear chromosome with highest protein-coding gene density on GRCm39 = chr7; ensembl+mco, first mco question)
 
   list:
-    count: 15
-    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068', '073']
-    status: 'ok'  # 15 uses - Q073 (mouse strains carrying a Col19a1 missense variant; ensembl+mogplus)
+    count: 16
+    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068', '073', '080']
+    status: 'ok'  # 16 uses - Q080 (19 approved reactions with free coenzyme M; rhea+chebi) — completes the balanced 80-question milestone (all five types at 16)
 
   summary:
-    count: 15
-    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070', '075']
-    status: 'ok'  # 15 uses - Q075 (integrated fosfomycin profile: chemistry + drug status + AMR surveillance; amrportal+chebi+chembl) completes the balanced 75-question milestone (all five types at 15)
+    count: 16
+    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070', '075', '076']
+    status: 'ok'  # 16 uses - Q076 (cytogenetic distribution of reviewed human homeobox genes across GRCh38 cytobands; uniprot+hgnc+hco, first hco question)
 
   choice:
-    count: 15
-    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067', '072']
-    status: 'ok'  # 15 uses - Q072 (most-represented cyanobacterial genus in NBRC holdings; nbrc+taxonomy)
+    count: 16
+    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067', '072', '078']
+    status: 'ok'  # 16 uses - Q078 (3rd most-represented source organism in jPOST after human/mouse = African green monkey; jpostdb+taxonomy)
 
 databases:
   uniprot:
-    count: 34
-    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067', '071']
-    status: 'ok'  # At 47.9% (34/71), below 70% cap
+    count: 36
+    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067', '071', '076', '079']
+    status: 'ok'  # At 45.6% (36/79), below 70% cap
 
   rhea:
-    count: 11
-    questions: ['003', '011', '024', '026', '027', '031', '041', '043', '045', '051', '053']
+    count: 12
+    questions: ['003', '011', '024', '026', '027', '031', '041', '043', '045', '051', '053', '080']
     status: 'ok'
 
   pubchem:
@@ -151,8 +177,8 @@ databases:
     status: 'ok'
 
   chebi:
-    count: 10
-    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068', '075']
+    count: 11
+    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068', '075', '080']
     status: 'ok'
 
   reactome:
@@ -161,8 +187,8 @@ databases:
     status: 'ok'
 
   ensembl:
-    count: 6
-    questions: ['007', '023', '037', '038', '071', '073']
+    count: 7
+    questions: ['007', '023', '037', '038', '071', '073', '077']
     status: 'ok'
 
   mogplus:
@@ -196,8 +222,8 @@ databases:
     status: 'ok'
 
   taxonomy:
-    count: 9
-    questions: ['014', '016', '018', '020', '034', '048', '050', '069', '072']
+    count: 10
+    questions: ['014', '016', '018', '020', '034', '048', '050', '069', '072', '078']
     status: 'ok'
 
   nbrc:
@@ -251,9 +277,19 @@ databases:
     status: 'ok'
 
   hgnc:
-    count: 4
-    questions: ['052', '057', '063', '065']
+    count: 6
+    questions: ['052', '057', '063', '065', '076', '079']
     status: 'ok'  # newly added life-science DB
+
+  hco:
+    count: 1
+    questions: ['076']
+    status: 'ok'  # Human Chromosome Ontology (cytobands, Giemsa stains, GRCh38/37 coordinates); first use Q076
+
+  mco:
+    count: 1
+    questions: ['077']
+    status: 'ok'  # Mouse Chromosome Ontology (whole-chromosome lengths + RefSeq/INSDC/Ensembl xrefs, GRCm39/38); first use Q077 — completes registry coverage
 
   bgee:
     count: 4
@@ -266,8 +302,8 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   jpostdb:
-    count: 3
-    questions: ['054', '058', '066']
+    count: 4
+    questions: ['054', '058', '066', '078']
     status: 'ok'  # newly added life-science DB
 
   oma:
@@ -282,15 +318,15 @@ databases:
 
 multi_database_metrics:
   two_plus_databases:
-    count: 75
-    percentage: 100.0  # 75/75 (Q075 is 3-DB: amrportal + chebi + chembl)
+    count: 80
+    percentage: 100.0  # 80/80 (Q080 is 2-DB: rhea + chebi)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
-    count: 26
-    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070', '071', '075']
-    percentage: 34.7  # 26/75 (Q075 is 3-DB: amrportal + chebi + chembl)
+    count: 27
+    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070', '071', '075', '076']
+    percentage: 33.8  # 27/80 (Q080 is 2-DB: rhea + chebi)
     target: '>= 20%'
     status: 'excellent'
 
@@ -370,6 +406,11 @@ keywords_used:
   - 'KW-0517'  # Myogenesis (Q073)
   - 'KW-0852'  # von Willebrand disease (Q074)
   - 'KW-0929'  # Antimicrobial (Q075)
+  - 'KW-0371'  # Homeobox (Q076)
+  - 'KW-0158'  # Chromosome (Q077)
+  - 'KW-1267'  # Proteomics identification (Q078)
+  - 'KW-0490'  # MHC I (Q079)
+  - 'KW-0174'  # Coenzyme M biosynthesis (Q080)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_076.yaml
+++ b/benchmark/questions/question_076.yaml
@@ -1,0 +1,266 @@
+id: question_076
+type: summary
+body: "Homeobox transcription factors are one of the largest families of developmental regulators encoded in the human genome, and many of their genes are organised into tandem genomic clusters. For the set of manually reviewed human homeobox proteins, provide an integrated summary of how their genes are distributed across the cytogenetic map on the GRCh38 assembly: how many such genes there are and across how many distinct cytogenetic bands they fall; which bands harbour the largest gene clusters and which specific genes those clusters contain; and the Giemsa staining character and genomic coordinates of those top cluster bands. Note any bands that are tied for the largest cluster, and any genes that cannot be placed on a single band."
+
+inspiration_keyword:
+  keyword_id: KW-0371
+  name: Homeobox
+  category: Domain
+
+togomcp_databases_used:
+  - uniprot
+  - hgnc
+  - hco
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 11 minutes
+  method: |
+    Attempted to retrieve the specific quantitative fact the summary reports — a genome-wide
+    cytogenetic census of reviewed human homeobox genes with per-band counts, the identity of
+    the tied largest clusters, and the Giemsa stain / GRCh38 coordinates of the cluster bands.
+    Ran five PubMed searches and read the returned abstracts:
+    (1) "homeobox genes cytogenetic band distribution genome-wide human"
+    (2) "HOX cluster chromosomal location Giemsa band 7p15 17q21 human"
+    (3) "human homeobox gene family genomic organization clusters review"
+    (4) "HOX gene clusters chromosomal distribution mammalian"
+    and read abstracts of PMIDs 37322110 (Hox timer / CTCF insulation) and 32403166 (Dlx bigene clusters).
+  result: |
+    The two hyper-specific queries returned zero articles; the broader queries returned reviews on
+    Hox-cluster regulation (topologically associating domains, CTCF timers) and Dlx bigene enhancer
+    sharing. None report a genome-wide cytogenetic tally of the reviewed homeobox gene set: not the
+    248-gene / 154-band count, not that band 7p15.2 (HOXA + EVX1) and band 2q31.1 (HOXD + DLX1/DLX2 +
+    EVX2) are tied at 12 genes each, and not the Giemsa stain (gpos50, gneg, gneg, gpos25) or GRCh38
+    coordinates of the cluster bands. Those are a live aggregate over the current protein-keyword set
+    joined to gene nomenclature/location and to the chromosome-band ontology, not a fact stated in the
+    literature.
+  conclusion: PASS (cannot answer from literature; requires a live join of the reviewed homeobox protein set, gene chromosomal locations, and the cytoband ontology with Giemsa/coordinate data)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# UniProt keyword KW-0371 (Homeobox) resolved to IRI http://purl.uniprot.org/keywords/371 (a controlled
+# UniProt keyword, not an ontology term with a subsumption hierarchy — no getDescendants applicable).
+# HCO cytobands and Giemsa stain types are a controlled ISCN vocabulary matched by exact label/IRI.
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Retrieve every reviewed (Swiss-Prot) human (taxon 9606) protein annotated with the Homeobox
+      keyword (KW-0371 = keywords/371), returning its accession. Defines the protein scope; the 248
+      accessions returned here are the exhaustive VALUES set reused in the HGNC/HCO joins below
+      (Hard Rule 2 — no sampling).
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+
+      SELECT (COUNT(DISTINCT ?p) AS ?nprot) (COUNT(DISTINCT ?acc) AS ?nacc)
+      WHERE {
+        ?p a up:Protein ;
+           up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:classifiedWith <http://purl.uniprot.org/keywords/371> ;
+           dcterms:identifier ?acc .
+      }
+    result_count: 1   # returns nprot=248, nacc=248 (248 distinct reviewed human homeobox proteins/accessions)
+
+  - query_number: 2
+    database: hgnc
+    description: >-
+      Cytogenetic distribution. For the 248 homeobox accessions, join each to its HGNC gene via the
+      typed UniProt cross-reference node (rdfs:seeAlso -> idt:uniprot -> dct:identifier) and read the
+      chromosomal band string obo:so_part_of, then count distinct genes per band. All 248 accessions
+      map to exactly one HGNC gene, each with one location string. Returns 154 band rows; the five
+      largest are 7p15.2 (12), 2q31.1 (12), 12q13.13 (10), 17q21.32 (10), 4q35.2 (8).
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+
+      SELECT ?band (COUNT(DISTINCT ?gene) AS ?n)
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?acc { "A0A1W2PPF3" "A0A1W2PPK0" "A0A1W2PPM1" "A2RU54" "A6NCS4" "A6NDR6" "A6NFQ7" "A6NHT5" "A6NJ46" "A6NJG6" "A6NJT0" "A6NLW8" "A6NMT0" "A6NNA5" "A8K0S8" "A8MTQ0" "A8MZ59" "E9PGG2" "O00470" "O14529" "O14627" "O14770" "O14813" "O15266" "O15499" "O15522" "O43186" "O43248" "O43316" "O43364" "O43365" "O43711" "O43763" "O43812" "O60315" "O60393" "O60422" "O60479" "O60663" "O60902" "O75360" "O75364" "O95076" "O95096" "O95231" "O95343" "O95475" "O95948" "P09016" "P09017" "P09067" "P09086" "P09629" "P09630" "P0C7M4" "P0CJ85" "P0CJ86" "P0CJ87" "P0CJ88" "P0CJ89" "P0CJ90" "P0DV77" "P13378" "P14651" "P14652" "P14653" "P14859" "P17481" "P17482" "P17483" "P17509" "P19622" "P20264" "P20265" "P20719" "P20823" "P23759" "P23760" "P26367" "P28069" "P28356" "P28358" "P28360" "P31249" "P31260" "P31267" "P31268" "P31269" "P31270" "P31271" "P31273" "P31274" "P31275" "P31276" "P31277" "P31314" "P32242" "P32243" "P35452" "P35453" "P35548" "P35680" "P37275" "P39880" "P40424" "P40425" "P40426" "P43699" "P47902" "P48742" "P49335" "P49639" "P49640" "P50219" "P50221" "P50222" "P50458" "P52945" "P52951" "P52952" "P52954" "P54821" "P55347" "P56177" "P56178" "P56179" "P56915" "P58304" "P61371" "P78337" "P78367" "P78411" "P78412" "P78413" "P78414" "P78415" "P78424" "P78426" "Q00056" "Q00444" "Q01826" "Q01851" "Q01860" "Q03014" "Q03052" "Q03828" "Q04741" "Q04743" "Q05925" "Q06416" "Q07687" "Q12837" "Q14549" "Q14774" "Q14863" "Q15270" "Q15319" "Q15475" "Q15583" "Q15699" "Q15911" "Q2M1V0" "Q3B8N5" "Q3C1V8" "Q5SQQ9" "Q5XKR4" "Q63HK5" "Q68G74" "Q6IQ32" "Q6NSW7" "Q6NT76" "Q6RFH8" "Q6XYB7" "Q6ZNG2" "Q6ZSZ6" "Q7Z353" "Q7Z5D8" "Q86UP3" "Q8IUE0" "Q8IUE1" "Q8IX15" "Q8IYA7" "Q8N196" "Q8N693" "Q8N7G0" "Q8N7R0" "Q8N7U7" "Q8NFW5" "Q8NHV9" "Q8TAU0" "Q8TE12" "Q92786" "Q92826" "Q92988" "Q969G2" "Q96A47" "Q96IS3" "Q96KN3" "Q96PT3" "Q96PT4" "Q96QS3" "Q99453" "Q99626" "Q99687" "Q99697" "Q99801" "Q99811" "Q9BPY8" "Q9BQY4" "Q9BYU1" "Q9BZE3" "Q9BZI1" "Q9BZM3" "Q9C056" "Q9C0A1" "Q9GZN2" "Q9GZZ0" "Q9H161" "Q9H2C1" "Q9H2P0" "Q9H2W2" "Q9H2Z4" "Q9H4I2" "Q9H4S2" "Q9H9S0" "Q9HB31" "Q9HBU1" "Q9NP08" "Q9NPC8" "Q9NQ69" "Q9NRE2" "Q9NY43" "Q9NYD6" "Q9NZR4" "Q9UBC0" "Q9UBR4" "Q9UBX0" "Q9UBX2" "Q9UD57" "Q9UIU6" "Q9UIW0" "Q9UKI9" "Q9UKY1" "Q9UMQ3" "Q9UPM6" "Q9UPW6" "Q9Y2V3" "Q9Y6X8" }
+        ?gene a m2r:Gene ;
+              rdfs:seeAlso ?ref ;
+              obo:so_part_of ?band .
+        ?ref a idt:uniprot ; dct:identifier ?acc .
+      }
+      GROUP BY ?band
+      ORDER BY DESC(?n)
+    result_count: 154   # 154 distinct location strings; top bands 7p15.2=12, 2q31.1=12, 12q13.13=10, 17q21.32=10, 4q35.2=8
+
+  - query_number: 3
+    database: hgnc
+    description: >-
+      Arithmetic verification (Hard Rule 3). Over the same 248-accession set, count total distinct
+      genes, total distinct bands, and total gene->band rows. genes = rows = 248 proves each gene has
+      exactly one band, so the per-band counts of Query 2 sum to 248 with no coverage gap and no
+      overlap (248 = sum over the 154 bands).
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+
+      SELECT (COUNT(DISTINCT ?gene) AS ?genes) (COUNT(DISTINCT ?band) AS ?bands) (COUNT(*) AS ?rows)
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?acc { "A0A1W2PPF3" "A0A1W2PPK0" "A0A1W2PPM1" "A2RU54" "A6NCS4" "A6NDR6" "A6NFQ7" "A6NHT5" "A6NJ46" "A6NJG6" "A6NJT0" "A6NLW8" "A6NMT0" "A6NNA5" "A8K0S8" "A8MTQ0" "A8MZ59" "E9PGG2" "O00470" "O14529" "O14627" "O14770" "O14813" "O15266" "O15499" "O15522" "O43186" "O43248" "O43316" "O43364" "O43365" "O43711" "O43763" "O43812" "O60315" "O60393" "O60422" "O60479" "O60663" "O60902" "O75360" "O75364" "O95076" "O95096" "O95231" "O95343" "O95475" "O95948" "P09016" "P09017" "P09067" "P09086" "P09629" "P09630" "P0C7M4" "P0CJ85" "P0CJ86" "P0CJ87" "P0CJ88" "P0CJ89" "P0CJ90" "P0DV77" "P13378" "P14651" "P14652" "P14653" "P14859" "P17481" "P17482" "P17483" "P17509" "P19622" "P20264" "P20265" "P20719" "P20823" "P23759" "P23760" "P26367" "P28069" "P28356" "P28358" "P28360" "P31249" "P31260" "P31267" "P31268" "P31269" "P31270" "P31271" "P31273" "P31274" "P31275" "P31276" "P31277" "P31314" "P32242" "P32243" "P35452" "P35453" "P35548" "P35680" "P37275" "P39880" "P40424" "P40425" "P40426" "P43699" "P47902" "P48742" "P49335" "P49639" "P49640" "P50219" "P50221" "P50222" "P50458" "P52945" "P52951" "P52952" "P52954" "P54821" "P55347" "P56177" "P56178" "P56179" "P56915" "P58304" "P61371" "P78337" "P78367" "P78411" "P78412" "P78413" "P78414" "P78415" "P78424" "P78426" "Q00056" "Q00444" "Q01826" "Q01851" "Q01860" "Q03014" "Q03052" "Q03828" "Q04741" "Q04743" "Q05925" "Q06416" "Q07687" "Q12837" "Q14549" "Q14774" "Q14863" "Q15270" "Q15319" "Q15475" "Q15583" "Q15699" "Q15911" "Q2M1V0" "Q3B8N5" "Q3C1V8" "Q5SQQ9" "Q5XKR4" "Q63HK5" "Q68G74" "Q6IQ32" "Q6NSW7" "Q6NT76" "Q6RFH8" "Q6XYB7" "Q6ZNG2" "Q6ZSZ6" "Q7Z353" "Q7Z5D8" "Q86UP3" "Q8IUE0" "Q8IUE1" "Q8IX15" "Q8IYA7" "Q8N196" "Q8N693" "Q8N7G0" "Q8N7R0" "Q8N7U7" "Q8NFW5" "Q8NHV9" "Q8TAU0" "Q8TE12" "Q92786" "Q92826" "Q92988" "Q969G2" "Q96A47" "Q96IS3" "Q96KN3" "Q96PT3" "Q96PT4" "Q96QS3" "Q99453" "Q99626" "Q99687" "Q99697" "Q99801" "Q99811" "Q9BPY8" "Q9BQY4" "Q9BYU1" "Q9BZE3" "Q9BZI1" "Q9BZM3" "Q9C056" "Q9C0A1" "Q9GZN2" "Q9GZZ0" "Q9H161" "Q9H2C1" "Q9H2P0" "Q9H2W2" "Q9H2Z4" "Q9H4I2" "Q9H4S2" "Q9H9S0" "Q9HB31" "Q9HBU1" "Q9NP08" "Q9NPC8" "Q9NQ69" "Q9NRE2" "Q9NY43" "Q9NYD6" "Q9NZR4" "Q9UBC0" "Q9UBR4" "Q9UBX0" "Q9UBX2" "Q9UD57" "Q9UIU6" "Q9UIW0" "Q9UKI9" "Q9UKY1" "Q9UMQ3" "Q9UPM6" "Q9UPW6" "Q9Y2V3" "Q9Y6X8" }
+        ?gene a m2r:Gene ;
+              rdfs:seeAlso ?ref ;
+              obo:so_part_of ?band .
+        ?ref a idt:uniprot ; dct:identifier ?acc .
+      }
+    result_count: 1   # genes=248, bands=154, rows=248 -> sum over bands = 248 (Rule 3 satisfied; no gap, no overlap)
+
+  - query_number: 4
+    database: hgnc
+    description: >-
+      Cluster membership. List the specific homeobox genes in the five largest bands (from Query 2),
+      so each cluster can be named: 7p15.2 = HOXA1-13 + EVX1; 2q31.1 = HOXD1-13 + DLX1/DLX2 + EVX2;
+      12q13.13 = HOXC4-13 + POU6F1; 17q21.32 = HOXB1-13; 4q35.2 = DUX4 + DUX4L2-9 (D4Z4 array).
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+
+      SELECT ?band (GROUP_CONCAT(?symbol; SEPARATOR=", ") AS ?genes)
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?band { "7p15.2" "2q31.1" "12q13.13" "17q21.32" "4q35.2" }
+        VALUES ?acc { "A0A1W2PPF3" "A0A1W2PPK0" "A0A1W2PPM1" "A2RU54" "A6NCS4" "A6NDR6" "A6NFQ7" "A6NHT5" "A6NJ46" "A6NJG6" "A6NJT0" "A6NLW8" "A6NMT0" "A6NNA5" "A8K0S8" "A8MTQ0" "A8MZ59" "E9PGG2" "O00470" "O14529" "O14627" "O14770" "O14813" "O15266" "O15499" "O15522" "O43186" "O43248" "O43316" "O43364" "O43365" "O43711" "O43763" "O43812" "O60315" "O60393" "O60422" "O60479" "O60663" "O60902" "O75360" "O75364" "O95076" "O95096" "O95231" "O95343" "O95475" "O95948" "P09016" "P09017" "P09067" "P09086" "P09629" "P09630" "P0C7M4" "P0CJ85" "P0CJ86" "P0CJ87" "P0CJ88" "P0CJ89" "P0CJ90" "P0DV77" "P13378" "P14651" "P14652" "P14653" "P14859" "P17481" "P17482" "P17483" "P17509" "P19622" "P20264" "P20265" "P20719" "P20823" "P23759" "P23760" "P26367" "P28069" "P28356" "P28358" "P28360" "P31249" "P31260" "P31267" "P31268" "P31269" "P31270" "P31271" "P31273" "P31274" "P31275" "P31276" "P31277" "P31314" "P32242" "P32243" "P35452" "P35453" "P35548" "P35680" "P37275" "P39880" "P40424" "P40425" "P40426" "P43699" "P47902" "P48742" "P49335" "P49639" "P49640" "P50219" "P50221" "P50222" "P50458" "P52945" "P52951" "P52952" "P52954" "P54821" "P55347" "P56177" "P56178" "P56179" "P56915" "P58304" "P61371" "P78337" "P78367" "P78411" "P78412" "P78413" "P78414" "P78415" "P78424" "P78426" "Q00056" "Q00444" "Q01826" "Q01851" "Q01860" "Q03014" "Q03052" "Q03828" "Q04741" "Q04743" "Q05925" "Q06416" "Q07687" "Q12837" "Q14549" "Q14774" "Q14863" "Q15270" "Q15319" "Q15475" "Q15583" "Q15699" "Q15911" "Q2M1V0" "Q3B8N5" "Q3C1V8" "Q5SQQ9" "Q5XKR4" "Q63HK5" "Q68G74" "Q6IQ32" "Q6NSW7" "Q6NT76" "Q6RFH8" "Q6XYB7" "Q6ZNG2" "Q6ZSZ6" "Q7Z353" "Q7Z5D8" "Q86UP3" "Q8IUE0" "Q8IUE1" "Q8IX15" "Q8IYA7" "Q8N196" "Q8N693" "Q8N7G0" "Q8N7R0" "Q8N7U7" "Q8NFW5" "Q8NHV9" "Q8TAU0" "Q8TE12" "Q92786" "Q92826" "Q92988" "Q969G2" "Q96A47" "Q96IS3" "Q96KN3" "Q96PT3" "Q96PT4" "Q96QS3" "Q99453" "Q99626" "Q99687" "Q99697" "Q99801" "Q99811" "Q9BPY8" "Q9BQY4" "Q9BYU1" "Q9BZE3" "Q9BZI1" "Q9BZM3" "Q9C056" "Q9C0A1" "Q9GZN2" "Q9GZZ0" "Q9H161" "Q9H2C1" "Q9H2P0" "Q9H2W2" "Q9H2Z4" "Q9H4I2" "Q9H4S2" "Q9H9S0" "Q9HB31" "Q9HBU1" "Q9NP08" "Q9NPC8" "Q9NQ69" "Q9NRE2" "Q9NY43" "Q9NYD6" "Q9NZR4" "Q9UBC0" "Q9UBR4" "Q9UBX0" "Q9UBX2" "Q9UD57" "Q9UIU6" "Q9UIW0" "Q9UKI9" "Q9UKY1" "Q9UMQ3" "Q9UPM6" "Q9UPW6" "Q9Y2V3" "Q9Y6X8" }
+        ?gene a m2r:Gene ; rdfs:label ?symbol ;
+              rdfs:seeAlso ?ref ; obo:so_part_of ?band .
+        ?ref a idt:uniprot ; dct:identifier ?acc .
+      }
+      GROUP BY ?band
+      ORDER BY ?band
+    result_count: 5
+
+  - query_number: 5
+    database: hco
+    description: >-
+      Cytoband ontology characterisation (the HCO-exclusive facts). For each of the five top cluster
+      bands, navigate from the band class to its GRCh38 instance and read the Giemsa stain type and
+      FALDO begin/end coordinates. Stains: 7p15.2 gpos50, 2q31.1 gneg, 12q13.13 gneg, 17q21.32 gpos25,
+      4q35.2 gpos25 — so the two tied largest clusters differ cytogenetically (gpos50 vs gneg).
+    query: |
+      PREFIX hco:   <http://identifiers.org/hco/>
+      PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+      PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?bandLabel ?stain ?begin ?end (?end - ?begin AS ?span)
+      FROM <http://rdfportal.org/dataset/hco>
+      WHERE {
+        VALUES ?bandLabel { "7p15.2" "2q31.1" "12q13.13" "17q21.32" "4q35.2" }
+        ?band rdfs:subClassOf hco:Cytoband ; rdfs:label ?bandLabel .
+        ?inst a ?band ; hco:build hco:GRCh38 ; hco:bandtype ?bt ; faldo:location ?loc .
+        ?bt rdfs:label ?stain .
+        ?loc faldo:begin/faldo:position ?begin ; faldo:end/faldo:position ?end .
+      }
+      ORDER BY ?bandLabel
+    result_count: 5
+
+  - query_number: 6
+    database: hco
+    description: >-
+      Cross-graph coverage (the flagship HGNC->HCO join, both on the primary endpoint). Counts how
+      many of the 248 genes fall in a band that HCO recognises as a single ISCN cytoband. Returns
+      241 genes across 149 HCO cytobands; the 7 unresolved genes sit at non-single-band strings
+      (DUX1/DUX3/DUX5 "not on reference assembly"; HMBOX1 8p21.1-p12, CUX2 12q24.11-q24.12,
+      ZFHX3 16q22.2-q22.3 spanning ranges; SHOX at pseudoautosomal Xp22.33 and Yp11.32).
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+      PREFIX hco: <http://identifiers.org/hco/>
+
+      SELECT (COUNT(DISTINCT ?gene) AS ?genes_in_hco_bands) (COUNT(DISTINCT ?band) AS ?hco_bands)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/hgnc> {
+          VALUES ?acc { "A0A1W2PPF3" "A0A1W2PPK0" "A0A1W2PPM1" "A2RU54" "A6NCS4" "A6NDR6" "A6NFQ7" "A6NHT5" "A6NJ46" "A6NJG6" "A6NJT0" "A6NLW8" "A6NMT0" "A6NNA5" "A8K0S8" "A8MTQ0" "A8MZ59" "E9PGG2" "O00470" "O14529" "O14627" "O14770" "O14813" "O15266" "O15499" "O15522" "O43186" "O43248" "O43316" "O43364" "O43365" "O43711" "O43763" "O43812" "O60315" "O60393" "O60422" "O60479" "O60663" "O60902" "O75360" "O75364" "O95076" "O95096" "O95231" "O95343" "O95475" "O95948" "P09016" "P09017" "P09067" "P09086" "P09629" "P09630" "P0C7M4" "P0CJ85" "P0CJ86" "P0CJ87" "P0CJ88" "P0CJ89" "P0CJ90" "P0DV77" "P13378" "P14651" "P14652" "P14653" "P14859" "P17481" "P17482" "P17483" "P17509" "P19622" "P20264" "P20265" "P20719" "P20823" "P23759" "P23760" "P26367" "P28069" "P28356" "P28358" "P28360" "P31249" "P31260" "P31267" "P31268" "P31269" "P31270" "P31271" "P31273" "P31274" "P31275" "P31276" "P31277" "P31314" "P32242" "P32243" "P35452" "P35453" "P35548" "P35680" "P37275" "P39880" "P40424" "P40425" "P40426" "P43699" "P47902" "P48742" "P49335" "P49639" "P49640" "P50219" "P50221" "P50222" "P50458" "P52945" "P52951" "P52952" "P52954" "P54821" "P55347" "P56177" "P56178" "P56179" "P56915" "P58304" "P61371" "P78337" "P78367" "P78411" "P78412" "P78413" "P78414" "P78415" "P78424" "P78426" "Q00056" "Q00444" "Q01826" "Q01851" "Q01860" "Q03014" "Q03052" "Q03828" "Q04741" "Q04743" "Q05925" "Q06416" "Q07687" "Q12837" "Q14549" "Q14774" "Q14863" "Q15270" "Q15319" "Q15475" "Q15583" "Q15699" "Q15911" "Q2M1V0" "Q3B8N5" "Q3C1V8" "Q5SQQ9" "Q5XKR4" "Q63HK5" "Q68G74" "Q6IQ32" "Q6NSW7" "Q6NT76" "Q6RFH8" "Q6XYB7" "Q6ZNG2" "Q6ZSZ6" "Q7Z353" "Q7Z5D8" "Q86UP3" "Q8IUE0" "Q8IUE1" "Q8IX15" "Q8IYA7" "Q8N196" "Q8N693" "Q8N7G0" "Q8N7R0" "Q8N7U7" "Q8NFW5" "Q8NHV9" "Q8TAU0" "Q8TE12" "Q92786" "Q92826" "Q92988" "Q969G2" "Q96A47" "Q96IS3" "Q96KN3" "Q96PT3" "Q96PT4" "Q96QS3" "Q99453" "Q99626" "Q99687" "Q99697" "Q99801" "Q99811" "Q9BPY8" "Q9BQY4" "Q9BYU1" "Q9BZE3" "Q9BZI1" "Q9BZM3" "Q9C056" "Q9C0A1" "Q9GZN2" "Q9GZZ0" "Q9H161" "Q9H2C1" "Q9H2P0" "Q9H2W2" "Q9H2Z4" "Q9H4I2" "Q9H4S2" "Q9H9S0" "Q9HB31" "Q9HBU1" "Q9NP08" "Q9NPC8" "Q9NQ69" "Q9NRE2" "Q9NY43" "Q9NYD6" "Q9NZR4" "Q9UBC0" "Q9UBR4" "Q9UBX0" "Q9UBX2" "Q9UD57" "Q9UIU6" "Q9UIW0" "Q9UKI9" "Q9UKY1" "Q9UMQ3" "Q9UPM6" "Q9UPW6" "Q9Y2V3" "Q9Y6X8" }
+          ?gene a m2r:Gene ; rdfs:seeAlso ?ref ; obo:so_part_of ?band .
+          ?ref a idt:uniprot ; dct:identifier ?acc .
+        }
+        GRAPH <http://rdfportal.org/dataset/hco> {
+          ?bandClass rdfs:subClassOf hco:Cytoband ; rdfs:label ?band .
+        }
+      }
+    result_count: 1   # genes_in_hco_bands=241, hco_bands=149 (7 of 248 genes at non-single-band locations)
+
+rdf_triples: |
+  @prefix up:    <http://purl.uniprot.org/core/> .
+  @prefix hgnc:  <http://identifiers.org/hgnc/> .
+  @prefix hco:   <http://identifiers.org/hco/> .
+  @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix obo:   <http://purl.obolibrary.org/obo/> .
+  @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:    <http://example.org/homeobox-cytoband-analysis#> .
+
+  <http://purl.uniprot.org/keywords/371> rdfs:label "Homeobox" .
+  # Database: uniprot | Query: 1 | Comment: The UniProt keyword KW-0371 (Homeobox) used to define the protein scope
+  ex:homeoboxSet ex:reviewedHumanProteins "248"^^xsd:integer .
+  # Database: uniprot | Query: 1 | Comment: 248 distinct reviewed (Swiss-Prot) human proteins carry the Homeobox keyword (up:classifiedWith keywords/371, taxon 9606) — the exhaustive scope
+
+  ex:homeoboxSet ex:distinctHgncGenes "248"^^xsd:integer ; ex:distinctLocationBands "154"^^xsd:integer .
+  # Database: hgnc | Query: 3 | Comment: All 248 accessions map to 248 HGNC genes, each with exactly one obo:so_part_of location string, across 154 distinct bands; genes = rows = 248 so per-band counts sum to 248 (Rule 3, no gap/overlap)
+
+  ex:homeoboxSet ex:genesInHcoCytobands "241"^^xsd:integer ; ex:distinctHcoCytobands "149"^^xsd:integer .
+  # Database: hco | Query: 6 | Comment: 241 of the 248 genes resolve to a single ISCN cytoband in HCO (149 distinct GRCh38 bands); the flagship HGNC obo:so_part_of == HCO band rdfs:label join on the shared primary endpoint
+
+  ex:band_7p15_2 ex:homeoboxGeneCount "12"^^xsd:integer ; ex:members "HOXA1-HOXA13, EVX1" .
+  # Database: hgnc | Query: 4 | Comment: 7p15.2 harbours 12 homeobox genes (the HOXA cluster HOXA1-13 plus EVX1) — tied for the largest cluster
+  hco:7p15.2 rdfs:label "7p15.2" ; ex:giemsaStainGRCh38 "gpos50" ; ex:beginGRCh38 "25500001"^^xsd:integer ; ex:endGRCh38 "27900000"^^xsd:integer .
+  # Database: hco | Query: 5 | Comment: HCO band class 7p15.2; its GRCh38 instance is Giemsa gpos50, spanning 25,500,001-27,900,000 (~2.4 Mb) — coordinates/stain live on the per-build instance, reached by navigation
+
+  ex:band_2q31_1 ex:homeoboxGeneCount "12"^^xsd:integer ; ex:members "HOXD1-HOXD13, DLX1, DLX2, EVX2" .
+  # Database: hgnc | Query: 4 | Comment: 2q31.1 also harbours 12 homeobox genes (the HOXD cluster plus the DLX1/DLX2 bigene pair and EVX2) — tied with 7p15.2 for the largest cluster
+  hco:2q31.1 rdfs:label "2q31.1" ; ex:giemsaStainGRCh38 "gneg" ; ex:beginGRCh38 "168900001"^^xsd:integer ; ex:endGRCh38 "177100000"^^xsd:integer .
+  # Database: hco | Query: 5 | Comment: HCO band class 2q31.1; GRCh38 instance is Giemsa gneg, spanning 168,900,001-177,100,000 (~8.2 Mb) — the two tied top clusters differ cytogenetically (gpos50 vs gneg)
+
+  ex:band_12q13_13 ex:homeoboxGeneCount "10"^^xsd:integer ; ex:members "HOXC4-HOXC13, POU6F1" .
+  # Database: hgnc | Query: 4 | Comment: 12q13.13 harbours 10 homeobox genes (the HOXC cluster plus POU6F1)
+  hco:12q13.13 rdfs:label "12q13.13" ; ex:giemsaStainGRCh38 "gneg" ; ex:beginGRCh38 "51100001"^^xsd:integer ; ex:endGRCh38 "54500000"^^xsd:integer .
+  # Database: hco | Query: 5 | Comment: HCO band class 12q13.13; GRCh38 instance is Giemsa gneg, spanning 51,100,001-54,500,000 (~3.4 Mb)
+
+  ex:band_17q21_32 ex:homeoboxGeneCount "10"^^xsd:integer ; ex:members "HOXB1-HOXB13" .
+  # Database: hgnc | Query: 4 | Comment: 17q21.32 harbours 10 homeobox genes (the complete HOXB cluster)
+  hco:17q21.32 rdfs:label "17q21.32" ; ex:giemsaStainGRCh38 "gpos25" ; ex:beginGRCh38 "46800001"^^xsd:integer ; ex:endGRCh38 "49300000"^^xsd:integer .
+  # Database: hco | Query: 5 | Comment: HCO band class 17q21.32; GRCh38 instance is Giemsa gpos25, spanning 46,800,001-49,300,000 (~2.5 Mb)
+
+  ex:band_4q35_2 ex:homeoboxGeneCount "8"^^xsd:integer ; ex:members "DUX4, DUX4L2-DUX4L9" .
+  # Database: hgnc | Query: 4 | Comment: 4q35.2 harbours 8 homeobox genes — the DUX4 double-homeobox array (D4Z4 macrosatellite, the FSHD locus), a distinct non-HOX cluster
+  hco:4q35.2 rdfs:label "4q35.2" ; ex:giemsaStainGRCh38 "gpos25" ; ex:beginGRCh38 "186200001"^^xsd:integer ; ex:endGRCh38 "190214555"^^xsd:integer .
+  # Database: hco | Query: 5 | Comment: HCO band class 4q35.2; GRCh38 instance is Giemsa gpos25, spanning 186,200,001-190,214,555 (~4.0 Mb), the subtelomeric 4q terminus
+
+  ex:unresolvedGenes ex:count "7"^^xsd:integer ; ex:examples "DUX1/DUX3/DUX5 (not on reference assembly); SHOX (pseudoautosomal Xp22.33 and Yp11.32); HMBOX1/CUX2/ZFHX3 (range-spanning locations)" .
+  # Database: hco | Query: 6 | Comment: 7 of the 248 genes lack a single-band ISCN string so do not resolve to one HCO cytoband — unplaced DUX paralogues, the pseudoautosomal SHOX, and three genes recorded as multi-band ranges
+
+exact_answer: ""
+
+ideal_answer: |
+  The manually reviewed human proteins carrying a homeobox domain number 248, and every one maps to a single approved gene, so the family spans 248 genes distributed across 154 distinct cytogenetic-location strings; 241 of these genes resolve to a single ISCN band, occupying 149 distinct cytobands on the GRCh38 assembly. Their distribution is strongly clustered, reflecting the tandem-array organisation of homeobox loci. The two largest clusters are tied at 12 genes each: band 7p15.2, which holds the HOXA cluster (HOXA1 through HOXA13) together with EVX1, and band 2q31.1, which holds the HOXD cluster (HOXD1 through HOXD13) together with the DLX1/DLX2 bigene pair and EVX2. Next are the other two Hox loci, each with 10 genes: 12q13.13, carrying the HOXC cluster (HOXC4 through HOXC13) plus POU6F1, and 17q21.32, carrying the complete HOXB cluster (HOXB1 through HOXB13). A fifth notable cluster of 8 genes sits at the subtelomeric band 4q35.2 — not a Hox locus but the DUX4/DUX4L double-homeobox array of the D4Z4 macrosatellite, the region implicated in facioscapulohumeral muscular dystrophy. Cytogenetically these clusters are heterogeneous: the two co-largest bands differ in Giemsa character, with 7p15.2 staining gpos50 (GRCh38 25,500,001-27,900,000, ~2.4 Mb) and 2q31.1 staining gneg (168,900,001-177,100,000, ~8.2 Mb); 12q13.13 is gneg (51,100,001-54,500,000), while 17q21.32 and 4q35.2 are both gpos25 (46,800,001-49,300,000 and 186,200,001-190,214,555 respectively). Seven genes cannot be placed on a single band and are excluded from the cytoband tally: the DUX1/DUX3/DUX5 paralogues recorded as "not on reference assembly", the short-stature homeobox gene SHOX in the pseudoautosomal regions of Xp22.33 and Yp11.32, and HMBOX1, CUX2 and ZFHX3, whose locations are given as multi-band ranges. Overall, the reviewed homeobox gene set is a textbook example of a family whose members are concentrated in a handful of ancient tandem clusters — the four Hox loci accounting for 44 genes in just four bands — set against a long tail of singleton bands, and the four Hox clusters themselves span the full range of Giemsa staining rather than sharing a single cytogenetic signature.
+
+question_template_used: "Summary Multi-scale cytogenetic distribution of a keyword-defined protein family (reviewed protein set + gene nomenclature/chromosomal location + cytoband ontology with Giemsa stain and coordinates) synthesised into one narrative"
+
+time_spent:
+  exploration: 32 minutes
+  formulation: 18 minutes
+  verification: 14 minutes
+  pubmed_test: 11 minutes
+  extraction: 18 minutes
+  documentation: 28 minutes
+  total: 121 minutes

--- a/benchmark/questions/question_077.yaml
+++ b/benchmark/questions/question_077.yaml
@@ -1,0 +1,170 @@
+id: question_077
+type: factoid
+body: "In the current mouse reference genome assembly (GRCm39), consider the protein-coding genes annotated on each of the nuclear chromosomes — the autosomes 1 through 19 and the sex chromosomes X and Y, excluding the mitochondrial genome. Relative to each chromosome's assembled length, which single nuclear chromosome has the highest density of protein-coding genes, i.e. the greatest number of protein-coding genes per megabase?"
+
+inspiration_keyword:
+  keyword_id: KW-0158
+  name: Chromosome
+  category: Cellular component
+
+togomcp_databases_used:
+  - ensembl
+  - mco
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 9 minutes
+  method: |
+    Attempted to answer the specific question — which mouse nuclear chromosome has the highest
+    protein-coding gene density in GRCm39 — directly from the literature:
+    (1) "mouse chromosome protein-coding gene density GRCm39 highest"
+    (2) "mouse genome gene density per chromosome distribution comparison"
+    and read the single returned abstract (PMID 11528127).
+  result: |
+    The first query returned zero articles. The second returned one 2001 comparative-genomics
+    paper (PMID 11528127) that sequences a single ~620 kb syntenic locus on mouse chromosome 7
+    and reports a LOCAL gene density ("one gene per 66 kb") for that region only — it predates
+    the GRCm39 assembly (2020) by two decades and says nothing about genome-wide per-chromosome
+    protein-coding gene counts or which chromosome is densest. No source states the per-chromosome
+    density ranking: that requires counting the current protein-coding gene annotation on each
+    chromosome and normalising by the current assembled chromosome length, a live join of the gene
+    annotation set and the chromosome-length reference, not a fact recorded in the literature.
+  conclusion: PASS (cannot answer from literature; requires a live join of per-chromosome protein-coding gene counts with the GRCm39 chromosome-length reference)
+
+sparql_queries:
+  - query_number: 1
+    database: ensembl
+    description: >-
+      Count reviewed mouse (Mus musculus) protein-coding genes per GRCm39 chromosome. Genes are
+      filtered by the Ensembl species IRI (<http://ensembl.org/Mus_musculus>) and the protein_coding
+      biotype IRI (ENSGLOSSARY_0000026), grouped by their so:part_of chromosome IRI; the chromosome
+      name is derived from the IRI (version-independent, via STRAFTER on "/GRCm39/"). Returns 34 rows:
+      the 22 canonical chromosomes (1-19, X, Y, MT) plus 12 unplaced GRCm39 scaffolds. Chromosome 7
+      has the most protein-coding genes (2034), then chr2 (1822) and chr11 (1618).
+    query: |
+      PREFIX terms: <http://rdf.ebi.ac.uk/terms/ensembl/>
+      PREFIX so: <http://purl.obolibrary.org/obo/so#>
+
+      SELECT ?name (COUNT(DISTINCT ?gene) AS ?n)
+      FROM <http://rdfportal.org/dataset/ensembl>
+      WHERE {
+        ?gene a terms:EnsemblGene ;
+              <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Mus_musculus> ;
+              terms:has_biotype <http://ensembl.org/glossary/ENSGLOSSARY_0000026> ;
+              so:part_of ?chr .
+        FILTER(CONTAINS(STR(?chr), "/mus_musculus/GRCm39/"))
+        BIND(STRAFTER(STR(?chr), "/GRCm39/") AS ?name)
+      }
+      GROUP BY ?name
+      ORDER BY DESC(?n)
+    result_count: 34   # 22 canonical chromosomes + 12 unplaced scaffolds; chr7=2034, chr2=1822, chr11=1618, ... chrY=154, MT=13
+
+  - query_number: 2
+    database: ensembl
+    description: >-
+      Arithmetic verification (Hard Rule 3). Total distinct mouse protein-coding genes placed on any
+      GRCm39 sequence, and the raw gene-chromosome row count. Both equal 21808, proving each gene has
+      exactly one so:part_of GRCm39 placement, so the per-chromosome counts of Query 1 sum to 21808
+      with no gene double-counted (21760 on the 22 canonical chromosomes + 48 on the 12 scaffolds).
+    query: |
+      PREFIX terms: <http://rdf.ebi.ac.uk/terms/ensembl/>
+      PREFIX so: <http://purl.obolibrary.org/obo/so#>
+
+      SELECT (COUNT(DISTINCT ?gene) AS ?total_genes_on_grcm39) (COUNT(*) AS ?gene_chr_rows)
+      FROM <http://rdfportal.org/dataset/ensembl>
+      WHERE {
+        ?gene a terms:EnsemblGene ;
+              <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Mus_musculus> ;
+              terms:has_biotype <http://ensembl.org/glossary/ENSGLOSSARY_0000026> ;
+              so:part_of ?chr .
+        FILTER(CONTAINS(STR(?chr), "/mus_musculus/GRCm39/"))
+      }
+    result_count: 1   # total_genes_on_grcm39 = 21808, gene_chr_rows = 21808 (sum over Query-1 bins = 21760 canonical + 48 scaffolds)
+
+  - query_number: 3
+    database: mco
+    description: >-
+      Assembled length (bp) of every mouse chromosome on GRCm39, the normalising denominator for gene
+      density. Navigate from each chromosome class to its GRCm39 instance and read mco:length; the
+      chromosome name is taken from the IRI (mco rdfs:label is a known broken constant, so it is never
+      used). Returns 22 chromosomes; chr1 is longest (195,154,279 bp), MT shortest (16,299 bp).
+    query: |
+      PREFIX mco: <http://identifiers.org/mco/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT (STRAFTER(STR(?chr), "http://identifiers.org/mco/") AS ?name) ?length
+      FROM <http://rdfportal.org/dataset/mco>
+      WHERE {
+        ?inst a ?chr ;
+              mco:build mco:GRCm39 ;
+              mco:length ?length .
+        ?chr rdfs:subClassOf mco:MouseChromosome .
+      }
+      ORDER BY DESC(?length)
+    result_count: 22   # per-chromosome GRCm39 lengths; chr7 = 144,995,196 bp; chr11 = 121,973,369 bp; chr19 = 61,420,004 bp
+
+  # Density = (Query-1 gene count) / (Query-3 length in Mb), matched by chromosome name. The two
+  # source datasets are on different endpoints (ensembl = ebi, mco = primary), so the density is
+  # computed by joining the 22 (count, length) pairs. Among the nuclear chromosomes (excluding the
+  # mitochondrial outlier MT = 13 genes / 0.0163 Mb ~ 798 genes/Mb), chromosome 7 is the densest at
+  # 2034 / 144.995 = 14.03 genes/Mb, ahead of chr11 (1618 / 121.973 = 13.27) and chr19 (722 / 61.420 = 11.76).
+
+rdf_triples: |
+  @prefix mco:  <http://identifiers.org/mco/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:   <http://example.org/mouse-gene-density-analysis#> .
+
+  ex:analysis ex:assembly "GRCm39" ; ex:geneBiotype "protein_coding" ; ex:species "Mus musculus" .
+  # Database: ensembl | Query: 1 | Comment: Scope — protein-coding genes (biotype ENSGLOSSARY_0000026) of Mus musculus on the GRCm39 assembly, counted per chromosome via so:part_of
+
+  ex:mouseGenome ex:proteinCodingGenesOnGRCm39 "21808"^^xsd:integer ; ex:onCanonicalChromosomes "21760"^^xsd:integer ; ex:onUnplacedScaffolds "48"^^xsd:integer .
+  # Database: ensembl | Query: 2 | Comment: 21,808 protein-coding genes placed on GRCm39 (rows = distinct = 21,808, one placement per gene); 21,760 on the 22 canonical chromosomes + 48 on 12 unplaced scaffolds (Rule 3: sum of Query-1 bins = 21,808)
+
+  ex:chr7 ex:proteinCodingGenes "2034"^^xsd:integer ; ex:densityGenesPerMb "14.03" ; ex:rank "1 (highest nuclear density)" .
+  # Database: ensembl | Query: 1 | Comment: Chromosome 7 carries 2034 protein-coding genes — the most of any mouse chromosome — the numerator of its density
+  mco:7/GRCm39 mco:build mco:GRCm39 ; mco:length "144995196"^^xsd:integer .
+  # Database: mco | Query: 3 | Comment: Chromosome 7 GRCm39 length 144,995,196 bp; 2034 / 144.995 Mb = 14.03 genes/Mb — the highest density among the nuclear chromosomes (the ANSWER)
+
+  ex:chr11 ex:proteinCodingGenes "1618"^^xsd:integer ; ex:densityGenesPerMb "13.27" ; ex:rank "2" .
+  # Database: ensembl | Query: 1 | Comment: Chromosome 11, the runner-up in density
+  mco:11/GRCm39 mco:build mco:GRCm39 ; mco:length "121973369"^^xsd:integer .
+  # Database: mco | Query: 3 | Comment: Chromosome 11 GRCm39 length 121,973,369 bp; 1618 / 121.973 Mb = 13.27 genes/Mb (second highest, ~0.76 genes/Mb behind chr7)
+
+  ex:chr19 ex:proteinCodingGenes "722"^^xsd:integer ; ex:densityGenesPerMb "11.76" .
+  # Database: ensembl | Query: 1 | Comment: Chromosome 19, the shortest autosome, is third by density despite having few genes — small denominator
+  mco:19/GRCm39 mco:build mco:GRCm39 ; mco:length "61420004"^^xsd:integer .
+  # Database: mco | Query: 3 | Comment: Chromosome 19 GRCm39 length 61,420,004 bp (shortest autosome); 722 / 61.420 Mb = 11.76 genes/Mb
+
+  ex:chr1 ex:proteinCodingGenes "1211"^^xsd:integer ; ex:densityGenesPerMb "6.21" .
+  # Database: ensembl | Query: 1 | Comment: Chromosome 1, the longest chromosome, has only middling gene density — length and gene-richness are decoupled
+  mco:1/GRCm39 mco:build mco:GRCm39 ; mco:length "195154279"^^xsd:integer .
+  # Database: mco | Query: 3 | Comment: Chromosome 1 GRCm39 length 195,154,279 bp (longest); 1211 / 195.154 Mb = 6.21 genes/Mb — less than half of chr7's density
+
+  ex:chrY ex:proteinCodingGenes "154"^^xsd:integer ; ex:densityGenesPerMb "1.68" .
+  # Database: ensembl | Query: 1 | Comment: Chromosome Y has the lowest nuclear density (154 genes over 91.5 Mb) — the sparse, repeat-rich sex chromosome
+  mco:MT/GRCm39 mco:build mco:GRCm39 ; mco:length "16299"^^xsd:integer .
+  # Database: mco | Query: 3 | Comment: The mitochondrial genome (16,299 bp, 13 genes ~ 798 genes/Mb) is an extreme outlier excluded from the nuclear-chromosome comparison
+
+exact_answer: "Chromosome 7"
+
+ideal_answer: |
+  Among the nuclear chromosomes of the mouse GRCm39 assembly, chromosome 7 has the highest density of protein-coding genes, at roughly 14.0 genes per megabase. It carries 2,034 protein-coding genes — the most of any mouse chromosome — over an assembled length of about 145.0 Mb (144,995,196 bp), giving 2034/144.995 ≈ 14.03 genes/Mb. It edges out chromosome 11 (1,618 genes over 122.0 Mb ≈ 13.27 genes/Mb) and chromosome 19 (722 genes over the shortest autosome, 61.4 Mb ≈ 11.76 genes/Mb), while the longest chromosome, chromosome 1 (195.2 Mb), holds only 1,211 genes for a far lower 6.21 genes/Mb, and chromosome Y is the sparsest nuclear chromosome at 1.68 genes/Mb — showing that physical length and gene richness are decoupled. In total 21,760 of the 21,808 GRCm39-placed protein-coding genes lie on the 22 canonical chromosomes (the remaining 48 on unplaced scaffolds); the mitochondrial genome, with 13 genes packed into just 16,299 bp (~798 genes/Mb), is an extreme outlier and is set aside as it is not a nuclear chromosome. The result requires normalising the current per-chromosome gene annotation by the current assembled chromosome length, so it cannot be read off either source alone.
+
+question_template_used: "Factoid extremal aggregation (per-chromosome protein-coding gene count from genome annotation, normalised by chromosome length from the chromosome-length reference, argmax density)"
+
+time_spent:
+  exploration: 26 minutes
+  formulation: 15 minutes
+  verification: 12 minutes
+  pubmed_test: 9 minutes
+  extraction: 16 minutes
+  documentation: 24 minutes
+  total: 102 minutes

--- a/benchmark/questions/question_078.yaml
+++ b/benchmark/questions/question_078.yaml
@@ -1,0 +1,165 @@
+id: question_078
+type: choice
+body: "A curated proteomics resource provides reanalysed mass-spectrometry datasets, each annotated with the single source organism of its biological sample. Across all of these datasets, the two most frequently represented organisms are, unsurprisingly, human and mouse. Setting those two aside, which of the following organisms is the source of the greatest number of datasets?"
+
+choices:
+  - "African green monkey (Chlorocebus sabaeus)"
+  - "Norway rat (Rattus norvegicus)"
+  - "Escherichia coli"
+  - "Bacillus subtilis"
+
+inspiration_keyword:
+  keyword_id: KW-1267
+  name: Proteomics identification
+  category: Technical term
+
+togomcp_databases_used:
+  - jpostdb
+  - taxonomy
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: |
+    Attempted to answer the specific question — which organism, after human and mouse, is the
+    source of the most datasets in the jPOST reanalysis database — from the literature:
+    (1) "jPOST proteomics repository species composition organisms datasets"
+    (2) "Chlorocebus sabaeus green monkey Vero cell proteomics mass spectrometry third most studied"
+    (3) "jPOST proteome standard repository database"
+    and read the current jPOST resource paper (PMID 39526391, Nucleic Acids Res 2025).
+  result: |
+    The two targeted queries returned zero articles. The jPOST resource paper describes the
+    infrastructure — jPOSTrepo (>2000 projects), the UniScore-based reanalysis protocol, the jPOSTdb
+    integrated database (>600 datasets), and the JPDM data-descriptor journal — but reports nothing
+    about the per-organism composition of the datasets, and does not state that the African green
+    monkey is the third most-represented species. That ranking is a live aggregate over the current
+    contents of the reanalysis database (which grows with each release) joined to the taxonomy of the
+    sample organisms; it is not a figure recorded in any publication.
+  conclusion: PASS (cannot answer from literature; requires a live per-organism dataset count over the current repository joined to organism taxonomy)
+
+sparql_queries:
+  - query_number: 1
+    database: jpostdb
+    description: >-
+      Count reanalysis datasets per source organism. Each Dataset has exactly one Profile -> Sample
+      -> species (an identifiers.org/taxonomy IRI). Group all 853 datasets by that species IRI.
+      Returns exactly 7 organisms: human (taxonomy/9606, 579), mouse (10090, 234), green monkey
+      (60711, 30), E. coli (562, 5), K. pneumoniae (573, 2), B. subtilis (1423, 2), rat (10116, 1).
+    query: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+
+      SELECT ?species (COUNT(DISTINCT ?ds) AS ?nDatasets)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          ?ds a jpost:Dataset ;
+              jpost:hasProfile/jpost:hasSample ?sample .
+          ?sample jpost:species ?species .
+        }
+      }
+      GROUP BY ?species
+      ORDER BY DESC(?nDatasets)
+    result_count: 7   # 7 distinct source organisms; green monkey (taxonomy/60711) = 30 datasets, 3rd after human (579) and mouse (234)
+
+  - query_number: 2
+    database: jpostdb
+    description: >-
+      Arithmetic verification (Hard Rule 3). Total distinct datasets, datasets carrying a species,
+      and dataset-species rows. All three equal 853, proving every dataset has exactly one source
+      organism, so the 7 per-species counts of Query 1 partition the whole set with no gap or overlap
+      (579 + 234 + 30 + 5 + 2 + 2 + 1 = 853).
+    query: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+
+      SELECT (COUNT(DISTINCT ?ds) AS ?totalDatasets)
+             (COUNT(DISTINCT ?dsWithSpecies) AS ?datasetsWithSpecies)
+             (COUNT(*) AS ?dsSpeciesRows)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          ?ds a jpost:Dataset .
+          OPTIONAL {
+            ?ds jpost:hasProfile/jpost:hasSample/jpost:species ?sp .
+            BIND(?ds AS ?dsWithSpecies)
+          }
+        }
+      }
+    result_count: 1   # totalDatasets=853, datasetsWithSpecies=853, dsSpeciesRows=853 -> exhaustive 1-species-per-dataset partition (Rule 3)
+
+  - query_number: 3
+    database: taxonomy
+    description: >-
+      Resolve each source-organism taxonomy IRI from Query 1 to its scientific and common name,
+      confirming their identities. taxid 60711 = Chlorocebus sabaeus, common name "green monkey"
+      (rank Species) — the African green monkey, whose kidney-derived Vero cell line is the standard
+      substrate for virus propagation (e.g. SARS-CoV-2), explaining its prominence in the repository.
+    query: |
+      PREFIX taxo: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?taxid ?sciName ?commonName
+      WHERE {
+        VALUES ?tax {
+          <http://identifiers.org/taxonomy/9606>
+          <http://identifiers.org/taxonomy/10090>
+          <http://identifiers.org/taxonomy/60711>
+          <http://identifiers.org/taxonomy/562>
+          <http://identifiers.org/taxonomy/573>
+          <http://identifiers.org/taxonomy/1423>
+          <http://identifiers.org/taxonomy/10116>
+        }
+        ?tax taxo:scientificName ?sciName ;
+             dcterms:identifier ?taxid .
+        OPTIONAL { ?tax taxo:genbankCommonName ?commonName }
+      }
+    result_count: 7   # 9606 Homo sapiens (human); 10090 Mus musculus (house mouse); 60711 Chlorocebus sabaeus (green monkey); 562 Escherichia coli; 573 Klebsiella pneumoniae; 1423 Bacillus subtilis; 10116 Rattus norvegicus (Norway rat)
+
+rdf_triples: |
+  @prefix taxo: <http://ddbj.nig.ac.jp/ontologies/taxonomy/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:   <http://example.org/jpost-organism-analysis#> .
+
+  ex:jpostReanalysisDb ex:totalDatasets "853"^^xsd:integer ; ex:distinctSourceOrganisms "7"^^xsd:integer .
+  # Database: jpostdb | Query: 2 | Comment: The reanalysis database holds 853 datasets across exactly 7 distinct source organisms; every dataset carries exactly one species (853 = 853 = 853), so the per-species counts partition the whole set
+
+  <http://identifiers.org/taxonomy/9606> ex:jpostDatasetCount "579"^^xsd:integer .
+  # Database: jpostdb | Query: 1 | Comment: Homo sapiens is the most-represented organism with 579 datasets (excluded from the question as one of the two obvious top organisms)
+  <http://identifiers.org/taxonomy/10090> ex:jpostDatasetCount "234"^^xsd:integer .
+  # Database: jpostdb | Query: 1 | Comment: Mus musculus is second with 234 datasets (the other excluded top organism)
+
+  <http://identifiers.org/taxonomy/60711> rdfs:label "Chlorocebus sabaeus" ; taxo:genbankCommonName "green monkey" .
+  # Database: taxonomy | Query: 3 | Comment: taxid 60711 = Chlorocebus sabaeus, the African green monkey (rank Species); its Vero kidney cell line is the standard host for propagating viruses such as SARS-CoV-2
+  <http://identifiers.org/taxonomy/60711> ex:jpostDatasetCount "30"^^xsd:integer ; ex:rankAfterHumanMouse "1 (the answer)" .
+  # Database: jpostdb | Query: 1 | Comment: The African green monkey is the source of 30 datasets — the THIRD most-represented species overall and by far the most once human and mouse are set aside (THE ANSWER)
+
+  <http://identifiers.org/taxonomy/562> rdfs:label "Escherichia coli" ; ex:jpostDatasetCount "5"^^xsd:integer .
+  # Database: taxonomy,jpostdb | Query: 3 | Comment: Escherichia coli (taxid 562) is a distractor: only 5 datasets, a sixth of the green monkey total
+  <http://identifiers.org/taxonomy/10116> rdfs:label "Rattus norvegicus" ; ex:jpostDatasetCount "1"^^xsd:integer .
+  # Database: taxonomy,jpostdb | Query: 3 | Comment: Rattus norvegicus (Norway rat, taxid 10116) is a distractor and, strikingly, the LEAST-represented organism with a single dataset — a classic model organism far behind the green monkey
+  <http://identifiers.org/taxonomy/1423> rdfs:label "Bacillus subtilis" ; ex:jpostDatasetCount "2"^^xsd:integer .
+  # Database: taxonomy,jpostdb | Query: 3 | Comment: Bacillus subtilis (taxid 1423) is a distractor with 2 datasets
+  <http://identifiers.org/taxonomy/573> rdfs:label "Klebsiella pneumoniae" ; ex:jpostDatasetCount "2"^^xsd:integer .
+  # Database: taxonomy,jpostdb | Query: 3 | Comment: Klebsiella pneumoniae (taxid 573) has 2 datasets; the seven counts 579+234+30+5+2+2+1 sum to 853 = total datasets (Rule 3 complete)
+
+exact_answer:
+  - "African green monkey (Chlorocebus sabaeus)"
+
+ideal_answer: |
+  Setting aside human (579 datasets) and mouse (234 datasets), the organism that is the source of the greatest number of reanalysed mass-spectrometry datasets is the African green monkey, Chlorocebus sabaeus (NCBI taxon 60711), with 30 datasets. This puts it third overall, and it dominates the remaining organisms by a wide margin: Escherichia coli follows with just 5 datasets, then Bacillus subtilis and Klebsiella pneumoniae with 2 each, and — strikingly for such a common model organism — the Norway rat (Rattus norvegicus) last with a single dataset. Only seven distinct source organisms appear across the 853 datasets, and each dataset is annotated with exactly one, so the counts 579 + 234 + 30 + 5 + 2 + 2 + 1 sum precisely to 853. The green monkey's unexpected prominence is not because it is a mainstream model organism but because its kidney-derived Vero cell line is the standard substrate for propagating viruses — most conspicuously SARS-CoV-2 — so a surge of virus- and infection-focused proteomics reanalyses places a non-model primate above every classic bacterial and rodent model in the repository.
+
+question_template_used: "Choice extremal aggregation with obvious top-N excluded (per-category dataset count from a proteomics repository, category identity resolved via organism taxonomy, argmax among the non-obvious remainder)"
+
+time_spent:
+  exploration: 30 minutes
+  formulation: 14 minutes
+  verification: 10 minutes
+  pubmed_test: 10 minutes
+  extraction: 16 minutes
+  documentation: 22 minutes
+  total: 102 minutes

--- a/benchmark/questions/question_079.yaml
+++ b/benchmark/questions/question_079.yaml
@@ -1,0 +1,180 @@
+id: question_079
+type: yes_no
+body: "Major histocompatibility complex (MHC) class I molecules are a family of cell-surface glycoproteins that present intracellular peptides to CD8+ T cells and are central to adaptive immunity. Considering the complete set of manually reviewed human proteins classified as MHC class I molecules, are the genes that encode all of them located on the same chromosome?"
+
+inspiration_keyword:
+  keyword_id: KW-0490
+  name: MHC I
+  category: Cellular component
+
+togomcp_databases_used:
+  - uniprot
+  - hgnc
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: |
+    Attempted to answer the specific question — whether the genes for ALL reviewed human MHC
+    class I proteins lie on one chromosome — from the literature:
+    (1) "MHC class I proteins chromosomal location beta-2-microglobulin MR1 different chromosomes"
+    (2) "human MHC class I molecules all encoded single chromosome 6 HLA B2M"
+    (3) "MHC class I molecule structure beta-2-microglobulin heavy chain review"
+    and read the MHC-I review PMID 37398669 (Front Immunol 2023).
+  result: |
+    The two targeted queries returned zero articles. The review describes the functional
+    architecture of MHC class I — the polymorphic heavy chain, its non-covalent assembly with the
+    invariant light chain beta-2-microglobulin, and peptide loading — but says nothing about the
+    chromosomal locations of the encoding genes. The literature covers the MHC locus on 6p21, the
+    B2M gene on chromosome 15, and MR1 on chromosome 1 in separate contexts, but no source poses or
+    answers the completeness question over the MHC-class-I keyword set. Answering it requires
+    enumerating every reviewed human MHC class I protein and looking up each gene's chromosome — a
+    live cross-database check, not a stated fact. The intuitive answer ("yes, the MHC on chromosome
+    6") is in fact wrong, which cannot be established without the enumeration.
+  conclusion: PASS (cannot answer from literature; requires enumerating the full keyword-defined protein set and each gene's chromosomal location across two databases)
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Count the manually reviewed (Swiss-Prot) human (taxon 9606) proteins classified with the MHC
+      class I keyword (KW-0490 = keywords/490). Establishes the complete, exhaustive family scope:
+      exactly 9 proteins (Hard Rule 2 — the yes/no is decided over all 9, not a sample).
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+
+      SELECT (COUNT(DISTINCT ?p) AS ?n)
+      WHERE {
+        ?p a up:Protein ;
+           up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:classifiedWith <http://purl.uniprot.org/keywords/490> .
+      }
+    result_count: 1   # n = 9 reviewed human MHC class I proteins
+
+  - query_number: 2
+    database: uniprot
+    description: >-
+      Retrieve the accession and gene symbol of each of the 9 MHC class I proteins. Result: seven HLA
+      heavy-chain genes (HLA-A P04439, HLA-B P01889, HLA-C P10321, HLA-E P13747, HLA-F P30511,
+      HLA-G P17693, HLA-H P01893), plus the invariant light chain B2M (P61769) and the non-classical
+      MHC-I-related molecule MR1 (Q95460).
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT ?acc ?gene
+      WHERE {
+        ?p a up:Protein ;
+           up:reviewed 1 ;
+           up:organism <http://purl.uniprot.org/taxonomy/9606> ;
+           up:classifiedWith <http://purl.uniprot.org/keywords/490> ;
+           dcterms:identifier ?acc .
+        OPTIONAL { ?p up:encodedBy/skos:prefLabel ?gene }
+      }
+      ORDER BY ?gene
+    result_count: 9
+
+  - query_number: 3
+    database: hgnc
+    description: >-
+      Look up the chromosomal band (obo:so_part_of) of each of the 9 genes in HGNC, joining on the
+      UniProt accession via the typed cross-reference node. Result: HLA-A/E/F/G/H at 6p22.1, HLA-B/C
+      at 6p21.33 (all chromosome 6); B2M at 15q21.1 (chromosome 15); MR1 at 1q25.3 (chromosome 1).
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+
+      SELECT ?symbol ?location ?acc
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?acc { "P61769" "P04439" "P01889" "P10321" "P13747" "P30511" "P17693" "P01893" "Q95460" }
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              rdfs:seeAlso ?ref ;
+              obo:so_part_of ?location .
+        ?ref a idt:uniprot ; dct:identifier ?acc .
+      }
+      ORDER BY ?location
+    result_count: 9
+
+  - query_number: 4
+    database: hgnc
+    description: >-
+      Arithmetic / completeness verification (Hard Rule 3). Group the 9 genes by chromosome (derived
+      from the band string). Three distinct chromosomes are returned — 6 (7 genes), 15 (1 gene, B2M),
+      1 (1 gene, MR1) — and 7 + 1 + 1 = 9 covers the full family, so the answer is unambiguously "no"
+      (the genes are NOT all on one chromosome), with no member unaccounted for.
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX idt: <http://identifiers.org/>
+
+      SELECT ?chromosome (COUNT(DISTINCT ?gene) AS ?nGenes) (GROUP_CONCAT(?symbol; SEPARATOR=", ") AS ?genes)
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?acc { "P61769" "P04439" "P01889" "P10321" "P13747" "P30511" "P17693" "P01893" "Q95460" }
+        ?gene a m2r:Gene ;
+              rdfs:label ?symbol ;
+              rdfs:seeAlso ?ref ;
+              obo:so_part_of ?location .
+        ?ref a idt:uniprot ; dct:identifier ?acc .
+        BIND(REPLACE(?location, "[pq].*$", "") AS ?chromosome)
+      }
+      GROUP BY ?chromosome
+      ORDER BY DESC(?nGenes)
+    result_count: 3   # chr6 = 7 (HLA-A/B/C/E/F/G/H), chr15 = 1 (B2M), chr1 = 1 (MR1); 7+1+1 = 9
+
+rdf_triples: |
+  @prefix uniprot: <http://purl.uniprot.org/uniprot/> .
+  @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:      <http://example.org/mhc1-chromosome-analysis#> .
+
+  ex:mhcClassI ex:reviewedHumanMembers "9"^^xsd:integer ; ex:distinctChromosomes "3"^^xsd:integer ; ex:allOnOneChromosome "false"^^xsd:boolean .
+  # Database: uniprot | Query: 1 | Comment: Exactly 9 reviewed human proteins carry the MHC class I keyword (KW-0490); they map to 3 different chromosomes, so the answer to the question is NO
+
+  uniprot:P04439 ex:gene "HLA-A" ; ex:chromosomalBand "6p22.1" .
+  # Database: hgnc | Query: 3 | Comment: HLA-A, one of the seven polymorphic HLA heavy-chain genes clustered in the MHC on chromosome 6
+  uniprot:P01889 ex:gene "HLA-B" ; ex:chromosomalBand "6p21.33" .
+  # Database: hgnc | Query: 3 | Comment: HLA-B at 6p21.33 — the classical MHC-I heavy chains (HLA-A/B/C) and non-classical (HLA-E/F/G/H) all sit on chromosome 6
+  uniprot:P10321 ex:gene "HLA-C" ; ex:chromosomalBand "6p21.33" .
+  # Database: hgnc | Query: 3 | Comment: HLA-C at 6p21.33; together the seven HLA genes account for 7 of the 9 family members
+  uniprot:P61769 ex:gene "B2M" ; ex:chromosomalBand "15q21.1" .
+  # Database: hgnc | Query: 3 | Comment: B2M (beta-2-microglobulin), the OBLIGATE invariant light chain of every MHC-I molecule, is encoded on chromosome 15 (15q21.1) — NOT chromosome 6
+  uniprot:Q95460 ex:gene "MR1" ; ex:chromosomalBand "1q25.3" .
+  # Database: hgnc | Query: 3 | Comment: MR1 (MHC class I-related), which presents microbial metabolites to MAIT cells, is encoded on chromosome 1 (1q25.3) — a third chromosome
+
+  ex:chromosome6 ex:mhcClassIGeneCount "7"^^xsd:integer .
+  # Database: hgnc | Query: 4 | Comment: 7 members on chromosome 6 (all seven HLA genes)
+  ex:chromosome15 ex:mhcClassIGeneCount "1"^^xsd:integer .
+  # Database: hgnc | Query: 4 | Comment: 1 member on chromosome 15 (B2M)
+  ex:chromosome1 ex:mhcClassIGeneCount "1"^^xsd:integer .
+  # Database: hgnc | Query: 4 | Comment: 1 member on chromosome 1 (MR1); 7 + 1 + 1 = 9 accounts for the whole family (Rule 3 complete), confirming the genes span three chromosomes
+
+exact_answer: "no"
+
+ideal_answer: |
+  No. The nine manually reviewed human MHC class I proteins are not all encoded on one chromosome; their genes are distributed across three different chromosomes. Seven of them are the HLA heavy-chain genes — the classical HLA-A, HLA-B and HLA-C plus the non-classical HLA-E, HLA-F, HLA-G and HLA-H — which are indeed clustered together in the major histocompatibility complex on the short arm of chromosome 6 (at 6p21.33 and 6p22.1). But the eighth member, B2M, encodes beta-2-microglobulin, the invariant light chain that is non-covalently associated with every MHC class I heavy chain and is obligatory for a functional molecule; it lies on chromosome 15 (15q21.1). The ninth, MR1, encodes the MHC class I-related molecule that presents microbial vitamin-B metabolites to mucosal-associated invariant T (MAIT) cells, and it is on chromosome 1 (1q25.3). So while the polymorphic heavy chains are polygenic within the chromosome-6 MHC locus, the complete MHC class I family — counting its essential light chain and its class I-related member — is encoded across chromosomes 1, 6 and 15 (7 + 1 + 1 = 9). The intuitive "yes, they are all in the MHC on chromosome 6" is therefore incorrect once the full protein set is considered.
+
+question_template_used: "Yes/no completeness check over a keyword-defined protein family (are all members' genes co-localised to one chromosome?) — exhaustive per-member chromosomal-location lookup that overturns an intuitive single-locus assumption"
+
+time_spent:
+  exploration: 34 minutes
+  formulation: 14 minutes
+  verification: 12 minutes
+  pubmed_test: 10 minutes
+  extraction: 15 minutes
+  documentation: 22 minutes
+  total: 107 minutes

--- a/benchmark/questions/question_080.yaml
+++ b/benchmark/questions/question_080.yaml
@@ -1,0 +1,192 @@
+id: question_080
+type: list
+body: "Coenzyme M (2-mercaptoethanesulfonate) is one of the smallest known enzyme cofactors, best known as the terminal methyl-group carrier of methanogenesis. Considering the curated collection of approved biochemical reactions, list every reaction in which free coenzyme M, in its physiological monoanionic form, appears as a direct participant (reactant or product). Give the reactions by their stable reaction identifiers."
+
+inspiration_keyword:
+  keyword_id: KW-0174
+  name: Coenzyme M biosynthesis
+  category: Biological process
+
+togomcp_databases_used:
+  - rhea
+  - chebi
+
+verification_score:
+  biological_insight: 3
+  multi_database: 2
+  verifiability: 3
+  rdf_necessity: 3
+  total: 11
+  passed: true
+
+pubmed_test:
+  time_spent: 9 minutes
+  method: |
+    Attempted to obtain the complete set of biochemical reactions involving coenzyme M from the
+    literature:
+    (1) "coenzyme M all enzymatic reactions participant complete list methanogenesis epoxyalkane"
+    (2) "coenzyme M 2-mercaptoethanesulfonate cofactor reactions review biochemistry"
+    and read the review PMID 12524213 (Annu Rev Biochem 2003, "Aliphatic epoxide carboxylation").
+  result: |
+    The first query returned nothing; the second returned two focused reviews. The one read
+    (12524213) describes only the four-enzyme aerobic epoxide-carboxylation pathway that uses
+    coenzyme M as an "atypical cofactor" — confirming CoM participates there, but covering a single
+    pathway. No source enumerates the complete cross-pathway reaction set: the methanogenesis
+    methyl-transfer and heterodisulfide-reductase reactions plus the bacterial epoxyalkane reactions
+    are described in separate literatures, and no review lists them together as a defined reaction
+    collection. Producing the exhaustive list requires querying the curated reaction resource for
+    every approved reaction containing the specific physiological form of coenzyme M — a live
+    database enumeration, not a recallable or published set.
+  conclusion: PASS (cannot answer from literature; requires enumerating a curated reaction database for all approved reactions containing a specific ChEBI compound)
+
+# STRUCTURED VOCABULARY DISCOVERY (OLS4 searchClasses on ChEBI)
+# coenzyme M = CHEBI:17905 (neutral); its physiological conjugate base (major species at pH 7.3) is
+# CHEBI:58319 "coenzyme M(1-)" — the form the reaction database uses. Verified: 0 approved reactions
+# reference the neutral CHEBI:17905, so CHEBI:58319 captures the complete set (no coverage gap).
+
+sparql_queries:
+  - query_number: 1
+    database: rhea
+    description: >-
+      Count the approved reactions in which free coenzyme M participates, matching the physiological
+      monoanion (CHEBI:58319) on the reaction-participant path (reaction -> side -> contains ->
+      compound -> chebi). Returns 19 — the exhaustive count that the list must enumerate (Hard Rule 2).
+    query: |
+      PREFIX rh: <http://rdf.rhea-db.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT (COUNT(DISTINCT ?reaction) AS ?n)
+      WHERE {
+        ?reaction rdfs:subClassOf rh:Reaction ;
+                  rh:status rh:Approved ;
+                  rh:side ?side .
+        ?side rh:contains ?participant .
+        ?participant rh:compound ?compound .
+        ?compound rh:chebi <http://purl.obolibrary.org/obo/CHEBI_58319> .
+      }
+    result_count: 1   # n = 19
+
+  - query_number: 2
+    database: rhea
+    description: >-
+      Enumerate the 19 reactions with their stable Rhea identifier and equation. The set spans three
+      biochemistries: methyl-coenzyme M formation (corrinoid-protein methyltransferases for
+      methylamines/methanol/methanethiol/etc., and the Na+-pumping methyl-tetrahydromethanopterin /
+      -sarcinapterin methyltransferases), the heterodisulfide-reductase reactions (CoM + CoB ->
+      CoM-CoB heterodisulfide, coupled to methanophenazine/ferredoxin/F420/fumarate/H2/formate), and
+      the aerobic bacterial epoxyalkane pathway (epoxypropane + CoM; 2-oxopropyl-CoM carboxylation).
+    query: |
+      PREFIX rh: <http://rdf.rhea-db.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?rheaId ?equation
+      WHERE {
+        ?reaction rdfs:subClassOf rh:Reaction ;
+                  rh:status rh:Approved ;
+                  rh:id ?rheaId ;
+                  rh:equation ?equation ;
+                  rh:side ?side .
+        ?side rh:contains ?participant .
+        ?participant rh:compound ?compound .
+        ?compound rh:chebi <http://purl.obolibrary.org/obo/CHEBI_58319> .
+      }
+      ORDER BY ?rheaId
+    result_count: 19
+
+  - query_number: 3
+    database: rhea
+    description: >-
+      Completeness verification (Hard Rule 2 / no coverage gap). Count approved reactions referencing
+      the NEUTRAL coenzyme M form (CHEBI:17905) instead of the anion. Returns 0, confirming that the
+      reaction database uses only the monoanion (CHEBI:58319) and that the 19 reactions of Query 2 are
+      the complete set — no reaction is missed by scoping to the anionic form.
+    query: |
+      PREFIX rh: <http://rdf.rhea-db.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT (COUNT(DISTINCT ?reaction) AS ?nNeutralForm)
+      WHERE {
+        ?reaction rdfs:subClassOf rh:Reaction ;
+                  rh:status rh:Approved ;
+                  rh:side/rh:contains/rh:compound/rh:chebi <http://purl.obolibrary.org/obo/CHEBI_17905> .
+      }
+    result_count: 1   # nNeutralForm = 0 (so 19 via the anion is complete)
+
+  - query_number: 4
+    database: chebi
+    description: >-
+      Confirm the identity of the participant compound. CHEBI:58319 has label "coenzyme M(1-)"; per
+      its ChEBI definition it is the conjugate base of coenzyme M (CHEBI:17905, 2-mercaptoethanesulfonate)
+      and the major species at pH 7.3 — establishing that the reaction-database match is indeed free
+      coenzyme M in its physiological form (this is the compound-identity anchor for the whole query).
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?chebi ?label
+      WHERE {
+        VALUES ?chebi { obo:CHEBI_58319 obo:CHEBI_17905 }
+        ?chebi rdfs:label ?label .
+      }
+    result_count: 2   # CHEBI:58319 "coenzyme M(1-)", CHEBI:17905 "coenzyme M"
+
+rdf_triples: |
+  @prefix rh:   <http://rdf.rhea-db.org/> .
+  @prefix obo:  <http://purl.obolibrary.org/obo/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:   <http://example.org/coenzyme-m-reactions#> .
+
+  obo:CHEBI_58319 rdfs:label "coenzyme M(1-)" .
+  # Database: chebi | Query: 4 | Comment: The physiological monoanion of coenzyme M (conjugate base of CHEBI:17905, 2-mercaptoethanesulfonate; major species at pH 7.3) — the form matched in every reaction
+
+  ex:analysis ex:approvedReactionsWithFreeCoM "19"^^xsd:integer ; ex:reactionsViaNeutralForm "0"^^xsd:integer .
+  # Database: rhea | Query: 1 | Comment: 19 approved reactions contain free coenzyme M via the anion CHEBI:58319; 0 use the neutral CHEBI:17905, so the 19 are the complete set (Rule 2, no gap)
+
+  rh:32667 ex:equation "methanethiol + coenzyme M = methyl-coenzyme M + hydrogen sulfide + H(+)" .
+  # Database: rhea | Query: 2 | Comment: One of the corrinoid-independent / methylotrophic methyl-CoM-forming reactions — methanethiol methyltransferase
+  rh:45208 ex:equation "methyl-Co(III)-[methanol-specific corrinoid protein] + coenzyme M = Co(I)-[methanol-specific corrinoid protein] + methyl-coenzyme M + H(+)" .
+  # Database: rhea | Query: 2 | Comment: A corrinoid-protein methyltransferase forming methyl-CoM (methanol branch); the methylamine/dimethylamine/trimethylamine/tetramethylammonium/glycine-betaine/methylated-thiol analogues are also in the set
+  rh:53492 ex:equation "5-methyl-5,6,7,8-tetrahydromethanopterin + coenzyme M + 2 Na(+)(in) = 5,6,7,8-tetrahydromethanopterin + methyl-coenzyme M + 2 Na(+)(out)" .
+  # Database: rhea | Query: 2 | Comment: The sodium-pumping methyl-H4MPT:coenzyme M methyltransferase (Mtr) — a central membrane-bound step of hydrogenotrophic methanogenesis
+  rh:18085 ex:equation "methanophenazine + coenzyme B + coenzyme M = dihydromethanophenazine + coenzyme M-coenzyme B heterodisulfide" .
+  # Database: rhea | Query: 2 | Comment: A heterodisulfide-reductase reaction consuming free CoM (with coenzyme B) to form the CoM-CoB heterodisulfide; other electron-donor variants use ferredoxin, F420, fumarate, H2 or formate
+  rh:19421 ex:equation "(R)-2-hydroxypropyl-coenzyme M = (R)-1,2-epoxypropane + coenzyme M" .
+  # Database: rhea | Query: 2 | Comment: The aerobic bacterial epoxyalkane pathway (Xanthobacter/Rhodococcus) — CoM is the nucleophile that opens the epoxide; CoM is NOT confined to methanogenic archaea (the (S)-enantiomer reaction 20904 is also present)
+  rh:16977 ex:equation "coenzyme M + acetoacetate + NADP(+) = 2-oxopropyl-coenzyme M + CO2 + NADPH" .
+  # Database: rhea | Query: 2 | Comment: The NADPH:2-ketopropyl-CoM oxidoreductase/carboxylase step of aerobic epoxide carboxylation — the reaction that regenerates free CoM and fixes CO2
+
+exact_answer:
+  - "RHEA:16977"
+  - "RHEA:18085"
+  - "RHEA:18773"
+  - "RHEA:19421"
+  - "RHEA:20904"
+  - "RHEA:32667"
+  - "RHEA:40235"
+  - "RHEA:45208"
+  - "RHEA:45216"
+  - "RHEA:45220"
+  - "RHEA:47192"
+  - "RHEA:53492"
+  - "RHEA:55160"
+  - "RHEA:55744"
+  - "RHEA:55748"
+  - "RHEA:55752"
+  - "RHEA:60576"
+  - "RHEA:66004"
+  - "RHEA:79363"
+
+ideal_answer: |
+  Nineteen approved reactions contain free coenzyme M (matched as its physiological monoanion, ChEBI:58319 "coenzyme M(1-)") as a direct participant; no reaction uses the neutral form, so this set of 19 is complete. They fall into three biochemical groups. The first and largest group forms methyl-coenzyme M: eight corrinoid-protein methyltransferases transfer a methyl group to CoM from methanol- (RHEA:45208), methylamine- (RHEA:18773), dimethylamine- (RHEA:45216), trimethylamine- (RHEA:45220), tetramethylammonium- (RHEA:60576), glycine-betaine- (RHEA:66004), and methylated-thiol-specific (RHEA:47192) corrinoid proteins, and a methanethiol methyltransferase (RHEA:32667); two further sodium-translocating methyltransferases methylate CoM from 5-methyl-tetrahydromethanopterin (RHEA:53492) and 5-methyl-tetrahydrosarcinapterin (RHEA:79363), the central Mtr step of methanogenesis. The second group is the heterodisulfide-forming reactions that consume free CoM together with coenzyme B to make the CoM-CoB heterodisulfide, coupled to a range of electron donors — methanophenazine (RHEA:18085), fumarate (RHEA:40235), reduced ferredoxin (RHEA:55160), coenzyme F420 plus ferredoxin (RHEA:55744), H2 (RHEA:55748), and formate (RHEA:55752). The third group, strikingly, is not from methanogenic archaea at all but from the aerobic bacterial aliphatic-epoxide (epoxyalkane) carboxylation pathway of organisms such as Xanthobacter and Rhodococcus: CoM is the nucleophile that opens (R)- and (S)-1,2-epoxypropane (RHEA:19421 and RHEA:20904) and is regenerated in the NADPH-dependent carboxylation of 2-oxopropyl-CoM (RHEA:16977). The list therefore captures a small, unusual cofactor whose reactions were long thought to be the exclusive province of methanogenesis but which is in fact shared with an aerobic alkene-metabolism pathway.
+
+question_template_used: "List — enumerate every curated approved reaction in which a specific cofactor/metabolite (fixed to its physiological ChEBI form) is a direct participant (metabolite-centric reaction enumeration)"
+
+time_spent:
+  exploration: 30 minutes
+  formulation: 14 minutes
+  verification: 11 minutes
+  pubmed_test: 9 minutes
+  extraction: 18 minutes
+  documentation: 24 minutes
+  total: 106 minutes

--- a/benchmark/togomcp_qa_prompt.md
+++ b/benchmark/togomcp_qa_prompt.md
@@ -263,5 +263,10 @@ Mark: `P` = pass · `W` = minor issues · `F` = major errors
 | 073 | P      | —      |
 | 074 | P      | —      |
 | 075 | P      | —      |
+| 076 | P      | —      |
+| 077 | P      | —      |
+| 078 | P      | —      |
+| 079 | P      | —      |
+| 080 | P      | —      |
 
-**Summary:** `P` = 70 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 70 / 70
+**Summary:** `P` = 80 &nbsp;·&nbsp; `W` = 0 &nbsp;·&nbsp; `F` = 0 &nbsp;·&nbsp; Reviewed: 80 / 80


### PR DESCRIPTION
## Summary

Adds five fully-validated benchmark questions (Q076–Q080), bringing the TogoMCP evaluation set to a **balanced 80-question milestone**: exactly **16 per type**, **100% multi-database**, and **all 34 registry databases now covered** (HCO and MCO — the two previously uncovered databases — get their first questions here).

| Q | Type | Databases | Keyword | Topic |
|---|---|---|---|---|
| 076 | summary | uniprot + hgnc + hco | KW-0371 Homeobox | Cytogenetic distribution of reviewed human homeobox genes across GRCh38 cytobands (tied HOXA/HOXD clusters; Giemsa stains) — **first HCO use** |
| 077 | factoid | ensembl + mco | KW-0158 Chromosome | Mouse nuclear chromosome with highest protein-coding gene density on GRCm39 (chr 7) — **first MCO use** |
| 078 | choice | jpostdb + taxonomy | KW-1267 Proteomics identification | 3rd most-represented source organism in the jPOST reanalysis DB (African green monkey / Vero cells) |
| 079 | yes_no | uniprot + hgnc | KW-0490 MHC I | Are all reviewed human MHC class I genes on one chromosome? (no — chr6/chr15/chr1) |
| 080 | list | rhea + chebi | KW-0174 Coenzyme M biosynthesis | The 19 approved reactions in which free coenzyme M participates |

## Validation

- Each question passes the type-first protocol: exhaustive query scope (Rule 2), arithmetic/completeness verification (Rule 3), and both necessity gates (training + PubMed).
- `python benchmark/scripts/verify_questions.py`: **0 errors**, no structural near-duplicate signature collisions, **80/80 passing**.

## Tracker updates

`coverage_tracker.yaml` and `togomcp_qa_prompt.md` reconciled: per-type counts (all five → 16), per-database counts, `keywords_used`, and multi-database metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)