### PR TITLE
fix(togovar): handle mounted sub-server tools in _IgnoreUnknownSearchKwargs

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -272,3 +272,59 @@ class TestToolCallLogger:
         assert rec["extra"]["endpoint_url"] == "https://x/sparql"
         assert rec["extra"]["sparql_status"] == "ok"
         assert rec["extra"]["n_rows"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _IgnoreUnknownSearchKwargs middleware — mounted sub-server regression
+# ---------------------------------------------------------------------------
+class TestIgnoreUnknownSearchKwargs:
+    """A mounted sub-server search tool (e.g. togovar_search_*) is proxied as a
+    FastMCPProviderTool, which has NO `.fn`. The middleware used to derive valid
+    kwargs via `tool.fn`, raising AttributeError and killing every call to those
+    three TogoVar tools. Guard the schema-based fallback path here — none of the
+    togovar tests exercise the mount + middleware layer where the bug lived.
+    """
+
+    def _root_with_togovar(self):
+        from fastmcp import FastMCP
+        from togo_mcp.togovar import togovar_mcp
+
+        root = FastMCP("test-root")
+        root.mount(togovar_mcp, "togovar")
+        return root
+
+    def test_mounted_search_tool_valid_kwargs_no_fn(self) -> None:
+        from togo_mcp.server import _IgnoreUnknownSearchKwargs
+
+        root = self._root_with_togovar()
+        mw = _IgnoreUnknownSearchKwargs()
+        mw._valid_kwargs_cache.clear()
+        ctx = SimpleNamespace(fastmcp_context=SimpleNamespace(fastmcp=root))
+
+        # Must not raise (regression) and must resolve schema-derived arg names.
+        valid = asyncio.run(mw._valid_kwargs(ctx, "togovar_search_variant"))
+        assert valid is not None
+        assert {"gene_hgnc_id", "chromosome", "consequence", "limit"} <= valid
+
+    def test_mounted_search_tool_strips_unknown_kwargs(self) -> None:
+        from togo_mcp.server import _IgnoreUnknownSearchKwargs
+
+        root = self._root_with_togovar()
+        mw = _IgnoreUnknownSearchKwargs()
+        mw._valid_kwargs_cache.clear()
+        seen: dict = {}
+
+        async def call_next(context):
+            seen["args"] = dict(context.message.arguments)
+            return "ok"
+
+        context = SimpleNamespace(
+            message=SimpleNamespace(
+                name="togovar_search_gene",
+                arguments={"query": "ALDH2", "bogus": "drop-me"},
+            ),
+            fastmcp_context=SimpleNamespace(fastmcp=root),
+        )
+        asyncio.run(mw.on_call_tool(context, call_next))
+        # The made-up kwarg is dropped; the declared one survives.
+        assert seen["args"] == {"query": "ALDH2"}

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -317,7 +317,17 @@ class _IgnoreUnknownSearchKwargs(_Middleware):
             tool = await server.get_tool(tool_name)
         except Exception:
             return None
-        valid = set(_inspect.signature(tool.fn).parameters)
+        fn = getattr(tool, "fn", None)
+        if fn is not None:
+            # Local FunctionTool: the wrapped function is the source of truth.
+            valid = set(_inspect.signature(fn).parameters)
+        else:
+            # Mounted sub-server tools (e.g. togovar_search_*) are proxied as
+            # FastMCPProviderTool, which exposes no .fn — deriving valid arg
+            # names from tool.fn raised AttributeError and killed every call.
+            # Fall back to the accepted argument names in the input JSON schema.
+            props = (getattr(tool, "parameters", None) or {}).get("properties", {})
+            valid = set(props)
         self._valid_kwargs_cache[tool_name] = valid
         return valid
 


### PR DESCRIPTION
## Summary

The `_IgnoreUnknownSearchKwargs` middleware derived each tool's valid kwargs from `tool.fn`. Mounted sub-server tools — the three `togovar_search_*` tools — are proxied as `FastMCPProviderTool` objects that expose **no** `.fn`, so accessing it raised `AttributeError` and killed *every* call to those tools. The flat `search_*` tools (local `FunctionTool`s) were unaffected.

## Fix

- Fall back to the tool's input JSON-schema `properties` when `.fn` is absent.
- Local `FunctionTool`s still use the wrapped-function signature (unchanged).

## Tests

Adds `TestIgnoreUnknownSearchKwargs` in `tests/test_server.py`, exercising the mount + middleware layer none of the existing togovar tests touch:
- valid-kwargs resolution from the schema (no `.fn`)
- unknown-kwarg stripping (`bogus` dropped, declared arg preserved)

`uv run pytest tests/test_server.py` → 19 passed. All three TogoVar tools (`search_gene`/`search_disease`/`search_variant`) verified end-to-end against the live dev server after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)