### PR TITLE
docs(intro): add TogoVar to Related Resources

### DIFF
--- a/togo_mcp/data/docs/make_intro.md
+++ b/togo_mcp/data/docs/make_intro.md
@@ -91,6 +91,7 @@ These MCP servers are strongly recommended to be used with TogoMCP.
 List the following resources with summaries. Search the Web if necessary.
 - [RDF Portal](https://rdfportal.org)
 - [TogoID](https://togoid.dbcls.jp)
+- [TogoVar](https://grch38.togovar.org/)
 - [DBCLS](https://dbcls.rois.jp)
 
 ## Source code

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1307,6 +1307,11 @@
         <p>TogoID is an identifier conversion service by DBCLS that bridges 65+ life science databases. Unlike traditional converters, it supports cross-category conversions (e.g., disease IDs → gene IDs) with semantic relationship annotations. TogoMCP's ID conversion tools are powered by TogoID's API.</p>
       </div>
       <div class="resource-card">
+        <h3>TogoVar</h3>
+        <a class="resource-link" href="https://grch38.togovar.org/" target="_blank" rel="noopener">https://grch38.togovar.org/</a>
+        <p>TogoVar is an NBDC/DBCLS integrated database of human genomic variation. It aggregates allele frequencies from Japanese and global cohorts (ToMMo, JGA, GEM-J, NCBN, BioBank Japan, gnomAD) with ClinVar and MGeND clinical significance and functional predictions. TogoMCP's genomic-variation tools query TogoVar's REST API.</p>
+      </div>
+      <div class="resource-card">
         <h3>DBCLS</h3>
         <a class="resource-link" href="https://dbcls.rois.ac.jp/en/" target="_blank" rel="noopener">https://dbcls.rois.ac.jp/en/</a>
         <p>The Database Center for Life Science (DBCLS) is a Japanese research institute under ROIS, founded in 2007. It conducts research on database integration, Semantic Web technologies, and bioinformatics resources. DBCLS organizes the annual BioHackathon and monthly SPARQLthon events, and develops tools like TogoID, TogoTV, and TogoMCP.</p>


### PR DESCRIPTION
Adds a **TogoVar** resource card (<https://grch38.togovar.org/>) to the intro page's *Related Resources* section, plus the matching entry in the `make_intro.md` spec — following the TogoVar genomic-variation tools shipped in #139.

Placed after TogoID and before DBCLS. URL verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)