### PR TITLE
feat(togovar): TogoVar REST wrapper as a mounted sub-server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,13 @@ FastMCP server exposing the [RDF Portal](https://rdfportal.org/) (SPARQL) plus s
 
 ## Architecture
 
-The server is assembled in [main.py](togo_mcp/main.py): a root `FastMCP` instance (`mcp`, defined in [server.py](togo_mcp/server.py)) mounts two sub-servers as prefixes:
+The server is assembled in [main.py](togo_mcp/main.py): a root `FastMCP` instance (`mcp`, defined in [server.py](togo_mcp/server.py)) mounts three sub-servers as prefixes:
 
 - `togoid_mcp` from [togoid.py](togo_mcp/togoid.py) — mounted as `togoid`
 - `ncbi_mcp` from [ncbi_tools.py](togo_mcp/ncbi_tools.py) — mounted as `ncbi`
+- `togovar_mcp` from [togovar.py](togo_mcp/togovar.py) — mounted as `togovar`
+
+A REST wrapper becomes a **mounted sub-server** (not a flat `api_tools.py` `search_*` tool) when the external API is a cohesive multi-endpoint surface with *no* SPARQL counterpart in RDF Portal — the flat wrappers are keyword-search front doors to a SPARQL database (their error hint points back to `run_sparql`), so a DB without a SPARQL endpoint doesn't belong there. TogoVar (human genome variation: gnomAD/ToMMo/JGA/BBJ frequencies, ClinVar+MGeND significance) fits the sub-server shape, like TogoID and NCBI.
 
 Tools registered directly on the root `mcp` live in [rdf_portal.py](togo_mcp/rdf_portal.py) (SPARQL, MIE files, endpoint resolution) and [api_tools.py](togo_mcp/api_tools.py) (REST search wrappers).
 
@@ -40,6 +43,7 @@ Two intentional, *different* error conventions coexist — preserve each module'
 
 - **REST-wrapper tools** in [api_tools.py](togo_mcp/api_tools.py) (`search_uniprot/pdb/mesh/reactome/rhea_entity`, ChEMBL, PubChem) and the catalog tools in [rdf_portal.py](togo_mcp/rdf_portal.py) (`list_databases`, `find_databases`): **raise `ValueError` for bad parameters** (caught early, tells the caller not to retry) but **degrade gracefully on upstream/HTTP failure** by returning a payload carrying an `error` key plus a "fall back to SPARQL" hint. Never raise on a transient HTTP error here.
 - **TogoID tools** in [togoid.py](togo_mcp/togoid.py): **raise on HTTP error** via `raise_for_status_with_body` (with a `client_error_hint`). This is the module's consistent convention; FastMCP surfaces the message to the caller. Don't convert only some togoid tools to the return-JSON style — keep the module uniform.
+- **TogoVar tools** in [togovar.py](togo_mcp/togovar.py): same convention as TogoID — **raise `ValueError` on bad params AND on HTTP error** (via `raise_for_status_with_body`); never return an `{"error": ...}` payload. No "fall back to SPARQL" hint (TogoVar has no RDF Portal endpoint). Keep the module uniform. The variant-query DSL is assembled by the pure helper `_build_variant_query` (unit-tested without HTTP); the `search_variant` tool exposes flat filters, not raw nested JSON. Note two live-API quirks the wrapper handles: the client pins `Accept: application/json` (else the API 501s), and a frequency `dataset` is an object `{"name": ...}` (a bare string 500s). The list endpoint does not echo a tgv ID — `rs`/`clinvar` cross-links come from each row's `external_link`.
 
 List-style result tools return a **JSON string of a bare array** (not a Python `list`): empty and non-empty then share one wire shape. Returning a bare `list` makes FastMCP double-represent it (text array + wrapped `{"result": ...}`), so empty vs non-empty diverge for clients. `dict` returns (ChEMBL, `get_sparql_endpoints`) and NCBI `list[TextContent]` returns are exempt — they aren't wrapped.
 

--- a/tests/test_togovar.py
+++ b/tests/test_togovar.py
@@ -1,0 +1,284 @@
+"""Tests for togo_mcp.togovar — pure DSL builder plus respx-mocked tools.
+
+The `@togovar_mcp.tool()` decorator returns the original coroutine, so the tool
+functions are awaited directly here. HTTP is mocked with respx; the pure DSL
+builder (`_build_variant_query`) is tested without any network.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from togo_mcp.togovar import (
+    _as_list,
+    _build_variant_query,
+    _project_variant,
+    _range_from_bounds,
+    search_disease,
+    search_gene,
+    search_variant,
+)
+
+BASE = "https://grch38.togovar.org/api"
+
+
+# --------------------------------------------------------------------------- #
+# _build_variant_query — pure, no HTTP
+# --------------------------------------------------------------------------- #
+def test_no_filters_returns_empty():
+    assert _build_variant_query() == {}
+
+
+def test_single_filter_returned_bare():
+    # One clause is NOT wrapped in `and`.
+    assert _build_variant_query(gene_hgnc_id=404) == {
+        "gene": {"relation": "eq", "terms": [404]}
+    }
+
+
+def test_multiple_filters_wrapped_in_and():
+    q = _build_variant_query(gene_hgnc_id=404, variant_type="snv")
+    assert set(q) == {"and"}
+    assert {"gene": {"relation": "eq", "terms": [404]}} in q["and"]
+    assert {"type": {"relation": "eq", "terms": ["snv"]}} in q["and"]
+    assert len(q["and"]) == 2
+
+
+def test_tgv_id_list_and_string():
+    assert _build_variant_query(tgv_id="tgv16331") == {"id": ["tgv16331"]}
+    assert _build_variant_query(tgv_id=["tgv1", "tgv2"]) == {"id": ["tgv1", "tgv2"]}
+
+
+def test_location_single_position():
+    q = _build_variant_query(chromosome="12", position=111766887)
+    assert q == {"location": {"chromosome": "12", "position": 111766887}}
+
+
+def test_location_region_becomes_range():
+    q = _build_variant_query(chromosome="X", start=100, stop=200)
+    assert q == {"location": {"chromosome": "X", "position": {"gte": 100, "lte": 200}}}
+
+
+def test_frequency_filter_shape():
+    q = _build_variant_query(dataset="tommo", max_frequency=0.01)
+    assert q == {
+        "frequency": {"dataset": {"name": "tommo"}, "frequency": {"lte": 0.01}}
+    }
+
+
+def test_frequency_subpopulation_allowed():
+    q = _build_variant_query(dataset="gnomad_genomes.eas", min_frequency=0.05)
+    assert q["frequency"]["dataset"] == {"name": "gnomad_genomes.eas"}
+
+
+def test_significance_with_source():
+    q = _build_variant_query(
+        clinical_significance="pathogenic", significance_source="mgend"
+    )
+    assert q == {
+        "significance": {
+            "relation": "eq",
+            "terms": ["pathogenic"],
+            "source": ["mgend"],
+        }
+    }
+
+
+def test_consequence_passthrough():
+    q = _build_variant_query(consequence="missense_variant")
+    assert q == {"consequence": {"relation": "eq", "terms": ["missense_variant"]}}
+
+
+# --- validation errors ------------------------------------------------------
+def test_invalid_chromosome_raises():
+    with pytest.raises(ValueError, match="Invalid chromosome"):
+        _build_variant_query(chromosome="23", position=1)
+
+
+def test_position_without_chromosome_raises():
+    with pytest.raises(ValueError, match="require `chromosome`"):
+        _build_variant_query(position=1000)
+
+
+def test_position_and_region_mutually_exclusive():
+    with pytest.raises(ValueError, match="not both"):
+        _build_variant_query(chromosome="1", position=1, start=2, stop=3)
+
+
+def test_chromosome_without_coordinate_raises():
+    with pytest.raises(ValueError, match="requires `position`"):
+        _build_variant_query(chromosome="1")
+
+
+def test_invalid_variant_type_raises():
+    with pytest.raises(ValueError, match="Invalid variant_type"):
+        _build_variant_query(variant_type="deletion")
+
+
+def test_unknown_dataset_raises():
+    with pytest.raises(ValueError, match="Unknown frequency dataset"):
+        _build_variant_query(dataset="1000genomes", max_frequency=0.1)
+
+
+def test_frequency_bounds_without_dataset_raises():
+    with pytest.raises(ValueError, match="require `dataset`"):
+        _build_variant_query(max_frequency=0.1)
+
+
+def test_dataset_without_bounds_raises():
+    with pytest.raises(ValueError, match="min_frequency and/or max_frequency"):
+        _build_variant_query(dataset="tommo")
+
+
+def test_invalid_significance_source_raises():
+    with pytest.raises(ValueError, match="Invalid significance_source"):
+        _build_variant_query(clinical_significance="benign", significance_source="foo")
+
+
+# --- small helpers ----------------------------------------------------------
+def test_as_list():
+    assert _as_list("a") == ["a"]
+    assert _as_list("") == []
+    assert _as_list(["a", " b ", ""]) == ["a", "b"]
+
+
+def test_range_from_bounds():
+    assert _range_from_bounds(1, 2) == {"gte": 1, "lte": 2}
+    assert _range_from_bounds(None, 2) == {"lte": 2}
+    assert _range_from_bounds(1, None) == {"gte": 1}
+
+
+def test_project_variant():
+    row = {
+        "type": "SO_0001483",
+        "chromosome": "12",
+        "position": 111803962,
+        "reference": "G",
+        "alternate": "A",
+        "symbols": [{"name": "ALDH2", "id": 404}],
+        "external_link": {
+            "dbsnp": [{"title": "rs671"}],
+            "clinvar": [{"title": "VCV000018390"}],
+        },
+        "frequencies": [{"source": "tommo", "af": 0.21, "ac": 52, "an": 250}],
+        "significance": [
+            {
+                "source": "clinvar",
+                "interpretations": ["P"],
+                "conditions": [{"name": "Alcohol sensitivity", "medgen": "C123"}],
+            }
+        ],
+        "most_severe_consequence": "SO_0001583",
+    }
+    p = _project_variant(row)
+    assert p["variant"] == "12:111803962:G>A"
+    assert p["genes"] == ["ALDH2"]
+    assert p["rs"] == ["rs671"]
+    assert p["clinvar"] == ["VCV000018390"]
+    assert p["frequencies"]["tommo"] == {"af": 0.21, "ac": 52, "an": 250}
+    assert p["significance"][0]["conditions"] == ["Alcohol sensitivity"]
+
+
+# --------------------------------------------------------------------------- #
+# Tool coroutines — respx-mocked HTTP
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_gene_projects_hgnc_id():
+    respx.get(f"{BASE}/search/gene").mock(
+        return_value=httpx.Response(
+            200, json=[{"id": 404, "symbol": "ALDH2", "name": "aldehyde dehydrogenase 2"}]
+        )
+    )
+    out = json.loads(await search_gene(query="ALDH2"))
+    assert out == [
+        {"hgnc_id": 404, "symbol": "ALDH2", "name": "aldehyde dehydrogenase 2"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_gene_blank_raises():
+    with pytest.raises(ValueError, match="Missing gene search term"):
+        await search_gene(query="  ")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_disease_projects_mondo():
+    respx.get(f"{BASE}/search/disease").mock(
+        return_value=httpx.Response(
+            200,
+            json=[{"id": "MONDO_0004438", "cui": "C1336076", "label": "breast cancer"}],
+        )
+    )
+    out = json.loads(await search_disease(query="breast cancer"))
+    assert out[0]["mondo_id"] == "MONDO_0004438"
+    assert out[0]["medgen_cui"] == "C1336076"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variant_builds_body_and_projects():
+    route = respx.post(f"{BASE}/search/variant").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "statistics": {"total": 100, "filtered": 3},
+                "data": [
+                    {
+                        "chromosome": "12",
+                        "position": 111803962,
+                        "reference": "G",
+                        "alternate": "A",
+                        "symbols": [{"name": "ALDH2"}],
+                        "external_link": {"dbsnp": [{"title": "rs671"}]},
+                    }
+                ],
+            },
+        )
+    )
+    out = json.loads(
+        await search_variant(gene_hgnc_id=404, variant_type="snv", stat=False)
+    )
+    # Response projection — stat=False omits counts/statistics entirely
+    assert out["data"][0]["variant"] == "12:111803962:G>A"
+    assert out["data"][0]["rs"] == ["rs671"]
+    assert "statistics" not in out
+    assert "total" not in out
+    assert "filtered" not in out
+    # Request body carried the composed DSL and stat=0
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["query"] == {
+        "and": [
+            {"gene": {"relation": "eq", "terms": [404]}},
+            {"type": {"relation": "eq", "terms": ["snv"]}},
+        ]
+    }
+    assert route.calls.last.request.url.params["stat"] == "0"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variant_stat_included_when_requested():
+    respx.post(f"{BASE}/search/variant").mock(
+        return_value=httpx.Response(
+            200,
+            json={"statistics": {"total": 1, "filtered": 1, "type": {}}, "data": []},
+        )
+    )
+    out = json.loads(await search_variant(tgv_id="tgv16331", stat=True))
+    assert "statistics" in out
+    assert out["total"] == 1
+    assert out["filtered"] == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variant_http_error_raises():
+    respx.post(f"{BASE}/search/variant").mock(
+        return_value=httpx.Response(400, text="bad query")
+    )
+    with pytest.raises(ValueError, match="TogoVar variant search"):
+        await search_variant(gene_hgnc_id=404)

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1234,6 +1234,22 @@
           <div class="tool-item-desc">Retrieve detailed compound attributes and molecular descriptors from PubChem RDF.</div>
         </div>
       </div>
+
+      <div class="tool-group">
+        <div class="tool-group-header">🧬 Genomic Variation (TogoVar)</div>
+        <div class="tool-item">
+          <div class="tool-item-name">togovar_search_variant</div>
+          <div class="tool-item-desc">Search human genome variants with population allele frequencies (gnomAD, ToMMo, JGA, BioBank Japan), ClinVar/MGeND significance, and SIFT/PolyPhen/AlphaMissense predictions.</div>
+        </div>
+        <div class="tool-item">
+          <div class="tool-item-name">togovar_search_gene</div>
+          <div class="tool-item-desc">Resolve a gene symbol to its HGNC ID for variant search.</div>
+        </div>
+        <div class="tool-item">
+          <div class="tool-item-name">togovar_search_disease</div>
+          <div class="tool-item-desc">Resolve a disease name to MONDO / MedGen IDs for variant search.</div>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/togo_mcp/main.py
+++ b/togo_mcp/main.py
@@ -3,6 +3,7 @@ from .rdf_portal import *
 from .api_tools import *
 from .togoid import togoid_mcp
 from .ncbi_tools import ncbi_mcp
+from .togovar import togovar_mcp
 import asyncio
 import os
 
@@ -20,6 +21,7 @@ def _allowed_hosts() -> list[str]:
 async def setup():
     mcp.mount(togoid_mcp, "togoid")
     mcp.mount(ncbi_mcp, "ncbi")
+    mcp.mount(togovar_mcp, "togovar")
 
 def run():
     asyncio.run(setup())

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -303,7 +303,9 @@ class _IgnoreUnknownSearchKwargs(_Middleware):
     _valid_kwargs_cache: dict[str, set[str]] = {}
 
     async def _valid_kwargs(self, ctx, tool_name: str) -> set[str] | None:
-        if not tool_name.startswith("search_"):
+        # Match both root-level `search_*` tools and mounted sub-server search
+        # tools, whose names carry a mount prefix (e.g. `togovar_search_variant`).
+        if "search_" not in tool_name:
             return None
         cached = self._valid_kwargs_cache.get(tool_name)
         if cached is not None:

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -1,0 +1,480 @@
+import atexit
+import json
+from typing import Annotated, Any
+
+import httpx
+from pydantic import Field
+
+from .server import *
+
+# TogoVar REST API (GRCh38). Cohesive multi-endpoint external API, wrapped as a
+# mounted sub-server (like togoid/ncbi) rather than a flat api_tools search_*
+# tool — TogoVar has no SPARQL counterpart in RDF Portal, so it does not belong
+# to the "keyword-search front door to a SPARQL DB" family. Following the TogoID
+# convention, this module RAISES on HTTP error (via raise_for_status_with_body)
+# and raises ValueError on bad parameters; it never returns an {"error": ...}
+# payload. Keep the module uniform.
+# The API returns 501 "Not implemented" unless the client asks for JSON, so pin
+# the Accept header on every request via the shared client.
+_client = httpx.AsyncClient(
+    base_url="https://grch38.togovar.org/api",
+    timeout=30.0,
+    headers={"Accept": "application/json"},
+)
+
+
+def _close_client():
+    """Close the shared httpx client on interpreter shutdown."""
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_client.aclose())
+    except RuntimeError:
+        asyncio.run(_client.aclose())
+
+
+atexit.register(_close_client)
+
+togovar_mcp = FastMCP("TogoVar API server")
+
+
+# --------------------------------------------------------------------------- #
+# Variant-query DSL builder (pure function — unit-tested without HTTP).
+#
+# The TogoVar /search/variant endpoint takes an expressive nested-JSON query
+# language. Rather than make the LLM assemble that JSON, we expose a flat set of
+# optional filters and fold them into the DSL here. Friendly labels
+# (snv / missense_variant / pathogenic …) are accepted verbatim by the API, so
+# no SO-accession translation table is needed.
+# --------------------------------------------------------------------------- #
+
+# Chromosome names TogoVar accepts (1-22, X, Y, MT).
+_VALID_CHROMOSOMES = frozenset(
+    [str(i) for i in range(1, 23)] + ["X", "Y", "MT"]
+)
+
+# Short type aliases the API accepts alongside SO accessions.
+_VARIANT_TYPES = frozenset(["snv", "ins", "del", "indel", "sub"])
+
+# ClinVar/MGeND significance sources.
+_SIGNIFICANCE_SOURCES = frozenset(["clinvar", "mgend"])
+
+# Base frequency panels. Sub-population strata (e.g. gnomad_genomes.eas,
+# ncbn.jpn.hondo, bbj_riken.mpheno1) are passed through by validating only the
+# dotted prefix, so new strata don't require a code change.
+_FREQUENCY_DATASET_BASES = frozenset([
+    "gnomad_genomes",
+    "gnomad_exomes",
+    "tommo",
+    "ncbn",
+    "gem_j_wga",
+    "jga_wgs",
+    "jga_wes",
+    "jga_snp",
+    "bbj_riken",
+])
+
+
+def _as_list(value: str | list[str]) -> list[str]:
+    """Coerce a str-or-list argument to a clean list[str]."""
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+def _range_from_bounds(
+    minimum: float | None, maximum: float | None
+) -> dict[str, float]:
+    """Build a TogoVar Range object from optional inclusive bounds."""
+    rng: dict[str, float] = {}
+    if minimum is not None:
+        rng["gte"] = minimum
+    if maximum is not None:
+        rng["lte"] = maximum
+    return rng
+
+
+def _build_variant_query(
+    *,
+    tgv_id: str | list[str] = "",
+    gene_hgnc_id: int | None = None,
+    disease_id: str | list[str] = "",
+    disease_source: str | list[str] = "",
+    chromosome: str = "",
+    position: int | None = None,
+    start: int | None = None,
+    stop: int | None = None,
+    variant_type: str | list[str] = "",
+    consequence: str | list[str] = "",
+    clinical_significance: str | list[str] = "",
+    significance_source: str | list[str] = "",
+    dataset: str = "",
+    min_frequency: float | None = None,
+    max_frequency: float | None = None,
+) -> dict[str, Any]:
+    """Assemble a TogoVar /search/variant `query` object from flat filters.
+
+    Each supplied filter becomes one DSL clause. Zero filters returns `{}`
+    (match everything). Exactly one filter is returned bare; two or more are
+    combined under a top-level `and` (the API requires `and` to hold >= 2
+    items). Raises ValueError on invalid enum/coordinate inputs so the caller
+    is told not to retry.
+    """
+    clauses: list[dict[str, Any]] = []
+
+    tgv_ids = _as_list(tgv_id)
+    if tgv_ids:
+        clauses.append({"id": tgv_ids})
+
+    if gene_hgnc_id is not None:
+        clauses.append({"gene": {"relation": "eq", "terms": [gene_hgnc_id]}})
+
+    disease_ids = _as_list(disease_id)
+    if disease_ids:
+        disease_clause: dict[str, Any] = {
+            "disease": {"relation": "eq", "terms": disease_ids}
+        }
+        sources = _as_list(disease_source)
+        bad = [s for s in sources if s not in _SIGNIFICANCE_SOURCES]
+        if bad:
+            raise ValueError(
+                f"Invalid disease_source {bad}; valid: "
+                f"{sorted(_SIGNIFICANCE_SOURCES)}. Do not retry with the same value."
+            )
+        if sources:
+            disease_clause["disease"]["source"] = sources
+        clauses.append(disease_clause)
+
+    if chromosome:
+        if chromosome not in _VALID_CHROMOSOMES:
+            raise ValueError(
+                f"Invalid chromosome {chromosome!r}; valid: 1-22, X, Y, MT. "
+                "Do not retry with the same value."
+            )
+        if position is not None and (start is not None or stop is not None):
+            raise ValueError(
+                "Pass either `position` (a single site) or `start`/`stop` "
+                "(a region), not both."
+            )
+        if position is not None:
+            pos: Any = position
+        elif start is not None or stop is not None:
+            pos = _range_from_bounds(start, stop)
+        else:
+            raise ValueError(
+                "`chromosome` requires `position` (single site) or "
+                "`start`/`stop` (region)."
+            )
+        clauses.append({"location": {"chromosome": chromosome, "position": pos}})
+    elif position is not None or start is not None or stop is not None:
+        raise ValueError(
+            "`position`/`start`/`stop` require `chromosome` to be set."
+        )
+
+    types = _as_list(variant_type)
+    if types:
+        bad = [t for t in types if t not in _VARIANT_TYPES]
+        if bad:
+            raise ValueError(
+                f"Invalid variant_type {bad}; valid: {sorted(_VARIANT_TYPES)}. "
+                "Do not retry with the same value."
+            )
+        clauses.append({"type": {"relation": "eq", "terms": types}})
+
+    consequences = _as_list(consequence)
+    if consequences:
+        # SO accession or its label are both accepted by the API — pass through.
+        clauses.append(
+            {"consequence": {"relation": "eq", "terms": consequences}}
+        )
+
+    significances = _as_list(clinical_significance)
+    if significances:
+        sig_clause: dict[str, Any] = {
+            "significance": {"relation": "eq", "terms": significances}
+        }
+        sig_sources = _as_list(significance_source)
+        bad = [s for s in sig_sources if s not in _SIGNIFICANCE_SOURCES]
+        if bad:
+            raise ValueError(
+                f"Invalid significance_source {bad}; valid: "
+                f"{sorted(_SIGNIFICANCE_SOURCES)}. Do not retry with the same value."
+            )
+        if sig_sources:
+            sig_clause["significance"]["source"] = sig_sources
+        clauses.append(sig_clause)
+
+    if dataset or min_frequency is not None or max_frequency is not None:
+        if not dataset:
+            raise ValueError(
+                "min_frequency/max_frequency require `dataset` (which panel). "
+                f"Valid panels: {sorted(_FREQUENCY_DATASET_BASES)} "
+                "(sub-populations like gnomad_genomes.eas are allowed)."
+            )
+        base = dataset.split(".", 1)[0]
+        if base not in _FREQUENCY_DATASET_BASES:
+            raise ValueError(
+                f"Unknown frequency dataset {dataset!r} (base {base!r}); valid "
+                f"panels: {sorted(_FREQUENCY_DATASET_BASES)}. Sub-populations "
+                "like 'gnomad_genomes.eas' or 'ncbn.jpn' are allowed. "
+                "Do not retry with the same value."
+            )
+        if min_frequency is None and max_frequency is None:
+            raise ValueError(
+                "`dataset` requires min_frequency and/or max_frequency "
+                "(allele-frequency bounds in [0, 1])."
+            )
+        clauses.append({
+            "frequency": {
+                # The API models a dataset as an object keyed by `name`, not a
+                # bare string (a bare string 500s "Symbol into Integer").
+                "dataset": {"name": dataset},
+                "frequency": _range_from_bounds(min_frequency, max_frequency),
+            }
+        })
+
+    if not clauses:
+        return {}
+    if len(clauses) == 1:
+        return clauses[0]
+    return {"and": clauses}
+
+
+def _project_variant(row: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a /search/variant data row into the fields agents actually use.
+
+    The list endpoint does not echo a tgv ID; cross-database identifiers live
+    under `external_link` (dbsnp -> rs, clinvar -> VCV), which we surface as
+    `rs`/`clinvar` for TogoID/ClinVar interoperability. Per-dataset frequencies
+    are reshaped into a `{source: {af, ac, an}}` map.
+    """
+    ext = row.get("external_link") or {}
+
+    def _titles(key: str) -> list[str]:
+        return [e.get("title") for e in ext.get(key, []) if e.get("title")]
+
+    symbols = [s.get("name") for s in row.get("symbols", []) if s.get("name")]
+
+    freqs: dict[str, Any] = {}
+    for f in row.get("frequencies") or []:
+        src = f.get("source")
+        if src:
+            freqs[src] = {"af": f.get("af"), "ac": f.get("ac"), "an": f.get("an")}
+
+    significance = [
+        {
+            "source": s.get("source"),
+            "interpretations": s.get("interpretations"),
+            "conditions": [c.get("name") for c in s.get("conditions", [])],
+        }
+        for s in row.get("significance") or []
+    ]
+
+    return {
+        "variant": (
+            f"{row.get('chromosome')}:{row.get('position')}:"
+            f"{row.get('reference')}>{row.get('alternate')}"
+        ),
+        "type": row.get("type"),
+        "chromosome": row.get("chromosome"),
+        "position": row.get("position"),
+        "reference": row.get("reference"),
+        "alternate": row.get("alternate"),
+        "genes": symbols,
+        "rs": _titles("dbsnp"),
+        "clinvar": _titles("clinvar"),
+        "most_severe_consequence": row.get("most_severe_consequence"),
+        "sift": row.get("sift"),
+        "polyphen": row.get("polyphen"),
+        "alphamissense": row.get("alphamissense"),
+        "significance": significance,
+        "frequencies": freqs,
+    }
+
+
+@togovar_mcp.tool()
+async def search_gene(
+    query: Annotated[str, Field(description="Gene symbol or alias, e.g. 'ALDH2'.")] = "",
+) -> str:
+    """Resolve a human gene symbol/alias to its HGNC ID for variant search.
+
+    This is the FIRST step of the two-step variant workflow: the `hgnc_id`
+    returned here is what `search_variant` takes as `gene_hgnc_id`.
+
+    Args:
+        query (str): Gene symbol or alias (e.g. "ALDH2", "BRCA2").
+
+    Returns:
+        str: JSON array (bare list) of matches, each
+        `{"hgnc_id": int, "symbol": str, "name": str}`, best match first.
+        Empty and non-empty results share the same `[...]` shape.
+
+    Raises:
+        ValueError: If `query` is blank, or on any HTTP/upstream error.
+    """
+    if not query.strip():
+        raise ValueError("Missing gene search term. Pass a symbol via `query`, e.g. 'ALDH2'.")
+    response = await _client.get("/search/gene", params={"term": query.strip()})
+    raise_for_status_with_body(response, context="TogoVar gene search")
+    hits = response.json()
+    results = [
+        {"hgnc_id": h.get("id"), "symbol": h.get("symbol"), "name": h.get("name")}
+        for h in hits
+    ]
+    return json.dumps(results)
+
+
+@togovar_mcp.tool()
+async def search_disease(
+    query: Annotated[
+        str, Field(description="Disease term, e.g. 'breast cancer'.")
+    ] = "",
+) -> str:
+    """Resolve a disease term to MONDO / MedGen IDs for variant search.
+
+    The returned `mondo_id` (or MedGen CUI) is what `search_variant` takes as
+    `disease_id`. Both land directly on TogoMCP's existing mondo/medgen RDF
+    databases and TogoID nodes.
+
+    Args:
+        query (str): Disease name (e.g. "breast cancer", "Marfan syndrome").
+
+    Returns:
+        str: JSON array (bare list) of matches, each
+        `{"mondo_id": str, "medgen_cui": str | None, "label": str}`.
+
+    Raises:
+        ValueError: If `query` is blank, or on any HTTP/upstream error.
+    """
+    if not query.strip():
+        raise ValueError(
+            "Missing disease search term. Pass a disease name via `query`."
+        )
+    response = await _client.get("/search/disease", params={"term": query.strip()})
+    raise_for_status_with_body(response, context="TogoVar disease search")
+    hits = response.json()
+    results = [
+        {"mondo_id": h.get("id"), "medgen_cui": h.get("cui"), "label": h.get("label")}
+        for h in hits
+    ]
+    return json.dumps(results)
+
+
+@togovar_mcp.tool()
+async def search_variant(
+    tgv_id: str | list[str] = "",
+    gene_hgnc_id: int | None = None,
+    disease_id: str | list[str] = "",
+    disease_source: str | list[str] = "",
+    chromosome: str = "",
+    position: int | None = None,
+    start: int | None = None,
+    stop: int | None = None,
+    variant_type: str | list[str] = "",
+    consequence: str | list[str] = "",
+    clinical_significance: str | list[str] = "",
+    significance_source: str | list[str] = "",
+    dataset: str = "",
+    min_frequency: float | None = None,
+    max_frequency: float | None = None,
+    limit: Annotated[int, Field(ge=0, le=1000)] = 100,
+    offset: Annotated[int, Field(ge=0)] = 0,
+    stat: bool = False,
+) -> str:
+    """Search TogoVar for human genome variants with population frequencies.
+
+    TogoVar integrates allele frequencies from gnomAD, ToMMo (Japanese), NCBN,
+    GEM-J, JGA, and BioBank Japan, plus ClinVar + MGeND clinical significance
+    and SIFT/PolyPhen/AlphaMissense predictions — data with no SPARQL
+    counterpart elsewhere in TogoMCP.
+
+    All filters are optional and combined with AND. Supply zero filters to
+    browse; but scope tightly — the database holds ~1 billion variants.
+
+    TWO-STEP WORKFLOW for gene/disease filters:
+        1. `search_gene("ALDH2")` -> hgnc_id -> pass as `gene_hgnc_id`.
+        2. `search_disease("breast cancer")` -> mondo_id -> pass as `disease_id`.
+
+    Args:
+        tgv_id: TogoVar variant ID(s), e.g. "tgv16331".
+        gene_hgnc_id: HGNC ID (integer) from `search_gene` (NOT a symbol).
+        disease_id: MONDO ID(s) (e.g. "MONDO_0007254") or MedGen CUI(s) from
+            `search_disease`.
+        disease_source: Restrict disease link source(s): "clinvar", "mgend".
+        chromosome: "1"-"22", "X", "Y", "MT". Required for a positional filter.
+        position: Single 1-based site (mutually exclusive with start/stop).
+        start, stop: Inclusive region bounds (require `chromosome`).
+        variant_type: "snv", "ins", "del", "indel", "sub".
+        consequence: SO consequence term or label, e.g. "missense_variant",
+            "stop_gained", "frameshift_variant".
+        clinical_significance: e.g. "pathogenic", "likely_pathogenic", "benign",
+            "uncertain_significance", "risk_factor".
+        significance_source: Restrict significance source(s): "clinvar", "mgend".
+        dataset: Frequency panel for a frequency filter, e.g. "gnomad_genomes",
+            "gnomad_exomes", "tommo", "ncbn", "gem_j_wga", "jga_wgs", "jga_wes",
+            "jga_snp", "bbj_riken". Sub-populations allowed (e.g.
+            "gnomad_genomes.eas", "ncbn.jpn").
+        min_frequency, max_frequency: Allele-frequency bounds in [0, 1] on
+            `dataset` (e.g. dataset="tommo", max_frequency=0.01 for rare-in-Japan).
+        limit: Max variant rows to return, in [0, 1000]. Default 100.
+        offset: Rows to skip (pagination). Default 0.
+        stat: If True, also return match counts (`total`, `filtered`) and the
+            aggregate breakdown (counts by dataset, type, consequence,
+            significance). REQUIRED to get a count — e.g. "how many variants
+            match". Left False by default because computing the aggregation is
+            the slow part of the query; use stat=False when you only need rows.
+
+    Returns:
+        str: JSON string `{"data": [...], "total"?, "filtered"?, "statistics"?}`.
+        Each data row carries `variant` (chr:pos:ref>alt), coordinates, genes,
+        `rs` (dbSNP) and `clinvar` (VCV) cross-links, most-severe consequence,
+        SIFT/PolyPhen/AlphaMissense scores, clinical `significance`, and a
+        `frequencies` map keyed by dataset ({af, ac, an}). `total`/`filtered`/
+        `statistics` are present ONLY when `stat=True`. (The list endpoint does
+        not return a tgv ID; use `rs`/`clinvar` for cross-database linking.)
+
+    Raises:
+        ValueError: On invalid enum/coordinate inputs, or any HTTP/upstream error.
+    """
+    query = _build_variant_query(
+        tgv_id=tgv_id,
+        gene_hgnc_id=gene_hgnc_id,
+        disease_id=disease_id,
+        disease_source=disease_source,
+        chromosome=chromosome,
+        position=position,
+        start=start,
+        stop=stop,
+        variant_type=variant_type,
+        consequence=consequence,
+        clinical_significance=clinical_significance,
+        significance_source=significance_source,
+        dataset=dataset,
+        min_frequency=min_frequency,
+        max_frequency=max_frequency,
+    )
+
+    body: dict[str, Any] = {"limit": limit, "offset": offset}
+    if query:
+        body["query"] = query
+    # stat=1 (default upstream) collects the aggregate statistics block; stat=0
+    # skips it for a lighter/faster response.
+    params = {"stat": 1 if stat else 0}
+
+    response = await _client.post("/search/variant", params=params, json=body)
+    raise_for_status_with_body(response, context="TogoVar variant search")
+    payload = response.json()
+
+    result: dict[str, Any] = {
+        "data": [_project_variant(row) for row in payload.get("data", [])],
+    }
+    # Match counts and the category breakdown come from the statistics block,
+    # which the API only computes (and it is the expensive part) when stat=1.
+    # With stat=False the caller gets rows only — counts are omitted, not zero.
+    if stat and "statistics" in payload:
+        stats = payload["statistics"]
+        result["total"] = stats.get("total")
+        result["filtered"] = stats.get("filtered")
+        result["statistics"] = stats
+    return json.dumps(result)


### PR DESCRIPTION
## What

Adds **TogoVar** (<https://grch38.togovar.org>) to TogoMCP — human genome variation with population allele frequencies (gnomAD, ToMMo, JGA, GEM-J, NCBN, BioBank Japan), ClinVar + MGeND clinical significance, and SIFT/PolyPhen/AlphaMissense predictions. This is data with **no SPARQL counterpart** elsewhere in TogoMCP, and it lands cleanly on the existing catalog (gene→HGNC, disease→MONDO/MedGen, variant→rs/ClinVar; TogoID already has a `togovar` node).

## How

New sub-server `togovar_mcp` in [togo_mcp/togovar.py](../blob/feat/togovar-module/togo_mcp/togovar.py), mounted as `togovar` alongside `togoid`/`ncbi`. Three tools:

| Tool | Purpose |
|---|---|
| `togovar_search_gene` | gene symbol → HGNC ID |
| `togovar_search_disease` | disease term → MONDO / MedGen CUI |
| `togovar_search_variant` | flat filters (gene / disease / region / type / consequence / significance / frequency) folded into the API's nested-JSON query DSL |

The variant-query DSL is assembled by the pure helper `_build_variant_query` (unit-tested without HTTP); the tool exposes flat filters, not raw nested JSON.

### Why a sub-server, not a flat `api_tools.py` `search_*` wrapper
The flat wrappers are keyword-search front doors to a SPARQL database (their error hint points back to `run_sparql`). TogoVar has no RDF Portal endpoint, so it's a cohesive multi-endpoint REST API like TogoID/NCBI. Module convention follows TogoID: **raise `ValueError` on bad params AND on HTTP error**; no "fall back to SPARQL" hint.

### Live-API quirks handled
- Client pins `Accept: application/json` (else the API `501`s).
- A frequency `dataset` is an object `{"name": ...}` (a bare string `500`s).
- The list endpoint does not echo a tgv ID — `rs`/`clinvar` cross-links are extracted from each row's `external_link`.
- `total`/`filtered` counts come from the statistics block (the slow part), returned only when `stat=True`.

## Other changes
- **Middleware**: generalize the unknown-kwarg-stripping guard from `startswith("search_")` to `"search_" in name`, so mounted `togovar_search_*` tools keep the LLM-junk-kwarg safety net.
- **Docs**: [CLAUDE.md](../blob/feat/togovar-module/CLAUDE.md) (sub-server rationale + module convention) and the intro page (new "🧬 Genomic Variation (TogoVar)" tool group).

## Testing
- `tests/test_togovar.py`: 28 tests (pure DSL builder + respx-mocked tools).
- Full suite: **118 passed**.
- Live end-to-end verified against the real API (gene/disease/variant, frequency filter, clinical significance, region query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)