### PR TITLE
feat(togovar): add TogoVar as a SPARQL database (MIE + endpoint registration)

### DIFF
--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1042,6 +1042,10 @@
         <div class="db-card-desc">Genome-wide sequence variation across 62 inbred and wild-derived mouse strains on the GRCm39 assembly: ~146M variants (SNVs and indels) with per-strain genotypes, Ensembl VEP and SnpEff functional consequences, and Ensembl gene-overlap links.</div>
       </div>
       <div class="db-card">
+        <div class="db-card-name">TogoVar</div>
+        <div class="db-card-desc">Integrated human genome variation database (GRCh38): ~390M variants (SNV, deletion, insertion, MNV, indel) with normalized/VCF coordinates, Ensembl-VEP consequences (SIFT/PolyPhen/AlphaMissense, HGVS), dbSNP and HGNC/Ensembl gene links, and an embedded ClinVar annotation layer. Per-population allele frequencies are served via the TogoVar REST API tools.</div>
+      </div>
+      <div class="db-card">
         <div class="db-card-name">ClinVar</div>
         <div class="db-card-desc">Aggregates genomic variation and health relationships. 3.5M+ variant records with clinical interpretations, gene associations, and disease conditions.</div>
       </div>

--- a/togo_mcp/data/mie/togovar.yaml
+++ b/togo_mcp/data/mie/togovar.yaml
@@ -1,0 +1,561 @@
+schema_info:
+  title: TogoVar
+  description: |
+    TogoVar is an integrated Japanese/human genome variation database. This
+    self-hosted GRCh38 SPARQL endpoint holds ~390 million variant records
+    (SNV, Deletion, Insertion, MNV, Indel) with VCF/normalized coordinates,
+    Ensembl-VEP functional consequences (per-transcript, SIFT/PolyPhen/AlphaMissense,
+    HGVS), dbSNP cross-references, and an embedded ClinVar annotation layer plus
+    supporting reference datasets (ClinVar, Ensembl gene models, HGNC, MedGen,
+    MONDO, Sequence Ontology, GWAS Catalog, PubMed/PubTator, MeSH, EFO, GO).
+    Primary use: variant-to-gene-to-consequence lookup and clinical-significance
+    triage for human variants. NOTE: per-population allele frequencies are NOT in
+    this endpoint (REST API only) — see critical_warnings.
+  keywords:
+    - variant
+    - variation
+    - mutation
+    - polymorphism
+    - snv
+    - snp
+    - indel
+    - genome
+    - human
+    - japanese
+    - dbsnp
+    - clinvar
+    - vep
+    - consequence
+    - allele
+  categories:
+    - variant
+    - disease
+    - genomics
+  endpoint: https://grch38.togovar.org/sparql
+  base_uri: http://togovar.org/
+  graphs:
+    - http://togovar.org/variant                       # CORE: variant records (position, ref/alt, tgv id)
+    - http://togovar.org/variant/annotation/ensembl    # VEP consequences + dbSNP seeAlso (per variant)
+    - http://togovar.org/variant/annotation/clinvar    # ClinVar annotation on the variant (VariationID, ALLELEID)
+    - http://togovar.org/clinvar                        # embedded DBCLS ClinVar RDF dataset (see clinvar.yaml)
+    - http://togovar.org/ensembl                        # Ensembl gene-model reference (FALDO positions)
+    - http://togovar.org/hgnc                           # HGNC gene records (med2rdf:Gene)
+    - http://togovar.org/medgen                         # MedGen (MGREL relations)
+    - http://togovar.org/mondo                          # MONDO disease ontology
+    - http://togovar.org/so                             # Sequence Ontology (owl:Class)
+    - http://togovar.org/go                             # Gene Ontology
+    - http://togovar.org/mesh                           # MeSH
+    - http://togovar.org/efo                            # Experimental Factor Ontology
+    - http://togovar.org/gwas-catalog                   # GWAS Catalog associations
+    - http://togovar.org/pubmed                         # PubMed
+    - http://togovar.org/pubtator                       # PubTator
+    - http://togovar.org/hco                            # Human Chromosome Ontology (reference IRIs)
+  co_hosted_graphs:
+    - "http://togovar.org/variant/annotation/clinvar — RE-TYPES the SAME variant IRI as `a gvo:SNV`/Deletion/etc. that http://togovar.org/variant already types (2,944,525 variants). An unscoped `?s a gvo:SNV` COUNT double-counts these. Multiplier = x2 for ClinVar-annotated variants. Safe pattern: pin GRAPH <http://togovar.org/variant> or use COUNT(DISTINCT ?variant)."
+    - "http://togovar.org/clinvar — full embedded ClinVar RDF; its own med2rdf:Variation / clinvar:VariationArchiveType nodes re-use dcterms:identifier and med2rdf:gene on shared IRIs. Join to the variant layer only via the ClinVar VariationID string; do not COUNT variant classes across this graph."
+  kw_search_tools: []
+  version:
+    mie_version: "1.0"
+    mie_created: "2026-07-12"
+    data_version: "GRCh38 endpoint (grch38.togovar.org), snapshot 2026-07"
+    update_frequency: "Periodic (aligned with TogoVar releases)"
+  license:
+    data_license: "CC BY 4.0 (TogoVar); underlying sources retain their own licenses (ClinVar, dbSNP, Ensembl, etc.)"
+  access:
+    backend: "Virtuoso"
+
+critical_warnings: |
+  - NO ALLELE FREQUENCY IN THIS ENDPOINT. TogoVar's headline per-population
+    frequencies (ToMMo/54KJPN, gnomAD genomes/exomes, JGA, GEM-J WGA, NCBN, BBJ)
+    are NOT stored in this SPARQL endpoint — they are served only via the TogoVar
+    REST API (togovar.py sub-server). Verified: even rs671 (extremely common) has
+    only the 9 core predicates and no frequency predicate in ANY graph. There is no
+    `frequency`/`info` bnode chain in the variant graph. Do not attempt to query
+    frequencies here; you will get 0 rows, not an error.
+  - CROSS-GRAPH RE-TYPING / UNION INFLATION. The same variant IRI is typed
+    `a <http://genome-variation.org/resource#SNV>` (or Deletion/Insertion/...) in
+    BOTH <http://togovar.org/variant> AND <http://togovar.org/variant/annotation/clinvar>
+    (confirmed: rs671 returns COUNT=2 for the type across graphs). An UNSCOPED
+    `SELECT (COUNT(?s) AS ?n) WHERE { ?s a gvo:SNV }` double-counts the 2,944,525
+    ClinVar-annotated variants. SAFE PATTERN: pin `GRAPH <http://togovar.org/variant>`
+    (or use `COUNT(DISTINCT ?s)`). SELECT DISTINCT only masks the symptom.
+  - GRAPH-SCOPED PREDICATES. Core fields (gvo:pos, gvo:ref, gvo:alt, dcterms:identifier,
+    faldo:location) live in <http://togovar.org/variant>. VEP consequences
+    (tgvo:hasConsequence, tgvo:most_severe_consequence) and dbSNP links (rdfs:seeAlso)
+    live in <http://togovar.org/variant/annotation/ensembl>. ClinVar annotation
+    (dcterms:identifier = ClinVar VariationID, gvo:info = ALLELEID) lives in
+    <http://togovar.org/variant/annotation/clinvar>. Querying the wrong graph returns
+    0 rows silently — always pin the correct GRAPH.
+  - NORMALIZED vs VCF ALLELES. gvo:ref/gvo:alt are VOA-normalized (trimmed) alleles
+    and are the EMPTY STRING "" for pure deletions (alt) / insertions (ref).
+    gvo:ref_vcf/gvo:alt_vcf carry the VCF anchor base (never empty). gvo:pos differs
+    from gvo:pos_vcf by 1 for indels (VCF anchor). Pick the pair that matches your
+    input convention; mixing them silently mismatches.
+  - gvo:pos and faldo:position are xsd:integer. Match with an integer literal
+    (e.g. `gvo:pos 111803962`), NOT a string ("111803962") — a string joins to nothing.
+    gvo:ref/gvo:alt and dcterms:identifier are xsd:string (plain literal matches fine).
+  - tgvo:gene IS POLYMORPHIC UNDER ONE NAMESPACE. Objects of tgvo:gene are BOTH
+    Ensembl gene IRIs (http://rdf.ebi.ac.uk/resource/ensembl/ENSG...) AND NCBI Gene
+    IDs (http://rdf.ebi.ac.uk/resource/ensembl/217) — both minted under the SAME
+    ensembl namespace. The sibling tgvo:gene_symbol_source ("HGNC" vs "EntrezGene")
+    distinguishes them. Filter to the ENSG form if you mean Ensembl genes.
+
+shape_expressions: |
+  PREFIX gvo:   <http://genome-variation.org/resource#>
+  PREFIX tgvo:  <http://togovar.biosciencedbc.jp/vocabulary/>
+  PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+  PREFIX dcterms: <http://purl.org/dc/terms/>
+  PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX obo:   <http://purl.obolibrary.org/obo/>
+
+  # ---- CORE VARIANT (graph: http://togovar.org/variant) ----
+  # Total 390,725,782 variants: SNV 339,076,968 | Deletion 29,307,469 |
+  # Insertion 22,340,786 | MNV 492 | Indel 67. IRI pattern:
+  # http://identifiers.org/hco/{chr}/GRCh38#{pos}-{ref}-{alt}
+  <VariantShape> {
+    a [ gvo:SNV gvo:Deletion gvo:Insertion gvo:MNV gvo:Indel ] ;  # exactly one type
+    dcterms:identifier xsd:string ;        # tgv ID, e.g. "tgv239865485" — exactly 1
+    gvo:pos      xsd:integer ;             # normalized 1-based position (=1)
+    gvo:pos_vcf  xsd:integer ;             # VCF position (indels differ from pos by 1)
+    gvo:ref      xsd:string ;             # normalized REF ("" for pure insertions)
+    gvo:alt      xsd:string ;             # normalized ALT ("" for pure deletions)
+    gvo:ref_vcf  xsd:string ;             # VCF REF (with anchor base, never empty)
+    gvo:alt_vcf  xsd:string ;             # VCF ALT (with anchor base, never empty)
+    faldo:location @<LocationShape>       # SNV->ExactPosition, Ins->InBetween, Del->Region
+  }
+
+  # SNVs (and MNV/Indel anchor) use an ExactPosition. 339,076,968 instances.
+  <ExactPositionShape> {
+    a [ faldo:ExactPosition ] ;
+    faldo:position  xsd:integer ;
+    faldo:reference IRI                    # http://identifiers.org/hco/{chr}/GRCh38
+  }
+  # Insertions use a single InBetweenPosition (between two bases). 80,955,858 instances.
+  <InBetweenPositionShape> {
+    a [ faldo:InBetweenPosition ] ;
+    faldo:after     xsd:integer ;
+    faldo:before    xsd:integer ;
+    faldo:reference IRI
+  }
+  # Deletions (and multi-base) use a Region spanning two InBetweenPositions. 29,308,028 instances.
+  <RegionShape> {
+    a [ faldo:Region ] ;
+    faldo:begin @<InBetweenPositionShape> ;
+    faldo:end   @<InBetweenPositionShape>
+  }
+  <LocationShape> @<ExactPositionShape> OR @<InBetweenPositionShape> OR @<RegionShape>
+
+  # ---- VEP ANNOTATION (graph: http://togovar.org/variant/annotation/ensembl) ----
+  # Same variant IRI as subject; ~100% of variants annotated (sampling N=2000 SNV).
+  <VepAnnotationShape> {
+    rdfs:seeAlso IRI * ;                        # dbSNP: http://identifiers.org/dbsnp/rs... (~99% of SNVs; 0..n)
+    tgvo:most_severe_consequence IRI ;          # SO term obo:SO_XXXXXXX (exactly 1)
+    tgvo:hasConsequence @<ConsequenceShape> +   # one per transcript overlap
+  }
+  # Consequence blank node — typed with its SO consequence term(s).
+  <ConsequenceShape> {
+    a [ obo:SO_0001583 ] * ;                    # rdf:type = SO consequence term(s), e.g. missense_variant
+    tgvo:transcript IRI ? ;                     # http://rdf.ebi.ac.uk/resource/ensembl.transcript/{ENST|NM_...}
+    tgvo:gene IRI * ;                           # http://rdf.ebi.ac.uk/resource/ensembl/{ENSG...|NCBIGeneID}  (POLYMORPHIC)
+    tgvo:gene_symbol xsd:string * ;             # e.g. "ALDH2"
+    tgvo:gene_symbol_source xsd:string * ;      # "HGNC" or "EntrezGene" (pairs with gene form)
+    tgvo:hgnc IRI * ;                           # http://identifiers.org/hgnc/{n}
+    tgvo:hgvsc xsd:string * ;                   # transcript HGVS, e.g. "ENST...:c.2222T>C"
+    tgvo:hgvsg xsd:string * ;                   # genomic HGVS, e.g. "chr1:g.12291025T>C"
+    tgvo:hgvsp xsd:string * ;                   # protein HGVS, e.g. "ENSP...:p.Glu504Lys"
+    tgvo:impact xsd:string * ;                  # VEP impact: HIGH | MODERATE | LOW | MODIFIER
+    tgvo:sift xsd:decimal * ;                   # SIFT score — MIXED xsd:decimal/xsd:integer (0 stored as integer)
+    tgvo:sift_prediction xsd:string * ;         # "deleterious" | "tolerated" (+ "_low_confidence")
+    tgvo:polyphen xsd:decimal * ;               # PolyPhen score — MIXED decimal/integer
+    tgvo:polyphen_prediction xsd:string * ;
+    tgvo:alphamissense xsd:decimal * ;
+    tgvo:alphamissense_prediction xsd:string *
+  }
+
+  # ---- CLINVAR ANNOTATION (graph: http://togovar.org/variant/annotation/clinvar) ----
+  # RE-DECLARES the variant IRI (same subject) — see critical_warnings union inflation.
+  # 2,944,525 variants carry this annotation.
+  <ClinvarAnnotationShape> {
+    a [ gvo:SNV gvo:Deletion gvo:Insertion ] ;  # re-typed here (double-count trap)
+    dcterms:identifier xsd:string ;             # ClinVar VariationID, e.g. "18390"
+    gvo:ref xsd:string ; gvo:alt xsd:string ;
+    gvo:pos xsd:integer ;
+    faldo:location @<LocationShape> ;
+    gvo:info @<ClinvarInfoShape> +              # key/value INFO bnode
+  }
+  # INFO key/value bnode; observed key so far: ALLELEID (rdfs:label) + rdf:value.
+  <ClinvarInfoShape> {
+    rdfs:label xsd:string ;                     # e.g. "ALLELEID"
+    rdf:value xsd:integer                       # e.g. 33429 (the ClinVar Allele ID) — xsd:integer
+  }
+  # For full clinical significance / conditions, join the ClinVar VariationID into the
+  # embedded ClinVar dataset graph <http://togovar.org/clinvar> (DBCLS ClinVar RDF;
+  # med2rdf:Variation nodes keyed by dcterms:identifier; med2rdf:gene -> NCBI gene).
+  # That graph mirrors the standalone `clinvar` database — see clinvar.yaml.
+
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix gvo:     <http://genome-variation.org/resource#> .
+    @prefix tgvo:    <http://togovar.biosciencedbc.jp/vocabulary/> .
+    @prefix faldo:   <http://biohackathon.org/resource/faldo#> .
+    @prefix dcterms: <http://purl.org/dc/terms/> .
+    @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix hco:     <http://identifiers.org/hco/12/GRCh38#> .
+  entries:
+    - title: "Core SNV record — rs671 / ALDH2 (graph: variant)"
+      description: "The canonical variant node: type, tgv ID, normalized+VCF coordinates, FALDO ExactPosition."
+      rdf: |
+        # GRAPH <http://togovar.org/variant>
+        hco:111803962-G-A a gvo:SNV ;
+            dcterms:identifier "tgv47264307" ;
+            gvo:pos 111803962 ; gvo:pos_vcf 111803962 ;
+            gvo:ref "G" ; gvo:alt "A" ;
+            gvo:ref_vcf "G" ; gvo:alt_vcf "A" ;
+            faldo:location [ a faldo:ExactPosition ;
+                             faldo:position 111803962 ;
+                             faldo:reference <http://identifiers.org/hco/12/GRCh38> ] .
+    - title: "VEP consequence annotation — rs671 (graph: variant/annotation/ensembl)"
+      description: dbSNP link, most-severe SO consequence, and a per-transcript consequence bnode with gene, HGVSp, impact.
+      rdf: |
+        # GRAPH <http://togovar.org/variant/annotation/ensembl>
+        hco:111803962-G-A rdfs:seeAlso <http://identifiers.org/dbsnp/rs671> ;
+            tgvo:most_severe_consequence <http://purl.obolibrary.org/obo/SO_0001583> ;  # missense_variant
+            tgvo:hasConsequence [
+                a <http://purl.obolibrary.org/obo/SO_0001583> ;
+                tgvo:gene <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000111275> ;      # ALDH2
+                tgvo:gene_symbol "ALDH2" ; tgvo:gene_symbol_source "HGNC" ;
+                tgvo:hgnc <http://identifiers.org/hgnc/404> ;
+                tgvo:transcript <http://rdf.ebi.ac.uk/resource/ensembl.transcript/ENST00000261733> ;
+                tgvo:hgvsp "ENSP00000261733.2:p.Glu504Lys" ;
+                tgvo:impact "MODERATE" ] .
+    - title: "ClinVar annotation — re-typed variant IRI (graph: variant/annotation/clinvar)"
+      description: The SAME variant IRI re-declared with the ClinVar VariationID and an ALLELEID INFO bnode (illustrates the union-inflation trap).
+      rdf: |
+        # GRAPH <http://togovar.org/variant/annotation/clinvar>
+        hco:111803962-G-A a gvo:SNV ;                 # re-typed here AND in the variant graph
+            dcterms:identifier "18390" ;              # ClinVar VariationID
+            gvo:info [ rdfs:label "ALLELEID" ; rdf:value 33429 ] .
+
+sparql_query_examples:
+  - title: "Variant core record by TogoVar variant IRI"
+    description: Fetch the canonical variant node (type, tgv ID, coordinates) — graph-pinned to avoid the ClinVar re-typing double.
+    question: "What are the coordinates and alleles of the variant at chr12:111803962 G>A?"
+    complexity: basic
+    sparql: |
+      PREFIX gvo: <http://genome-variation.org/resource#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+
+      SELECT ?type ?tgv ?pos ?ref ?alt
+      WHERE {
+        GRAPH <http://togovar.org/variant> {            # pin: variant IRI is re-typed in clinvar graph
+          <http://identifiers.org/hco/12/GRCh38#111803962-G-A>
+              a ?type ; dcterms:identifier ?tgv ;
+              gvo:pos ?pos ; gvo:ref ?ref ; gvo:alt ?alt .
+        }
+      }
+      LIMIT 20
+
+  - title: "Resolve a dbSNP rsID to variant + most-severe consequence"
+    description: dbSNP rsIDs are stored as IRIs (rdfs:seeAlso) in the ensembl annotation graph — use the IRI, not a text match.
+    question: "Which TogoVar variant is dbSNP rs671, and what is its most severe consequence?"
+    complexity: basic
+    sparql: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?variant ?soConsequence
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant rdfs:seeAlso <http://identifiers.org/dbsnp/rs671> ;
+                   tgvo:most_severe_consequence ?soConsequence .
+        }
+      }
+      LIMIT 20
+
+  - title: "All variants in a gene by Ensembl gene IRI, with consequence"
+    description: Filter the consequence bnode by the Ensembl gene IRI (typed predicate lookup) — no gene-name text search.
+    question: "List variants affecting ALDH2 (ENSG00000111275) with their most severe consequence."
+    complexity: intermediate
+    sparql: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+
+      SELECT DISTINCT ?variant ?soConsequence
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c ;
+                   tgvo:most_severe_consequence ?soConsequence .
+          ?c tgvo:gene <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000111275> .
+        }
+      }
+      LIMIT 20
+
+  - title: "SAFE variant-class count (avoid cross-graph re-typing inflation)"
+    description: Demonstrates the graph-pinned COUNT that returns the true class size; the unscoped form double-counts ClinVar-annotated variants.
+    question: "How many Insertion variants are in TogoVar?"
+    complexity: intermediate
+    sparql: |
+      PREFIX gvo: <http://genome-variation.org/resource#>
+
+      SELECT (COUNT(?v) AS ?insertions)
+      WHERE {
+        GRAPH <http://togovar.org/variant> {          # pin core graph; WITHOUT this, the 2.94M
+          ?v a gvo:Insertion .                        # ClinVar-annotated variants are counted twice
+        }
+      }
+      LIMIT 1
+
+  - title: "Predicted-deleterious missense variants in a gene (SIFT)"
+    description: Uses the controlled SIFT prediction literal and the Ensembl gene IRI on the same consequence bnode; STRSTARTS covers the *_low_confidence variants.
+    question: "Which ALDH2 variants are predicted deleterious by SIFT, and what is the protein change?"
+    complexity: intermediate
+    sparql: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+
+      SELECT DISTINCT ?variant ?hgvsp ?pred
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:gene <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000111275> ;
+             tgvo:sift_prediction ?pred ;
+             tgvo:hgvsp ?hgvsp .
+          FILTER(STRSTARTS(?pred, "deleterious"))    # "deleterious" and "deleterious_low_confidence"
+        }
+      }
+      LIMIT 20
+
+  - title: "Full variant report joining core + VEP annotation graphs"
+    description: Cross-GRAPH join within the endpoint — core coordinates from the variant graph, dbSNP + gene + protein change from the ensembl annotation graph, anchored on a gene to stay bounded.
+    question: "For ALDH2 variants, give position, ref/alt, dbSNP rsID and protein consequence."
+    complexity: advanced
+    sparql: |
+      PREFIX gvo:  <http://genome-variation.org/resource#>
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT DISTINCT ?variant ?pos ?ref ?alt ?rs ?hgvsp
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:gene <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000111275> ;
+             tgvo:hgvsp ?hgvsp .
+          OPTIONAL { ?variant rdfs:seeAlso ?rs . FILTER(STRSTARTS(STR(?rs), "http://identifiers.org/dbsnp/")) }
+        }
+        GRAPH <http://togovar.org/variant> {
+          ?variant gvo:pos ?pos ; gvo:ref ?ref ; gvo:alt ?alt .
+        }
+      }
+      LIMIT 20
+
+  - title: "Variant to ClinVar VariationID to embedded ClinVar dataset gene"
+    description: Bridge the variant layer to the embedded DBCLS ClinVar RDF via the ClinVar VariationID string join; the ClinVar variation node carries the NCBI gene link.
+    question: "For the variant chr12:111803962 G>A, what ClinVar VariationID and gene does the ClinVar dataset record?"
+    complexity: advanced
+    sparql: |
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+
+      SELECT DISTINCT ?variationId ?gene
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          <http://identifiers.org/hco/12/GRCh38#111803962-G-A> dcterms:identifier ?variationId .
+        }
+        GRAPH <http://togovar.org/clinvar> {           # embedded ClinVar RDF (see clinvar.yaml)
+          ?cv dcterms:identifier ?variationId ;
+              med2rdf:gene ?gene .
+        }
+      }
+      LIMIT 20
+
+cross_database_queries:
+  shared_endpoint: togovar
+  co_located_databases: []
+  examples: []
+  notes: |
+    TogoVar is served from its own self-hosted endpoint (https://grch38.togovar.org/sparql)
+    and is NOT co-located with the RDF Portal databases, so federated cross-DATABASE SPARQL
+    with uniprot/chembl/etc. is not available here. However the endpoint embeds several
+    reference datasets AS INTERNAL GRAPHS (clinvar, ensembl gene models, hgnc, medgen,
+    mondo, so, gwas-catalog, mesh, efo, go, pubmed, pubtator), so the important joins are
+    CROSS-GRAPH within this endpoint — demonstrated in sparql_query_examples #6 (core+VEP)
+    and #7 (variant -> ClinVar VariationID -> embedded ClinVar dataset).
+    Manual bridging to RDF Portal: use the stable external IRIs TogoVar exposes as join keys
+    — dbSNP rsID (http://identifiers.org/dbsnp/rs...), Ensembl gene (ENSG...), Ensembl
+    transcript, HGNC (http://identifiers.org/hgnc/...), SO terms (obo:SO_...), and ClinVar
+    VariationID — via TogoID conversion or a separate query against the RDF Portal endpoint.
+
+cross_references:
+  - pattern: rdfs:seeAlso (dbSNP)
+    description: |
+      Each annotated variant links to its dbSNP refSNP as an IRI in the ensembl
+      annotation graph: http://identifiers.org/dbsnp/rs{N}. Can be multi-valued
+      (merged rsIDs). Use the IRI directly; do not string-match "rs...".
+    databases:
+      variant:
+        - "TogoVar: ~99% of SNVs (sampling N=2000)"
+  - pattern: tgvo:gene / tgvo:hgnc (gene links)
+    description: |
+      Consequence bnodes carry tgvo:gene (Ensembl gene IRI ENSG... AND, separately,
+      NCBI Gene IDs — both under http://rdf.ebi.ac.uk/resource/ensembl/; disambiguate
+      with tgvo:gene_symbol_source) and tgvo:hgnc (http://identifiers.org/hgnc/{n}).
+    databases:
+      variant:
+        - "TogoVar: gene links present on essentially all VEP-annotated variants (~100%)"
+  - pattern: tgvo:most_severe_consequence / consequence rdf:type (Sequence Ontology)
+    description: |
+      Functional consequences are Sequence Ontology term IRIs
+      (http://purl.obolibrary.org/obo/SO_XXXXXXX), both as most_severe_consequence and
+      as the rdf:type of each hasConsequence bnode. The SO terms themselves are in the
+      embedded <http://togovar.org/so> graph.
+    databases:
+      variant:
+        - "TogoVar: most_severe_consequence on ~100% of variants (sampling N=2000)"
+  - pattern: dcterms:identifier (ClinVar VariationID) -> embedded ClinVar
+    description: |
+      The clinvar annotation graph stores the ClinVar VariationID as dcterms:identifier
+      (xsd:string). Join it into <http://togovar.org/clinvar> (DBCLS ClinVar RDF) for
+      significance, conditions (MONDO/MedGen), and gene links.
+    databases:
+      variant:
+        - "TogoVar: 2,944,525 variants carry a ClinVar annotation (~0.75% of 390.7M)"
+
+architectural_notes:
+  query_strategy:
+    - "FIRST: read this MIE; note which GRAPH each predicate lives in (core vs ensembl-anno vs clinvar-anno)."
+    - "KEYWORD ENTRY (REST->SPARQL handoff): resolve names with the TogoVar REST tools, then anchor SPARQL on the returned ID. togovar_search_gene('ALDH2')->hgnc_id 404 anchors directly via `?c tgvo:hgnc <http://identifiers.org/hgnc/404>` (no Ensembl-ENSG conversion needed; verified 6,490 ALDH2 variants). togovar_search_disease(name)->MONDO id feeds the <http://togovar.org/mondo> graph / ClinVar join. rsIDs need no search — they are rdfs:seeAlso IRIs."
+    - "Anchor on a specific IRI: variant IRI (hco/{chr}/GRCh38#{pos}-{ref}-{alt}), dbSNP rsID, Ensembl gene ENSG, or HGNC IRI."
+    - "Always pin GRAPH — predicates are graph-scoped and the variant IRI is re-typed across graphs."
+    - "For counts of variant classes, pin GRAPH <http://togovar.org/variant> (or COUNT(DISTINCT)) to avoid the x2 ClinVar re-typing inflation."
+    - "Priority: Specific IRIs > typed predicates (SO/impact/prediction literals) > cross-graph joins. Text search is not needed."
+  schema_design:
+    - "Central entity: Variant (390.7M) with 9 core predicates in the variant graph; type is one of SNV/Deletion/Insertion/MNV/Indel."
+    - "Coordinates via FALDO: SNV->ExactPosition, Insertion->InBetweenPosition, Deletion/multi-base->Region(begin/end InBetweenPosition). Normalized (gvo:*) vs VCF (gvo:*_vcf) allele/pos pairs."
+    - "Annotation is layered in separate graphs keyed by the SAME variant IRI: ensembl (VEP consequences, dbSNP), clinvar (VariationID, ALLELEID)."
+    - "hasConsequence bnodes are per-transcript, typed with SO consequence term(s), carrying gene/transcript/HGVS/impact/SIFT/PolyPhen/AlphaMissense."
+    - "Reference ontologies/datasets embedded as graphs: clinvar (DBCLS ClinVar RDF), ensembl gene models, hgnc, medgen, mondo, so, go, mesh, efo, gwas-catalog, pubmed, pubtator, hco."
+  performance:
+    - "COUNT/DISTINCT over the full annotation graphs (390M+ subjects) times out (~90s) — anchor on a gene/variant IRI, or use the indexed class-count on the variant graph."
+    - "Class-partitioned COUNTs on the variant graph (?s a gvo:SNV) ARE fast (Virtuoso type index)."
+    - "Bound every consequence/gene query with a specific gene or variant IRI plus LIMIT."
+    - "bif:contains is available (Virtuoso) but unnecessary here; if ever used, split property paths before it."
+  data_integration:
+    - "Join keys: variant IRI (internal cross-graph), dbSNP rsID, Ensembl gene/transcript IRI, HGNC IRI, SO term IRI, ClinVar VariationID."
+    - "ClinVar clinical detail lives in the embedded <http://togovar.org/clinvar> graph — reuse the clinvar.yaml MIE for its deep schema."
+    - "Allele frequencies are external to this endpoint (TogoVar REST API only)."
+  data_quality:
+    - "The same variant IRI is re-typed in the clinvar annotation graph (union inflation trap)."
+    - "tgvo:gene mixes Ensembl gene IRIs and NCBI Gene IDs under one namespace (disambiguate via gene_symbol_source)."
+    - "gvo:ref/gvo:alt are empty strings for pure indels; use gvo:ref_vcf/gvo:alt_vcf for anchor-base VCF form."
+    - "tgvo:sift and tgvo:polyphen have MIXED xsd:decimal/xsd:integer datatypes (numeric comparison works; exact equality does not)."
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0."
+    - "Every filter concept here is IRI- or controlled-literal-backed: genes (ENSG/HGNC IRIs), variants (dbSNP/variant IRIs), consequences (SO IRIs), impact/SIFT/PolyPhen (controlled literals)."
+    - "No free-text predicate exists on variants, so no bif:contains is warranted."
+
+data_statistics:
+  total_entities: 390725782
+  verified_date: "2026-07-12"
+  verification_method: "Direct GROUP BY type COUNT on GRAPH <http://togovar.org/variant> (indexed)"
+  by_class:
+    SNV: 339076968
+    Deletion: 29307469
+    Insertion: 22340786
+    MNV: 492
+    Indel: 67
+    verified_date: "2026-07-12"
+  coverage:
+    vep_consequence: "~100% of variants (most_severe_consequence present)"
+    vep_calculation: "sampling N=2000 SNV: all sampled had a most_severe_consequence"
+    dbsnp_seealso: "~99% of SNVs"
+    dbsnp_calculation: "sampling N=2000 SNV: 2771/2779 result rows carried an rsID"
+    clinvar_annotation: "0.75%"
+    clinvar_calculation: "2,944,525 variants with ClinVar annotation / 390,725,782 total"
+    verified_date: "2026-07-12"
+
+anti_patterns:
+  - title: "Schema Check Before Text Search (gene by name)"
+    problem: "Text-matching a gene symbol string instead of using the Ensembl/HGNC gene IRI."
+    wrong_sparql: |
+      # No structured lookup — scans literals
+      ?c tgvo:gene_symbol ?sym . FILTER(CONTAINS(?sym, "ALDH2"))
+    correct_sparql: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      SELECT DISTINCT ?variant WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:gene <http://rdf.ebi.ac.uk/resource/ensembl/ENSG00000111275> .  # ALDH2
+        }
+      } LIMIT 20
+    explanation: "Genes are identified by Ensembl (ENSG) and HGNC IRIs; use the IRI, which is canonical and indexed."
+
+  - title: "Unscoped Variant-Class COUNT (cross-graph re-typing inflation)"
+    problem: "Counting a variant class without pinning the graph double-counts the 2.94M ClinVar-annotated variants re-typed in the clinvar annotation graph."
+    wrong_sparql: |
+      # Union of all graphs — ClinVar-annotated variants counted twice
+      SELECT (COUNT(?s) AS ?n) WHERE { ?s a <http://genome-variation.org/resource#SNV> }
+    correct_sparql: |
+      PREFIX gvo: <http://genome-variation.org/resource#>
+      SELECT (COUNT(?s) AS ?n) WHERE {
+        GRAPH <http://togovar.org/variant> { ?s a gvo:SNV }
+      }
+    explanation: "The same variant IRI is typed gvo:SNV in both the variant and clinvar annotation graphs; pin the core graph (or COUNT DISTINCT) for the true class size."
+
+  - title: "Querying Allele Frequency from SPARQL"
+    problem: "Expecting per-population allele frequencies (ToMMo, gnomAD, JGA...) in this endpoint; they are not here."
+    wrong_sparql: |
+      # Returns 0 rows — no such predicate anywhere in the endpoint
+      ?variant tgvo:frequency ?f .
+    correct_sparql: |
+      # Frequencies come from the TogoVar REST API, not SPARQL. From SPARQL you can only
+      # obtain identity/annotation; fetch the variant IRI or rsID here, then call the REST API:
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?variant WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant rdfs:seeAlso <http://identifiers.org/dbsnp/rs671> .
+        }
+      } LIMIT 1
+    explanation: "This SPARQL endpoint holds variant identity, coordinates, VEP consequences and ClinVar/annotation only. Allele frequencies are served by the TogoVar REST API."
+
+  - title: "Normalized vs VCF Allele/Position Confusion"
+    problem: "Matching a VCF-style REF/ALT (with anchor base) against gvo:ref/gvo:alt, which are normalized and empty for pure indels."
+    wrong_sparql: |
+      # A VCF deletion "TTCAGG.../T" will never match the normalized alleles
+      ?v gvo:ref "TTCAGGAAGTCAGATGGTTAAGCGACTG" ; gvo:alt "T" .
+    correct_sparql: |
+      PREFIX gvo: <http://genome-variation.org/resource#>
+      SELECT ?v WHERE {
+        GRAPH <http://togovar.org/variant> {
+          ?v gvo:ref_vcf "TTCAGGAAGTCAGATGGTTAAGCGACTG" ; gvo:alt_vcf "T" .   # VCF pair
+        }
+      } LIMIT 5
+    explanation: "gvo:ref/gvo:alt are VOA-normalized (trimmed, empty for pure indels); use the gvo:*_vcf pair to match VCF input, and gvo:pos_vcf for the VCF position."
+
+common_errors:
+  - error: "Empty results despite a valid-looking query"
+    causes:
+      - "Predicate queried in the wrong graph (core vs ensembl-anno vs clinvar-anno)"
+      - "Looking for allele frequency (not present in this endpoint)"
+      - "Matching gvo:pos with a string, or matching normalized alleles against VCF alleles"
+      - "SIFT/PolyPhen prediction filter using '=' when values include *_low_confidence suffixes"
+    solutions:
+      - "Pin the GRAPH that owns the predicate (see shape_expressions graph comments)"
+      - "Fetch frequencies from the TogoVar REST API, not SPARQL"
+      - "Use integer literals for gvo:pos/faldo:position; use gvo:*_vcf for VCF alleles"
+      - "Use STRSTARTS(?pred, 'deleterious') / VALUES for prediction categories"
+  - error: "Query timeout"
+    causes:
+      - "COUNT(DISTINCT ?s) over an entire 390M-subject annotation graph"
+      - "Unbounded consequence/gene traversal without a specific gene or variant IRI"
+      - "Enumerating all named graphs or all predicates over the full store"
+    solutions:
+      - "Anchor on a specific gene/variant/dbSNP IRI and add LIMIT"
+      - "For class totals use the indexed class-count on GRAPH <http://togovar.org/variant>"
+      - "Avoid SELECT DISTINCT ?g / DISTINCT ?p sweeps over the union graph"
+  - error: "Counts larger than expected"
+    causes:
+      - "Cross-graph re-typing: ClinVar-annotated variants counted in both variant and clinvar graphs"
+      - "Multi-valued predicates (rdfs:seeAlso, tgvo:hasConsequence, tgvo:gene) inflating row counts in joins"
+    solutions:
+      - "Pin GRAPH <http://togovar.org/variant> for class counts"
+      - "Use COUNT(DISTINCT ?variant) and DISTINCT in projections when fanning out over consequences"

--- a/togo_mcp/data/resources/endpoints.csv
+++ b/togo_mcp/data/resources/endpoints.csv
@@ -33,3 +33,4 @@ nbrc,https://rdfportal.org/primary/sparql,primary,sparql
 mogplus,https://rdfportal.org/primary/sparql,primary,sparql
 hco,https://rdfportal.org/primary/sparql,primary,sparql
 mco,https://rdfportal.org/primary/sparql,primary,sparql
+togovar,https://grch38.togovar.org/sparql,togovar,togovar_search_(gene|disease)


### PR DESCRIPTION
## What

Registers **TogoVar's self-hosted GRCh38 SPARQL endpoint** as an RDF database and ships a **live-validated MIE** describing it. This complements the TogoVar REST sub-server (#139): the two layers are cleanly split.

| Layer | Serves |
|---|---|
| **REST** (`togovar_*` tools) | per-population allele frequencies (ToMMo, gnomAD, JGA, GEM-J, NCBN, BBJ) — **not in SPARQL** |
| **SPARQL** (this MIE) | variant identity, tgv IDs, Ensembl-VEP consequences, HGVS, dbSNP/HGNC/Ensembl/SO links, embedded ClinVar annotation, + join keys into RDF Portal |

## Files
- **`togo_mcp/data/mie/togovar.yaml`** — new MIE (v1.0, ~390M variants). All 3 sample RDF entries and 7 + cross-DB SPARQL examples validated live against the endpoint.
- **`endpoints.csv`** — `togovar` row. `keyword_search_api = togovar_search_(gene|disease)` — the REST tools that resolve gene/disease keywords to IDs (a returned `hgnc_id` anchors SPARQL directly via `tgvo:hgnc`; verified ALDH2 = 6,490 variants).
- **intro page** — TogoVar database card in the genome-variation group.

## Documented traps (all verified live)
- **No allele frequency in SPARQL** — REST-API only (even rs671 has zero frequency predicates). Lead `critical_warning` + anti-pattern.
- **Cross-graph re-typing / union inflation** — the same variant IRI is typed in both the `variant` and `clinvar` graphs, so an unscoped class COUNT double-counts (pinned Insertion 22,340,786 vs unscoped 22,415,153). Safe pattern = pin `GRAPH` / `COUNT(DISTINCT)`.
- Graph-scoped predicates; normalized vs VCF alleles; polymorphic `tgvo:gene`.

## Verification
- `run_sparql(database='togovar')` executes — MNV count 492 matches the MIE `by_class`.
- Independently re-validated (not just the authoring agent): YAML parses (561 lines); union-inflation multiplier reproduced; 3/3 sample ASKs true; frequency-absence confirmed; advanced cross-graph queries return rows.

⚠️ The running local/prod MCP server must be **restarted** to pick up the new `endpoints.csv` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)