### PR TITLE
chore(docker): bump base to python3.12-trixie-slim (Python 3.12.13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-# Use a lightweight Python base image
-FROM docker.io/astral/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
+# Use a lightweight Python base image.
+# Pinned by digest for reproducible builds — bump the digest to move Python/uv/OS.
+# python3.12-trixie-slim (Debian 13) = Python 3.12.13, uv 0.11.28 (image built 2026-07-07).
+# NB: astral froze the bookworm-slim (Debian 12) line at uv 0.9.30 / Python 3.12.12
+# on 2026-02-04 and now ships only trixie variants, so this is a Debian 12->13 bump.
+FROM docker.io/astral/uv:python3.12-trixie-slim@sha256:3137a0b606f65a74ee0245f43dae219b09e8af98fc37fef20841cbceef35a646
 
 # Install tzdata so the TZ env var (set in compose.yaml) resolves correctly
 # instead of silently falling back to UTC.


### PR DESCRIPTION
## ⚠️ Do not merge until `scripts/deploy.sh test` is green on the host

This is a **Debian major bump (12 bookworm → 13 trixie)**, so it must be built and smoke-tested on the Podman host before promotion, not merged blind.

## Why

The pinned base `python3.12-bookworm-slim@sha256:e5b65587…` (built 2026-02-04) ships **Python 3.12.12** / uv 0.9.30. Python **3.12.13** (a security-only release) shipped 2026-03-03. astral **froze the `bookworm-slim` line on 2026-02-04** and now publishes only `trixie` variants — so re-pinning `bookworm-slim` is a no-op; there is no bookworm-slim image carrying 3.12.13.

## Change

`FROM` → `python3.12-trixie-slim@sha256:3137a0b6…` (built 2026-07-07):

| | Before | After |
|---|---|---|
| Debian | 12 bookworm | 13 trixie |
| Python | 3.12.12 | **3.12.13** |
| uv | 0.9.30 | 0.11.28 |

Digest verified via `docker buildx imagetools inspect`: amd64 config reports `PYTHON_VERSION=3.12.13`.

## Risk / validation

- Debian 12→13 shifts system libs (glibc, OpenSSL, CA certs); Dockerfile only layers `tzdata` on top, so risk is low but real.
- uv 0.9.30→0.11.28 is a large jump; build runs `uv sync --frozen` against the existing `uv.lock` — the test build is where a lock-format incompatibility would surface.
- **Validation gate:** `./scripts/deploy.sh test` (build candidate, recreate TEST on :8001, smoke → 200) must pass, then `./scripts/deploy.sh prod` to promote the tested bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)