### PR TITLE
Sync dev → main: benchmark questions 081-085 (balanced 85-question set)

### DIFF
--- a/benchmark/questions/coverage_tracker.yaml
+++ b/benchmark/questions/coverage_tracker.yaml
@@ -1,4 +1,41 @@
 # Coverage Tracker for TogoMCP Evaluation Dataset
+# Updated after Question 085 added (2026-07-12): list | uniprot + hgnc + togovar + clinvar (4 databases; KW-1004 Congenital myasthenic syndrome)
+# Q085: of the 24 congenital-myasthenic-syndrome genes, which have >=1 loss-of-function variant (stop_gained/
+#   frameshift/splice) present in the TogoVar catalogue AND classified Pathogenic/Likely-pathogenic in ClinVar?
+#   = 14 genes (AGRN, CHAT, CHRND, CHRNE, COL13A1, COLQ, DOK7, GFPT1, LRP4, MUSK, PREPL, RAPSN, SCN4A, SLC25A1).
+#   Pipeline: UniProt KW-1004->24 genes; HGNC IRIs; TogoVar LoF+ClinVar-VariationID (71 pairs/18 genes);
+#   ClinVar significance filter -> 46 P/LP VariationIDs; map back -> 14 genes. Rule-3: per-gene counts
+#   (8+7+5+3x6+2x3+1x2) sum to 46 = total P/LP VariationIDs; 24 = 14 answer + 10 excluded (6 no-link + 4 non-path).
+#   Second togovar question, DIFFERENT angle from Q084 (clinical LoF-significance intersection vs missense count).
+# BALANCED 85-QUESTION MILESTONE REACHED — all five types now at 17 (yes_no/factoid/list/summary/choice)
+# Changes: list count 16->17 (Q085 added); togovar 1->2, hgnc 8->9, uniprot 38->39, clinvar 6->7
+# two_plus 84->85 (stays 100%, 85/85); three_plus 30->31 (Q085 is 4-DB); percentage 35.7->36.5% (31/85)
+# Updated after Question 084 added (2026-07-12): choice | uniprot + hgnc + togovar (3 databases; KW-0988 Intrahepatic cholestasis)
+# Q084: among four intrahepatic-cholestasis genes (MYO5B/ABCB11/ATP8B1/ABCB4), which harbours the most distinct
+#   missense variants (SO_0001583) in the TogoVar GRCh38 catalogue? = MYO5B (445), beating the canonical PFIC
+#   transporters ABCB11 (258), ATP8B1 (231), ABCB4 (215). Gene set = 19 reviewed human KW-0988 genes (UniProt),
+#   bridged symbol->HGNC IRI (hgnc), counted per HGNC IRI in TogoVar. Rule-3: 19 per-gene counts sum to 3205 =
+#   total DISTINCT missense across the set (disjoint loci). FIRST togovar question — closes the last uncovered DB.
+# Changes: choice count 16->17 (Q084 added); togovar NEW (count 1, first use); hgnc 7->8; uniprot 37->38
+# two_plus 83->84 (stays 100%, 84/84); three_plus 29->30 (Q084 is 3-DB); percentage 34.9->35.7% (30/84)
+# Updated after Question 083 added (2026-07-11): yes_no | mediadive + chebi (2 databases; KW-0533 Nickel)
+# Q083: is a nickel salt an ingredient in more standardized culture-media recipes than an inorganic cobalt salt? = NO
+#   (nickel salts 1206 media vs inorganic cobalt salts 1509 media; salt identity resolved via ChEBI cross-refs).
+#   First mediadive question using the ingredient->ChEBI chemical link (Q008/017/048 all used bacdive instead).
+# Changes: yes_no count 16->17 (Q083 added); mediadive 3->4, chebi 11->12
+# two_plus 82->83 (stays 100%, 83/83); three_plus stays 29 (Q083 is 2-DB); percentage 35.4->34.9% (29/83)
+# Updated after Question 082 added (2026-07-11): factoid | uniprot + ensembl + mogplus (3 databases; KW-0919 Taste)
+# Q082: how many distinct missense single-nucleotide variants fall within mouse gene Tas2r117 (bitter taste receptor
+#   type 2 member 117, ENSMUSG00000058349, chr6/GRCm39) predicted by Ensembl VEP? = 18 (protein positions 22-227).
+#   Rule-3: 18 missense + 8 synonymous + 1 5'UTR = 27 total VEP-annotated variants on the gene. VEP annotations for
+#   this gene are release-v3-only (v2.1 overlaps carry no VEP/SnpEff), so the VEP-missense set is exactly 18.
+# Changes: factoid count 16->17 (Q082 added); uniprot 36->37, ensembl 8->9, mogplus 2->3
+# two_plus 81->82 (stays 100%, 82/82); three_plus 28->29 (Q082 is 3-DB); percentage 34.6->35.4% (29/82)
+# Updated after Question 081 added (2026-07-10): summary | hgnc + hco + oma + ensembl + mco (5 databases; KW-0656 Proto-oncogene)
+# Q081: cross-species chromosomal synteny of the HRAS ortholog pair — human HRAS at 11p15.5 (gneg) vs mouse Hras (OMA MOUSE57051)
+#   on mouse chromosome 7 (GRCm39 length 144,995,196 bp); orthologs on differently-numbered chromosomes (11p15 <-> mouse chr7 synteny block)
+# Changes: summary count 16->17 (Q081 added); hgnc 6->7, hco 1->2, oma 2->3, ensembl 7->8, mco 1->2
+# two_plus 80->81 (stays 100%, 81/81); three_plus 27->28 (Q081 is 5-DB); percentage 33.8->34.6% (28/81)
 # Updated after Question 080 added (2026-07-10): list | rhea + chebi (2 databases; KW-0174 Coenzyme M biosynthesis)
 # Q080: list the 19 approved reactions with free coenzyme M (CHEBI:58319); methanogenesis + aerobic epoxyalkane pathway
 # Changes: list count 15->16 (Q080 added); rhea 11->12, chebi 10->11
@@ -122,39 +159,39 @@
 # Score upgraded: 10→11 (biological_insight 2→3; other dimensions unchanged)
 # three_plus_databases: unchanged at 19 (Q028 remains 2-DB)
 
-total_questions: 80
+total_questions: 85
 
 question_types:
   yes_no:
-    count: 16
-    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069', '074', '079']
-    status: 'ok'  # 16 uses - Q079 (are all reviewed human MHC class I genes on one chromosome? no — chr6/chr15/chr1; uniprot+hgnc)
+    count: 17
+    questions: ['001', '007', '012', '017', '020', '026', '032', '036', '042', '046', '053', '060', '064', '069', '074', '079', '083']
+    status: 'ok'  # 17 uses - Q083 (is a nickel salt in more media than an inorganic cobalt salt? no — 1206 vs 1509; mediadive+chebi)
 
   factoid:
-    count: 16
-    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066', '071', '077']
-    status: 'ok'  # 16 uses - Q077 (mouse nuclear chromosome with highest protein-coding gene density on GRCm39 = chr7; ensembl+mco, first mco question)
+    count: 17
+    questions: ['002', '003', '006', '011', '014', '022', '027', '031', '043', '047', '052', '056', '061', '066', '071', '077', '082']
+    status: 'ok'  # 17 uses - Q082 (18 missense SNVs in mouse Tas2r117 predicted by VEP; uniprot+ensembl+mogplus, KW-0919 Taste)
 
   list:
-    count: 16
-    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068', '073', '080']
-    status: 'ok'  # 16 uses - Q080 (19 approved reactions with free coenzyme M; rhea+chebi) — completes the balanced 80-question milestone (all five types at 16)
+    count: 17
+    questions: ['009', '013', '018', '023', '028', '033', '039', '040', '044', '048', '054', '057', '062', '068', '073', '080', '085']
+    status: 'ok'  # 17 uses - Q085 (14 CMS genes with a pathogenic loss-of-function variant catalogued in TogoVar+ClinVar; uniprot+hgnc+togovar+clinvar, KW-1004) — completes the balanced 85-question milestone (all five types at 17)
 
   summary:
-    count: 16
-    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070', '075', '076']
+    count: 17
+    questions: ['004', '008', '015', '021', '024', '029', '034', '037', '045', '049', '055', '059', '065', '070', '075', '076', '081']
     status: 'ok'  # 16 uses - Q076 (cytogenetic distribution of reviewed human homeobox genes across GRCh38 cytobands; uniprot+hgnc+hco, first hco question)
 
   choice:
-    count: 16
-    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067', '072', '078']
-    status: 'ok'  # 16 uses - Q078 (3rd most-represented source organism in jPOST after human/mouse = African green monkey; jpostdb+taxonomy)
+    count: 17
+    questions: ['005', '010', '016', '019', '025', '030', '035', '038', '041', '050', '051', '058', '063', '067', '072', '078', '084']
+    status: 'ok'  # 17 uses - Q084 (which intrahepatic-cholestasis gene has the most TogoVar missense variants = MYO5B 445; uniprot+hgnc+togovar, KW-0988)
 
 databases:
   uniprot:
-    count: 36
-    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067', '071', '076', '079']
-    status: 'ok'  # At 45.6% (36/79), below 70% cap
+    count: 39
+    questions: ['002', '003', '004', '006', '007', '012', '014', '015', '021', '023', '024', '027', '028', '030', '031', '033', '035', '037', '040', '044', '046', '049', '054', '055', '058', '059', '060', '062', '063', '064', '065', '066', '067', '071', '076', '079', '082', '084', '085']
+    status: 'ok'  # At 45.9% (39/85), below 70% cap
 
   rhea:
     count: 12
@@ -177,8 +214,8 @@ databases:
     status: 'ok'
 
   chebi:
-    count: 11
-    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068', '075', '080']
+    count: 12
+    questions: ['004', '011', '024', '043', '045', '051', '056', '059', '068', '075', '080', '083']
     status: 'ok'
 
   reactome:
@@ -187,14 +224,14 @@ databases:
     status: 'ok'
 
   ensembl:
-    count: 7
-    questions: ['007', '023', '037', '038', '071', '073', '077']
+    count: 9
+    questions: ['007', '023', '037', '038', '071', '073', '077', '081', '082']
     status: 'ok'
 
   mogplus:
-    count: 2
-    questions: ['071', '073']
-    status: 'ok'  # mouse genome variation / MoG+; Q071 (factoid) + Q073 (list)
+    count: 3
+    questions: ['071', '073', '082']
+    status: 'ok'  # mouse genome variation / MoG+; Q071 (factoid, strain-anchored) + Q073 (list, single-variant carriers) + Q082 (factoid, gene+VEP-consequence missense count)
 
   glycosmos:
     count: 4
@@ -212,8 +249,8 @@ databases:
     status: 'ok'
 
   clinvar:
-    count: 6
-    questions: ['001', '013', '025', '029', '040', '070']
+    count: 7
+    questions: ['001', '013', '025', '029', '040', '070', '085']
     status: 'ok'
 
   go:
@@ -247,9 +284,9 @@ databases:
     status: 'ok'
 
   mediadive:
-    count: 3
-    questions: ['008', '017', '048']
-    status: 'ok'
+    count: 4
+    questions: ['008', '017', '048', '083']
+    status: 'ok'  # Q083 first to use the ingredient->ChEBI chemical link (others paired with bacdive)
 
   amrportal:
     count: 4
@@ -277,18 +314,18 @@ databases:
     status: 'ok'
 
   hgnc:
-    count: 6
-    questions: ['052', '057', '063', '065', '076', '079']
+    count: 9
+    questions: ['052', '057', '063', '065', '076', '079', '081', '084', '085']
     status: 'ok'  # newly added life-science DB
 
   hco:
-    count: 1
-    questions: ['076']
+    count: 2
+    questions: ['076', '081']
     status: 'ok'  # Human Chromosome Ontology (cytobands, Giemsa stains, GRCh38/37 coordinates); first use Q076
 
   mco:
-    count: 1
-    questions: ['077']
+    count: 2
+    questions: ['077', '081']
     status: 'ok'  # Mouse Chromosome Ontology (whole-chromosome lengths + RefSeq/INSDC/Ensembl xrefs, GRCm39/38); first use Q077 — completes registry coverage
 
   bgee:
@@ -307,8 +344,8 @@ databases:
     status: 'ok'  # newly added life-science DB
 
   oma:
-    count: 2
-    questions: ['055', '060']
+    count: 3
+    questions: ['055', '060', '081']
     status: 'ok'  # newly added life-science DB
 
   massbank:
@@ -316,17 +353,22 @@ databases:
     questions: ['056', '059', '061', '068']
     status: 'ok'  # newly added life-science DB
 
+  togovar:
+    count: 2
+    questions: ['084', '085']
+    status: 'ok'  # Japanese/human GRCh38 genome variation; Q084 (choice, per-gene missense count) + Q085 (list, LoF+ClinVar-significance intersection)
+
 multi_database_metrics:
   two_plus_databases:
-    count: 80
-    percentage: 100.0  # 80/80 (Q080 is 2-DB: rhea + chebi)
+    count: 85
+    percentage: 100.0  # 85/85 (Q085 is 4-DB: uniprot + hgnc + togovar + clinvar)
     target: '>= 60%'
     status: 'excellent'
 
   three_plus_databases:
-    count: 27
-    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070', '071', '075', '076']
-    percentage: 33.8  # 27/80 (Q080 is 2-DB: rhea + chebi)
+    count: 31
+    questions: ['004', '006', '007', '011', '013', '014', '015', '019', '021', '024', '025', '027', '029', '034', '037', '039', '045', '047', '048', '049', '055', '059', '065', '070', '071', '075', '076', '081', '082', '084', '085']
+    percentage: 36.5  # 31/85 (Q085 is 4-DB: uniprot + hgnc + togovar + clinvar)
     target: '>= 20%'
     status: 'excellent'
 
@@ -411,6 +453,11 @@ keywords_used:
   - 'KW-1267'  # Proteomics identification (Q078)
   - 'KW-0490'  # MHC I (Q079)
   - 'KW-0174'  # Coenzyme M biosynthesis (Q080)
+  - 'KW-0656'  # Proto-oncogene (Q081)
+  - 'KW-0919'  # Taste (Q082)
+  - 'KW-0533'  # Nickel (Q083)
+  - 'KW-0988'  # Intrahepatic cholestasis (Q084)
+  - 'KW-1004'  # Congenital myasthenic syndrome (Q085)
 
 next_priorities:
   question_types:

--- a/benchmark/questions/question_081.yaml
+++ b/benchmark/questions/question_081.yaml
@@ -1,0 +1,301 @@
+id: question_081
+type: summary
+body: >-
+  The proto-oncogene HRAS, which encodes a small GTPase, is one of the most
+  intensively studied cancer genes. Because the human and mouse lineages have
+  reshuffled their chromosomes since their common ancestor, an orthologous gene
+  and its counterpart frequently reside on chromosomes bearing different numbers
+  in the two species, even where the local gene order is conserved. For the
+  orthologous HRAS gene pair, give an integrated cross-species summary of
+  chromosomal location: state the cytogenetic band of the human gene on the
+  current human reference assembly together with the Giemsa staining character
+  and the approximate coordinates of that band; identify the corresponding mouse
+  ortholog and the mouse chromosome on which it resides in the current mouse
+  reference assembly; report the assembled length of that mouse chromosome; and
+  explain what this human-versus-mouse placement illustrates about conserved
+  synteny despite the differing chromosome numbers.
+
+inspiration_keyword:
+  keyword_id: KW-0656
+  name: Proto-oncogene
+  category: Disease
+
+togomcp_databases_used:
+  - hgnc
+  - hco
+  - oma
+  - ensembl
+  - mco
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 8 minutes
+  method: |
+    Attempted to answer the specific, integrated question — the human HRAS
+    cytoband plus its Giemsa stain, the identity of the mouse ortholog, the mouse
+    chromosome it sits on, and that chromosome's GRCm39 assembled length — directly
+    from the literature with three PubMed searches:
+    (1) "HRAS human mouse ortholog chromosome 11p15 synteny chromosome 7 cytoband"
+    (2) "mouse Hras chromosome 7 GRCm39 assembled length cytogenetic band Giemsa"
+    (3) "HRAS mouse human comparative mapping conserved synteny chromosome location"
+  result: |
+    All three searches returned zero articles. The individual facts are scattered
+    across incompatible resources — the human cytoband and its Giemsa stain live in
+    a cytogenetic ontology, the ortholog assignment in a phylogenomic orthology
+    resource, the mouse chromosome placement in a genome annotation, and the exact
+    GRCm39 chromosome length in a chromosome reference — and no single paper states,
+    let alone integrates, them. In particular the Giemsa staining character of
+    11p15.5 and the exact assembled length of mouse chromosome 7 on the GRCm39 build
+    (144,995,196 bp) are assembly/ontology facts absent from the primary literature.
+  conclusion: PASS (the integrated cross-species summary cannot be assembled from the literature; it requires a live join of a cytoband ontology, an orthology resource, a genome annotation, and a mouse-chromosome reference)
+
+sparql_queries:
+  - query_number: 1
+    database: hgnc
+    description: >-
+      Resolve the human gene HRAS to its cytogenetic band. The HGNC gene record
+      carries obo:so_part_of, a plain ISCN cytoband string that is the join key to
+      the human cytoband ontology (its band rdfs:label). HRAS (hgnc/5173) maps to
+      band 11p15.5 — i.e. chromosome 11, short arm, distal band.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo:  <http://purl.obolibrary.org/obo/>
+
+      SELECT ?gene ?cytoband
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/hgnc> {
+          ?gene rdfs:label "HRAS" ; obo:so_part_of ?cytoband .
+        }
+      }
+    result_count: 1   # HRAS = hgnc/5173, cytoband "11p15.5"
+
+  - query_number: 2
+    database: hco
+    description: >-
+      Read the GRCh38 genomic span and the Giemsa stain of band 11p15.5 from the
+      human cytoband ontology. Navigate from the band class (matched by its ISCN
+      rdfs:label) to its GRCh38 instance and read the FALDO begin/end positions and
+      the hco:bandtype label. Band 11p15.5 is Giemsa-negative (gneg, a pale band),
+      spanning GRCh38 1–2,800,000 (~2.8 Mb, the distal tip of 11p).
+    query: |
+      PREFIX hco:   <http://identifiers.org/hco/>
+      PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+      PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?begin ?end ?stain
+      FROM <http://rdfportal.org/dataset/hco>
+      WHERE {
+        ?band rdfs:subClassOf hco:Cytoband ; rdfs:label "11p15.5" .
+        ?inst a ?band ; hco:build hco:GRCh38 ; hco:bandtype ?bt ; faldo:location ?loc .
+        ?bt rdfs:label ?stain .
+        ?loc faldo:begin/faldo:position ?begin ; faldo:end/faldo:position ?end .
+      }
+    result_count: 1   # begin 1, end 2,800,000, stain "gneg"
+
+  - query_number: 3
+    database: oma
+    description: >-
+      Locate the human HRAS protein in the orthology resource and its species-level
+      HOG cluster. The human OMA protein carrying the UniProt cross-reference P01112
+      is HUMAN03619; the single OrthologsCluster it is a direct member of is
+      HOG:E0792948.6w.50b.72a_9606 (taxonomic range 9606, human). Stripping the
+      _9606 species suffix yields the orthology (speciation) node .6w.50b.72a shared
+      with the mouse descendant.
+    query: |
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX lscr: <http://purl.org/lscr#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+
+      SELECT DISTINCT ?humanProt ?omaId ?cluster ?taxrange
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/oma> {
+          ?humanProt a orth:Protein ;
+                     lscr:xrefUniprot <http://purl.uniprot.org/uniprot/P01112> ;
+                     dct:identifier ?omaId .
+          FILTER(STRSTARTS(?omaId, "HUMAN"))
+          ?cluster a orth:OrthologsCluster ;
+                   orth:hasHomologousMember ?humanProt ;
+                   orth:hasTaxonomicRange ?taxrange .
+        }
+      }
+    result_count: 1   # HUMAN03619, cluster HOG:E0792948.6w.50b.72a_9606, taxrange taxonomy/9606
+
+  - query_number: 4
+    database: oma
+    description: >-
+      Retrieve the mouse ortholog by descending from the orthology node .6w.50b.72a
+      to its mouse (taxon 10090) leaf cluster. Exactly one mouse OrthologsCluster
+      identifier begins with "HOG:E0792948.6w.50b.72a" — HOG:E0792948.6w.50b.72a.53a_10090
+      — and its protein member is MOUSE57051, the 1:1 mouse ortholog. The RAS-family
+      paralogs KRAS/NRAS fall under sibling nodes (.72b, .6c, …) and are correctly
+      excluded by the shared-prefix filter. (Property paths over the 33M-cluster
+      hierarchy time out, so navigation is done by the HOG identifier prefix.)
+    query: |
+      PREFIX orth: <http://purl.org/net/orth#>
+      PREFIX dct:  <http://purl.org/dc/terms/>
+
+      SELECT DISTINCT ?cid ?mouseProt ?mid
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/oma> {
+          ?mouseCluster a orth:OrthologsCluster ;
+                        orth:hasTaxonomicRange <http://purl.uniprot.org/taxonomy/10090> ;
+                        dct:identifier ?cid ;
+                        orth:hasHomologousMember ?mouseProt .
+          FILTER(STRSTARTS(?cid, "HOG:E0792948.6w.50b.72a"))
+          ?mouseProt a orth:Protein ;
+                     dct:identifier ?mid .
+          FILTER(STRSTARTS(?mid, "MOUSE"))
+        }
+      }
+    result_count: 1   # cluster HOG:E0792948.6w.50b.72a.53a_10090, protein MOUSE57051
+
+  - query_number: 5
+    database: oma
+    description: >-
+      Confirm the identity of the mouse ortholog MOUSE57051 through its
+      cross-references. It carries UniProt xref Q61411 (mnemonic RASH_MOUSE) and an
+      rdfs:comment sourced from MGI ("Harvey rat sarcoma virus oncogene [Source:MGI
+      Symbol;Acc:MGI:96224]"), establishing MOUSE57051 as mouse Hras.
+    query: |
+      PREFIX lscr: <http://purl.org/lscr#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?uniprot ?comment
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/oma> {
+          OPTIONAL { <https://omabrowser.org/oma/info/MOUSE57051> lscr:xrefUniprot ?uniprot }
+          OPTIONAL { <https://omabrowser.org/oma/info/MOUSE57051> rdfs:comment ?comment }
+        }
+      }
+    result_count: 4   # UniProt xrefs A0A0G2JGM2, B2KGV5, Q61411, RASH_MOUSE; comment names MGI:96224 (mouse Hras)
+
+  - query_number: 6
+    database: ensembl
+    description: >-
+      Place mouse Hras on a chromosome of the current mouse reference assembly.
+      Filtering Mus musculus protein-coding genes (biotype ENSGLOSSARY_0000026) by
+      the gene symbol "Hras" and reading its so:part_of chromosome IRI gives Ensembl
+      gene ENSMUSG00000025499 on GRCm39 chromosome 7 (chromosome name taken from the
+      "/GRCm39/" segment of the IRI, version-independent).
+    query: |
+      PREFIX terms: <http://rdf.ebi.ac.uk/terms/ensembl/>
+      PREFIX so:    <http://purl.obolibrary.org/obo/so#>
+      PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?gene ?label (STRAFTER(STR(?chr), "/GRCm39/") AS ?name)
+      FROM <http://rdfportal.org/dataset/ensembl>
+      WHERE {
+        ?gene a terms:EnsemblGene ;
+              <http://purl.obolibrary.org/obo/RO_0002162> <http://ensembl.org/Mus_musculus> ;
+              terms:has_biotype <http://ensembl.org/glossary/ENSGLOSSARY_0000026> ;
+              rdfs:label ?label ;
+              so:part_of ?chr .
+        FILTER(?label = "Hras")
+        FILTER(CONTAINS(STR(?chr), "/mus_musculus/GRCm39/"))
+      }
+    result_count: 1   # ENSMUSG00000025499, label "Hras", chromosome name "7"
+
+  - query_number: 7
+    database: mco
+    description: >-
+      Read the assembled length of mouse chromosome 7 on GRCm39 from the mouse
+      chromosome reference. Navigate from the chromosome class mco:7 to its GRCm39
+      instance and read mco:length and mco:refseq (identified by IRI, since the MCO
+      rdfs:label is a known broken constant). Chromosome 7 is 144,995,196 bp
+      (~145.0 Mb) with RefSeq accession NC_000073.7.
+    query: |
+      PREFIX mco:  <http://identifiers.org/mco/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT (STRAFTER(STR(?chr), "http://identifiers.org/mco/") AS ?name) ?length ?refseq
+      FROM <http://rdfportal.org/dataset/mco>
+      WHERE {
+        ?inst a ?chr ;
+              mco:build mco:GRCm39 ;
+              mco:length ?length ;
+              mco:refseq ?refseq .
+        ?chr rdfs:subClassOf mco:MouseChromosome .
+        FILTER(?chr = mco:7)
+      }
+    result_count: 1   # chromosome 7, length 144,995,196 bp, refseq NC_000073.7
+
+rdf_triples: |
+  @prefix hco:   <http://identifiers.org/hco/> .
+  @prefix mco:   <http://identifiers.org/mco/> .
+  @prefix ensg:  <http://rdf.ebi.ac.uk/resource/ensembl/> .
+  @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+  @prefix ex:    <http://example.org/hras-cross-species-synteny#> .
+
+  ex:analysis ex:humanGene "HRAS" ; ex:mouseOrtholog "Hras" ; ex:theme "cross-species chromosomal synteny of an orthologous gene pair" .
+  # Database: hgnc | Query: 1 | Comment: Scope — the orthologous HRAS gene pair (human HRAS and its mouse ortholog), summarised across human and mouse reference assemblies
+
+  ex:HRAS_human ex:hgncId "hgnc/5173" ; ex:hgncSymbol "HRAS" ; ex:cytoband "11p15.5" .
+  # Database: hgnc | Query: 1 | Comment: HGNC gene HRAS (hgnc/5173) records obo:so_part_of "11p15.5" — the ISCN cytoband string that joins to the human cytoband ontology's band label
+
+  hco:11p15.5 ex:giemsaStain "gneg" ; ex:grch38Begin "1"^^xsd:integer ; ex:grch38End "2800000"^^xsd:integer .
+  # Database: hco | Query: 2 | Comment: HCO band 11p15.5 on GRCh38 is Giemsa-negative (gneg, a pale band), spanning ~1–2,800,000 (~2.8 Mb) at the distal tip of chromosome 11p
+
+  ex:HRAS_human ex:humanChromosome "11" .
+  # Database: hco | Query: 2 | Comment: The human gene sits on chromosome 11 (ISCN band prefix "11p") — the human member of the ortholog pair
+
+  ex:HRAS_human ex:omaProtein "HUMAN03619" ; ex:uniprot "P01112" ; ex:omaCluster "HOG:E0792948.6w.50b.72a_9606" .
+  # Database: oma | Query: 3 | Comment: The human OMA protein for HRAS (UniProt P01112) is HUMAN03619, direct member of species-level cluster HOG:E0792948.6w.50b.72a_9606 (taxon 9606)
+
+  ex:orthologyNode ex:hogFamily "HOG:E0792948" ; ex:speciationNode "HOG:E0792948.6w.50b.72a" .
+  # Database: oma | Query: 3 | Comment: Stripping the _9606 species suffix gives the orthology (speciation) node .6w.50b.72a shared by the human and mouse descendants — the node that defines the orthology
+
+  ex:Hras_mouse ex:omaProtein "MOUSE57051" ; ex:omaCluster "HOG:E0792948.6w.50b.72a.53a_10090" .
+  # Database: oma | Query: 4 | Comment: Exactly one mouse (taxon 10090) cluster descends from node .6w.50b.72a — MOUSE57051 — the 1:1 mouse ortholog; RAS paralogs KRAS/NRAS lie under sibling nodes and are excluded
+
+  ex:Hras_mouse ex:uniprot "Q61411" ; ex:uniprotMnemonic "RASH_MOUSE" ; ex:mgi "MGI:96224" ; ex:label "Harvey rat sarcoma virus oncogene" .
+  # Database: oma | Query: 5 | Comment: MOUSE57051 confirmed as mouse Hras via lscr:xrefUniprot Q61411 (RASH_MOUSE) and the MGI:96224 source annotation on rdfs:comment
+
+  ensg:ENSMUSG00000025499 ex:label "Hras" ; ex:mouseChromosome "7" .
+  # Database: ensembl | Query: 6 | Comment: Mouse Hras (Ensembl gene ENSMUSG00000025499, protein_coding) is placed via so:part_of on GRCm39 chromosome 7
+
+  mco:7/GRCm39 mco:build mco:GRCm39 ; mco:length "144995196"^^xsd:integer ; ex:refseq "NC_000073.7" .
+  # Database: mco | Query: 7 | Comment: Mouse chromosome 7 assembled length on GRCm39 is 144,995,196 bp (~145.0 Mb; RefSeq NC_000073.7) — the mouse ortholog resides here, on chromosome 7, not 11
+
+  ex:conclusion ex:humanChr "11" ; ex:mouseChr "7" ; ex:insight "orthologs on differently-numbered chromosomes: the human 11p15 ↔ mouse chromosome 7 conserved-synteny block" .
+  # Database: oma | Query: 4 | Comment: Synthesis — the orthologous pair occupies human chromosome 11 (11p15.5) versus mouse chromosome 7; orthology is defined by common ancestry (the shared HOG speciation node), not by chromosome number, and 11p15↔mouse-chr7 is a classic conserved-synteny block
+
+exact_answer: ""
+
+ideal_answer: >-
+  The orthologous HRAS gene pair is a compact illustration of conserved synteny across
+  rearranged genomes. In human, HRAS (HGNC 5173) lies in cytogenetic band 11p15.5 — the
+  distal tip of the short arm of chromosome 11 — a Giemsa-negative (gneg, pale-staining)
+  band occupying roughly the first 2.8 Mb of the chromosome (GRCh38 positions 1–2,800,000).
+  Its mouse ortholog, identified in the phylogenomic orthology hierarchy as OMA protein
+  MOUSE57051 and confirmed by its cross-references to be mouse Hras (UniProt Q61411 /
+  RASH_MOUSE, MGI:96224), descends from the same HOG speciation node (HOG:E0792948.6w.50b.72a)
+  as the human protein HUMAN03619, so the two are true 1:1 orthologs rather than paralogs of
+  the wider RAS family. In the current mouse reference assembly this ortholog (Ensembl gene
+  ENSMUSG00000025499) sits not on a chromosome numbered 11 but on mouse chromosome 7, whose
+  assembled length on GRCm39 is 144,995,196 bp (about 145.0 Mb; RefSeq NC_000073.7). The pair
+  therefore occupies human chromosome 11 versus mouse chromosome 7 — different chromosome
+  numbers for the very same ancestral gene — which is exactly what conserved synteny predicts:
+  orthology is defined by shared ancestry, not by chromosome identity, and human 11p15 maps to
+  a well-characterised syntenic block on mouse chromosome 7. Reading this summary requires
+  joining four disjoint resources — a human cytoband ontology (band and Giemsa stain), an
+  orthology resource (the ortholog assignment), a genome annotation (the mouse chromosome
+  placement) and a mouse-chromosome reference (the GRCm39 length) — none of which carries the
+  integrated picture on its own.
+
+question_template_used: "Summary cross-species chromosomal synteny of an orthologous gene pair (human cytoband + Giemsa stain from a cytogenetic ontology; ortholog identity from an orthology HOG hierarchy; mouse chromosome from genome annotation; mouse chromosome length from a chromosome reference) synthesised into one narrative"
+
+time_spent:
+  exploration: 34 minutes
+  formulation: 12 minutes
+  verification: 10 minutes
+  pubmed_test: 8 minutes
+  extraction: 14 minutes
+  documentation: 20 minutes
+  total: 98 minutes

--- a/benchmark/questions/question_082.yaml
+++ b/benchmark/questions/question_082.yaml
@@ -1,0 +1,224 @@
+---
+id: question_082
+type: factoid
+body: >-
+  The mouse gene Tas2r117 encodes bitter taste receptor type 2 member 117, a
+  G-protein-coupled receptor. Considering the collection of inbred and
+  wild-derived laboratory mouse strains whose genomes have been sequenced and
+  called against the C57BL/6J reference (assembly GRCm39), how many distinct
+  single-nucleotide variants that fall within this gene are predicted by the
+  Variant Effect Predictor (VEP) to cause a missense amino-acid substitution in
+  the encoded protein?
+
+inspiration_keyword:
+  keyword_id: KW-0919
+  name: Taste
+  category: Biological process
+
+togomcp_databases_used:
+  - uniprot
+  - ensembl
+  - mogplus
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: >-
+    Two searches aimed at answering the question directly: (1) "Tas2r117 mouse"
+    to find any strain-variation study of this receptor; (2) "Tas2r bitter taste
+    receptor missense variation inbred mouse strains" to find a cross-strain
+    coding-variation count for the mouse Tas2r family. Abstracts of the returned
+    records were read.
+  result: |
+    Search (1) returned a single article (PMID 26071358), which reports only that
+    Tas2r117 transcript is absent from small-intestine cDNA - it says nothing
+    about strain-level sequence variation or missense counts. Search (2) returned
+    0 articles. No publication reports how many missense single-nucleotide
+    variants lie within Tas2r117 across the sequenced mouse strain panel; that
+    figure is a computed aggregate over the live variant callset with per-variant
+    VEP consequence annotations and cannot be obtained from the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# Gene resolved via UniProt keyword KW-0919 (Taste) -> mouse reviewed protein
+#   Q7M715 (Tas2r117) -> Ensembl gene ENSMUSG00000058349 (togoid uniprot->ensembl_gene;
+#   confirmed by Ensembl rdfs:seeAlso Q7M715).
+# Consequence term is a single Sequence Ontology IRI, obo:SO_0001583 (missense_variant),
+#   used directly (VEP vep:consequence field) - no getDescendants expansion needed
+#   (missense_variant has no consequence-relevant sub-terms used by VEP here).
+# Graph scope: all MoG+ queries pinned to GRAPH <http://rdfportal.org/dataset/mogplus>
+#   with COUNT(DISTINCT ?variant); the SO label is read from the co-located graph
+#   <http://rdfportal.org/ontology/so> on the same endpoint. No union / cross-graph
+#   inflation is possible (Hard Rule 4 satisfied by explicit graph pinning).
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Establish that Tas2r117 is a taste receptor: the reviewed mouse (taxon
+      10090) protein Q7M715 has gene name Tas2r117 and is classified with keyword
+      KW-0919 (Taste). This links the gene to the inspiration keyword.
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+      PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?protein ?gene ?kwLabel WHERE {
+        ?protein up:reviewed true ;
+                 up:organism taxon:10090 ;
+                 up:classifiedWith keywords:919 ;
+                 up:encodedBy/skos:prefLabel ?gene .
+        keywords:919 skos:prefLabel ?kwLabel .
+        FILTER(?gene = "Tas2r117")
+      }
+    result_count: 1
+
+  - query_number: 2
+    database: ensembl
+    description: >-
+      Confirm the gene identity and location: ENSMUSG00000058349 is Tas2r117
+      (taste receptor, type 2, member 117), Mus musculus, on chromosome 6 of the
+      GRCm39 assembly, and cross-references UniProt Q7M715 (rdfs:seeAlso) - tying
+      the taste-receptor annotation to the Ensembl gene the variants overlap.
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX soterm: <http://purl.obolibrary.org/obo/so#>
+      SELECT DISTINCT ?label ?desc ?chr ?up WHERE {
+        <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000058349>
+            a <http://rdf.ebi.ac.uk/terms/ensembl/EnsemblGene> ;
+            rdfs:label ?label ;
+            obo:RO_0002162 <http://ensembl.org/Mus_musculus> ;
+            dcterms:description ?desc ;
+            soterm:part_of ?chr ;
+            rdfs:seeAlso ?up .
+        FILTER(STRSTARTS(STR(?up), "http://purl.uniprot.org/uniprot/"))
+        FILTER(CONTAINS(STR(?chr), "GRCm39/"))
+      }
+    result_count: 1
+
+  - query_number: 3
+    database: mogplus
+    description: >-
+      The answer set: distinct single-nucleotide variants overlapping Tas2r117
+      (ENSMUSG00000058349) whose Ensembl VEP consequence on this gene is
+      missense_variant (obo:SO_0001583, label read from the co-located Sequence
+      Ontology graph). The vep:gene guard ensures the missense call is on
+      Tas2r117 itself. Returns 18 variants (protein positions 22-227, chr6). No
+      release filter is applied because VEP annotations for this gene exist only
+      under release v3; v2.1 variants overlapping the gene carry no VEP/SnpEff
+      annotation, so the resource-wide VEP-missense set is exactly these 18.
+    query: |
+      PREFIX gvo: <http://genome-variation.org/resource#>
+      PREFIX vep: <http://genome-variation.org/resource/vep#>
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      PREFIX ensg: <http://rdf.ebi.ac.uk/resource/ensembl/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT DISTINCT ?variant ?pos ?ref ?alt ?aa ?soLabel WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          ?variant mogplus:overlaps_gene ensg:ENSMUSG00000058349 ;
+                   a gvo:SNV ;
+                   gvo:pos ?pos ; gvo:ref ?ref ; gvo:alt ?alt ;
+                   vep:has_consequence ?ann .
+          ?ann vep:gene ensg:ENSMUSG00000058349 ;
+               vep:consequence obo:SO_0001583 ;
+               vep:amino_acids ?aa .
+        }
+        GRAPH <http://rdfportal.org/ontology/so> {
+          obo:SO_0001583 rdfs:label ?soLabel .
+        }
+      }
+      ORDER BY ?pos
+    result_count: 18
+
+  - query_number: 4
+    database: mogplus
+    description: >-
+      Arithmetic-verification query (Rule 3) for query 3. Breaks the VEP
+      consequence annotations on Tas2r117 (vep:gene guard) down by consequence
+      label, counting DISTINCT variants per class: missense_variant 18,
+      synonymous_variant 8, 5_prime_UTR_variant 1. The three classes are disjoint
+      at the variant level and sum to 27, which equals the total distinct
+      variants VEP annotates on this gene (COUNT(DISTINCT ?variant) over the same
+      guard = 27) - confirming 18 is the exact missense subset with no
+      double-counting. VEP and SnpEff agree closely here (SnpEff labels 17 of the
+      18 as missense; the answer is defined by VEP).
+    query: |
+      PREFIX vep: <http://genome-variation.org/resource/vep#>
+      PREFIX mogplus: <http://identifiers.org/mogplus/ontology#>
+      PREFIX ensg: <http://rdf.ebi.ac.uk/resource/ensembl/>
+      SELECT ?csqLabel (COUNT(DISTINCT ?variant) AS ?n) WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          ?variant mogplus:overlaps_gene ensg:ENSMUSG00000058349 ;
+                   vep:has_consequence ?ann .
+          ?ann vep:gene ensg:ENSMUSG00000058349 ;
+               vep:consequence_label ?csqLabel .
+        }
+      }
+      GROUP BY ?csqLabel
+      ORDER BY DESC(?n)
+    result_count: 3
+
+rdf_triples: |
+  @prefix up: <http://purl.uniprot.org/core/> .
+  @prefix keywords: <http://purl.uniprot.org/keywords/> .
+  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix dcterms: <http://purl.org/dc/terms/> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix soterm: <http://purl.obolibrary.org/obo/so#> .
+  @prefix ensg: <http://rdf.ebi.ac.uk/resource/ensembl/> .
+  @prefix uniprot: <http://purl.uniprot.org/uniprot/> .
+  @prefix gvo: <http://genome-variation.org/resource#> .
+  @prefix vep: <http://genome-variation.org/resource/vep#> .
+  @prefix mogplus: <http://identifiers.org/mogplus/ontology#> .
+
+  uniprot:Q7M715 up:classifiedWith keywords:919 .
+  # Database: UniProt | Query: 1 | Comment: reviewed mouse protein Q7M715 (gene Tas2r117) is classified with keyword KW-0919
+  keywords:919 skos:prefLabel "Taste" .
+  # Database: UniProt | Query: 1 | Comment: KW-0919 is the Taste keyword, so Tas2r117 is a taste receptor
+  ensg:ENSMUSG00000058349 rdfs:label "Tas2r117" .
+  # Database: Ensembl | Query: 2 | Comment: the Ensembl mouse gene the variants overlap is Tas2r117
+  ensg:ENSMUSG00000058349 dcterms:description "taste receptor, type 2, member 117 [Source:MGI Symbol;Acc:MGI:2681242]" .
+  # Database: Ensembl | Query: 2 | Comment: Tas2r117 encodes bitter taste receptor type 2 member 117
+  ensg:ENSMUSG00000058349 soterm:part_of <http://rdf.ebi.ac.uk/resource/ensembl/115/mus_musculus/GRCm39/6> .
+  # Database: Ensembl | Query: 2 | Comment: the gene lies on mouse chromosome 6 of the GRCm39 assembly
+  ensg:ENSMUSG00000058349 rdfs:seeAlso uniprot:Q7M715 .
+  # Database: Ensembl | Query: 2 | Comment: the Ensembl gene cross-references UniProt Q7M715, tying the taste-receptor keyword to the gene
+  <http://identifiers.org/mogplus/v3/6/GRCm39#132780213-A-G> a gvo:SNV .
+  # Database: MoG+ | Query: 3 | Comment: one of the 18 missense loci - a single-nucleotide A>G substitution at chr6:132,780,213 (GRCm39)
+  <http://identifiers.org/mogplus/v3/6/GRCm39#132780213-A-G> mogplus:overlaps_gene ensg:ENSMUSG00000058349 .
+  # Database: MoG+ | Query: 3 | Comment: the variant's coordinate falls within the Tas2r117 gene
+  <http://identifiers.org/mogplus/v3/6/GRCm39#132780213-A-G> vep:has_consequence _:ann1 .
+  # Database: MoG+ | Query: 3 | Comment: the variant carries an Ensembl VEP consequence annotation on Tas2r117
+  _:ann1 vep:consequence obo:SO_0001583 .
+  # Database: MoG+ | Query: 3 | Comment: VEP predicts a missense_variant consequence (SO:0001583) for this variant on Tas2r117
+  _:ann1 vep:amino_acids "K/R" .
+  # Database: MoG+ | Query: 3 | Comment: the substitution changes lysine to arginine at protein position 117 (one representative of the 18)
+  obo:SO_0001583 rdfs:label "missense_variant" .
+  # Database: Sequence Ontology | Query: 3 | Comment: SO:0001583 (co-located SO graph) is the missense_variant term the VEP annotations reference
+
+exact_answer: "18"
+
+ideal_answer: |
+  Eighteen distinct single-nucleotide variants that fall within the mouse gene Tas2r117 (bitter taste receptor type 2 member 117; Ensembl ENSMUSG00000058349, chromosome 6 of GRCm39, UniProt Q7M715) are predicted by Ensembl's Variant Effect Predictor to cause a missense amino-acid substitution in the encoded receptor. They span protein positions 22 to 227 across the receptor's coding sequence (chr6:132,779,927-132,780,543) and include substitutions such as Val22Met, Leu66His, Thr80Pro, Ile149Thr and Arg227Lys, reflecting the extensive coding diversity typical of the rapidly evolving Tas2r bitter-receptor family. These missense variants are the coding subset of the variation VEP annotates on the gene: alongside them VEP records 8 synonymous and 1 five-prime UTR variant, for 27 annotated variants in total (18 + 8 + 1 = 27), so the missense figure is exact and non-overlapping. All 18 are single-nucleotide substitutions carried by wild-derived mouse strains (for example MSM/Ms, JF1/Ms, KJR and SWN/Ms) that diverge from the C57BL/6J reference, which defines the reference allele and is not itself among the genotyped strains; SnpEff independently classifies 17 of the 18 as missense, corroborating the VEP-based count.
+
+question_template_used: factoid_count_missense_SNVs_within_a_gene_consequence_typed
+
+time_spent:
+  exploration: 45
+  formulation: 12
+  verification: 12
+  pubmed_test: 12
+  extraction: 10
+  documentation: 16
+  total: 107

--- a/benchmark/questions/question_083.yaml
+++ b/benchmark/questions/question_083.yaml
@@ -1,0 +1,190 @@
+---
+id: question_083
+type: yes_no
+body: >-
+  In a comprehensive reference collection of standardized microbial
+  culture-media recipes, is a nickel salt (such as nickel chloride or nickel
+  sulfate) included as an ingredient in a greater number of distinct media than
+  an inorganic cobalt salt (such as cobalt chloride, cobalt sulfate, or cobalt
+  nitrate — excluding organic cobalt-containing compounds such as vitamin B12)?
+
+inspiration_keyword:
+  keyword_id: KW-0533
+  name: Nickel
+  category: Ligand
+
+togomcp_databases_used:
+  - mediadive
+  - chebi
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 10 minutes
+  method: >-
+    Two searches aimed at answering the comparison directly: (1) "nickel cobalt
+    trace element culture media recipe prevalence microbial cultivation"; (2)
+    "DSMZ growth media nickel versus cobalt supplementation frequency
+    comparison". Result sets inspected.
+  result: |
+    Both queries returned 0 articles. No publication reports how many
+    standardized culture-media recipes include a nickel salt versus a cobalt
+    salt, or compares the prevalence of these two trace metals across a
+    media-recipe collection. The answer is an aggregate over the live media
+    database (distinct media carrying a nickel-salt ingredient vs. a cobalt-salt
+    ingredient, with salt identity resolved through chemical cross-references)
+    and cannot be obtained from the literature.
+  conclusion: PASS (cannot answer from literature - requires RDF)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# "Nickel salt" and "cobalt salt" resolved to concrete ingredient sets via the ChEBI
+# cross-reference on each media ingredient (schema:hasChEBI), NOT free-text label matching:
+#   Nickel salts  -> ChEBI 34887 (nickel dichloride), 53001 (nickel sulfate),
+#                    86149 (ammonium nickel sulfate hexahydrate)  = 9 ingredient records
+#   Cobalt salts  -> ChEBI 35696 (cobalt dichloride), 53470 (cobalt(2+) sulfate),
+#                    86209/86214 (cobalt dinitrate / hexahydrate) = 8 ingredient records
+# Completeness (Rule 2 - no sampling): an exhaustive label sweep (CONTAINS "Ni"/"nickel",
+# "Co"/"cobalt" over all 1,489 ingredients) surfaced NO nickel/cobalt inorganic-salt
+# ingredient lacking a ChEBI annotation, so the ChEBI-keyed sets are complete. Organic
+# cobalt (cobalamin/vitamin B12, ChEBI 30411; Co-carboxylase) is deliberately excluded.
+# GRAPH-SCOPING (Rule 4): the media endpoint co-hosts ~40 datasets; every media query is
+# pinned to FROM <http://rdfportal.org/dataset/mediadive> and uses COUNT(DISTINCT ?medium),
+# so no cross-graph union inflation is possible.
+
+sparql_queries:
+  - query_number: 1
+    database: chebi
+    description: >-
+      Ground the salt definitions: confirm each ChEBI identifier used to select
+      the media ingredients is an inorganic nickel or cobalt salt. Returns 7
+      compounds - nickel dichloride (34887), nickel sulfate (53001), ammonium
+      nickel sulfate hexahydrate (86149); cobalt dichloride (35696), cobalt(2+)
+      sulfate (53470), cobalt dinitrate (86209) and its hexahydrate (86214).
+    query: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      SELECT DISTINCT ?chebi ?label WHERE {
+        VALUES ?chebi { obo:CHEBI_34887 obo:CHEBI_53001 obo:CHEBI_86149
+                        obo:CHEBI_35696 obo:CHEBI_53470 obo:CHEBI_86209 obo:CHEBI_86214 }
+        ?chebi rdfs:label ?label .
+      }
+    result_count: 7
+
+  - query_number: 2
+    database: mediadive
+    description: >-
+      Count the DISTINCT culture media whose flat medium composition includes a
+      nickel-salt ingredient (any ingredient cross-referenced to ChEBI 34887,
+      53001, or 86149). Graph-scoped to the media dataset; COUNT(DISTINCT ?medium).
+      Returns 1206.
+    query: |
+      PREFIX schema: <https://purl.dsmz.de/schema/>
+      SELECT (COUNT(DISTINCT ?medium) AS ?nickel_media)
+      FROM <http://rdfportal.org/dataset/mediadive>
+      WHERE {
+        ?ing a schema:Ingredient ; schema:hasChEBI ?chebi .
+        FILTER(?chebi IN (34887, 53001, 86149))
+        ?comp a schema:MediumComposition ;
+              schema:containsIngredient ?ing ;
+              schema:partOfMedium ?medium .
+      }
+    result_count: 1206
+
+  - query_number: 3
+    database: mediadive
+    description: >-
+      Count the DISTINCT culture media whose flat medium composition includes an
+      inorganic cobalt-salt ingredient (ChEBI 35696, 53470, 86209, or 86214).
+      Same graph scope and COUNT(DISTINCT ?medium) pattern as query 2. Returns
+      1509 - MORE than the 1206 media with a nickel salt, so the answer is NO.
+    query: |
+      PREFIX schema: <https://purl.dsmz.de/schema/>
+      SELECT (COUNT(DISTINCT ?medium) AS ?cobalt_media)
+      FROM <http://rdfportal.org/dataset/mediadive>
+      WHERE {
+        ?ing a schema:Ingredient ; schema:hasChEBI ?chebi .
+        FILTER(?chebi IN (35696, 53470, 86209, 86214))
+        ?comp a schema:MediumComposition ;
+              schema:containsIngredient ?ing ;
+              schema:partOfMedium ?medium .
+      }
+    result_count: 1509
+
+  - query_number: 4
+    database: mediadive
+    description: >-
+      Completeness / no-sampling evidence: enumerate every nickel-salt and
+      cobalt-salt ingredient (by ChEBI) with the number of media each appears in.
+      Returns 17 ingredient records - 9 nickel (NiCl2 in 5 hydration states,
+      NiSO4 x2, ammonium nickel sulfate x2) and 8 cobalt (CoCl2 x4, CoSO4 x2,
+      Co(NO3)2 x2). The dominant sources are NiCl2 x 6 H2O (1117 media) and
+      CoCl2 x 6 H2O (1018 media); per-ingredient counts exceed the distinct-media
+      totals because a few media list two hydration variants.
+    query: |
+      PREFIX schema: <https://purl.dsmz.de/schema/>
+      SELECT ?element ?label ?chebi (COUNT(DISTINCT ?medium) AS ?n_media)
+      FROM <http://rdfportal.org/dataset/mediadive>
+      WHERE {
+        ?ing a schema:Ingredient ; rdfs:label ?label ; schema:hasChEBI ?chebi .
+        FILTER(?chebi IN (34887, 53001, 86149, 35696, 53470, 86209, 86214))
+        BIND(IF(?chebi IN (34887,53001,86149), "Nickel", "Cobalt") AS ?element)
+        OPTIONAL {
+          ?comp a schema:MediumComposition ;
+                schema:containsIngredient ?ing ;
+                schema:partOfMedium ?medium .
+        }
+      }
+      GROUP BY ?element ?label ?chebi
+      ORDER BY ?element DESC(?n_media)
+    result_count: 17
+
+rdf_triples: |
+  @prefix schema: <https://purl.dsmz.de/schema/> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix obo: <http://purl.obolibrary.org/obo/> .
+  @prefix mding: <https://purl.dsmz.de/mediadive/ingredient/> .
+
+  mding:40 a schema:Ingredient .
+  # Database: MediaDive | Query: 4 | Comment: ingredient/40 is NiCl2 x 6 H2O, the most-used nickel source (in 1117 media)
+  mding:40 rdfs:label "NiCl2 x 6 H2O" .
+  # Database: MediaDive | Query: 4 | Comment: label of the dominant nickel-salt ingredient
+  mding:40 schema:hasChEBI 34887 .
+  # Database: MediaDive | Query: 4 | Comment: the ingredient cross-references ChEBI 34887, identifying it as a nickel compound
+  obo:CHEBI_34887 rdfs:label "nickel dichloride" .
+  # Database: ChEBI | Query: 1 | Comment: ChEBI 34887 is nickel dichloride, confirming ingredient/40 is a nickel salt
+  mding:38 a schema:Ingredient .
+  # Database: MediaDive | Query: 4 | Comment: ingredient/38 is CoCl2 x 6 H2O, the most-used cobalt source (in 1018 media)
+  mding:38 schema:hasChEBI 35696 .
+  # Database: MediaDive | Query: 4 | Comment: the ingredient cross-references ChEBI 35696, identifying it as a cobalt compound
+  obo:CHEBI_35696 rdfs:label "cobalt dichloride" .
+  # Database: ChEBI | Query: 1 | Comment: ChEBI 35696 is cobalt dichloride, confirming ingredient/38 is an inorganic cobalt salt
+  _:compNi a schema:MediumComposition .
+  # Database: MediaDive | Query: 2 | Comment: a medium-composition record carrying a nickel-salt ingredient
+  _:compNi schema:containsIngredient mding:40 .
+  # Database: MediaDive | Query: 2 | Comment: nickel salts occur in 1206 distinct media in total
+  _:compCo a schema:MediumComposition .
+  # Database: MediaDive | Query: 3 | Comment: a medium-composition record carrying a cobalt-salt ingredient
+  _:compCo schema:containsIngredient mding:38 .
+  # Database: MediaDive | Query: 3 | Comment: inorganic cobalt salts occur in 1509 distinct media - more than the 1206 with a nickel salt, so the answer is NO
+
+exact_answer: "no"
+
+ideal_answer: |
+  No. Across the standardized culture-media recipes, an inorganic cobalt salt is included as an ingredient in more distinct media than a nickel salt. A nickel salt - nickel chloride (ChEBI 34887, chiefly NiCl2 x 6 H2O, in 1117 media), nickel sulfate (ChEBI 53001), or ammonium nickel sulfate (ChEBI 86149) - appears in 1206 distinct media in total. An inorganic cobalt salt - cobalt chloride (ChEBI 35696, chiefly CoCl2 x 6 H2O, in 1018 media), cobalt sulfate (ChEBI 53470), or cobalt nitrate (ChEBI 86209/86214) - appears in 1509 distinct media, about 300 (roughly 25%) more than nickel. Both metals are staple constituents of the trace-element solutions used to formulate anaerobe and defined media, but cobalt is supplemented slightly more universally, consistent with the near-ubiquitous requirement for cobalamin (vitamin B12) biosynthesis, whereas nickel is required by a somewhat narrower set of enzymes (hydrogenases, ureases, carbon-monoxide dehydrogenase, and the methanogenic cofactor F430). Organic cobalt sources such as cobalamin itself are excluded from this count, which considers only inorganic cobalt salts.
+
+question_template_used: yes_no_compare_ingredient_prevalence_two_compound_classes_across_media
+
+time_spent:
+  exploration: 40
+  formulation: 10
+  verification: 10
+  pubmed_test: 10
+  extraction: 10
+  documentation: 15
+  total: 95

--- a/benchmark/questions/question_084.yaml
+++ b/benchmark/questions/question_084.yaml
@@ -1,0 +1,216 @@
+id: question_084
+type: choice
+body: "Intrahepatic cholestasis - impaired formation and flow of bile within the liver - is caused by germline defects in a curated set of human genes, spanning the canonical bile-transport pumps as well as regulatory, structural, and intracellular-trafficking genes. In a comprehensive GRCh38 catalogue of human genome variation annotated with per-transcript functional-consequence predictions, these disease genes differ greatly in how many missense single-nucleotide variants they carry. Among the following four genes, which one harbours the greatest number of distinct missense variants in that catalogue?"
+
+choices:
+  - "MYO5B (unconventional myosin-Vb)"
+  - "ABCB11 (bile salt export pump)"
+  - "ATP8B1 (phospholipid-transporting ATPase IC)"
+  - "ABCB4 (phosphatidylcholine translocator)"
+
+inspiration_keyword:
+  keyword_id: KW-0988
+  name: Intrahepatic cholestasis
+  category: Disease
+
+togomcp_databases_used:
+  - uniprot
+  - hgnc
+  - togovar
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: |
+    Tried to answer the specific question - which intrahepatic-cholestasis gene carries the most
+    missense variants in a genome-wide human variation catalogue - directly from the literature:
+    (1) "TogoVar intrahepatic cholestasis missense variant burden gene comparison"
+    (2) "progressive familial intrahepatic cholestasis MYO5B TJP2 ABCB11 missense variant count
+        Japanese population database"
+    (3) "intrahepatic cholestasis genes germline missense variant frequency spectrum population"
+  result: |
+    All three queries returned zero articles. The individual cholestasis genes (ABCB11, ABCB4,
+    ATP8B1, MYO5B, TJP2, ...) are each well described in the disease literature, and gene-specific
+    variant catalogues exist, but no publication ranks this curated multi-gene set by the number of
+    distinct missense variants observed in a genome-wide human variation resource. That ranking is a
+    live aggregate over a ~390-million-variant GRCh38 catalogue (which grows with each release),
+    computed per gene from per-transcript VEP consequence annotations - it is not a figure recorded
+    in any paper.
+  conclusion: PASS (cannot answer from literature; requires a live per-gene missense-variant count over a genome-wide variation catalogue joined to the disease gene set)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# UniProt keyword KW-0988 (Intrahepatic cholestasis) -> 19 reviewed human proteins (exact keyword IRI
+#   match, not text search): ABCB11, ABCB4, AKR1D1, AMACR, ATP8B1, CYP7B1, HSD3B7, KIF12, MYO5B,
+#   NR1H4, PSKH1, SEMA7A, SLC25A13, SLC51A, TJP2, USP53, VPS33B, VPS50, ZFYVE19 - ALL 19 counted.
+# Consequence term: Sequence Ontology SO_0001583 (missense_variant), used as the rdf:type of each
+#   per-transcript hasConsequence node in the variation catalogue (IRI-backed, no text search).
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Resolve the disease gene set. All reviewed human (taxon 9606) proteins classified with UniProt
+      keyword KW-0988 (Intrahepatic cholestasis), with their encoding gene symbols. Returns exactly 19
+      proteins, each with a single primary gene symbol: ABCB11, ABCB4, AKR1D1, AMACR, ATP8B1, CYP7B1,
+      HSD3B7, KIF12, MYO5B, NR1H4, PSKH1, SEMA7A, SLC25A13, SLC51A, TJP2, USP53, VPS33B, VPS50, ZFYVE19.
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+
+      SELECT ?acc (GROUP_CONCAT(DISTINCT ?gene; SEPARATOR="/") AS ?genes)
+      WHERE {
+        ?protein a up:Protein ;
+                 up:reviewed true ;
+                 up:organism taxon:9606 ;
+                 up:classifiedWith keywords:988 .
+        BIND(STRAFTER(STR(?protein), "uniprot/") AS ?acc)
+        OPTIONAL { ?protein up:encodedBy ?g . ?g skos:prefLabel ?gene }
+      }
+      GROUP BY ?acc
+      ORDER BY ?genes
+    result_count: 19   # 19 reviewed human intrahepatic-cholestasis genes
+
+  - query_number: 2
+    database: hgnc
+    description: >-
+      Bridge the 19 gene symbols to their stable HGNC identifiers (the nomenclature authority's IRI),
+      which is the exact key the variation catalogue uses to attach VEP consequences to a gene. Exact
+      rdfs:label match, no text search. All 19 symbols resolve, e.g. MYO5B -> HGNC:7603, ABCB11 -> 42,
+      ATP8B1 -> 3706, ABCB4 -> 45, TJP2 -> 11828, AKR1D1 -> 388.
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+
+      SELECT ?symbol ?hgnc_id
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?symbol { "ABCB11" "ABCB4" "AKR1D1" "AMACR" "ATP8B1" "CYP7B1" "HSD3B7"
+                         "KIF12" "MYO5B" "NR1H4" "PSKH1" "SEMA7A" "SLC25A13" "SLC51A"
+                         "TJP2" "USP53" "VPS33B" "VPS50" "ZFYVE19" }
+        ?gene a m2r:Gene ; rdfs:label ?symbol ; dct:identifier ?hgnc_id .
+      }
+      ORDER BY ?symbol
+    result_count: 19   # all 19 symbols map 1:1 to HGNC IRIs
+
+  - query_number: 3
+    database: togovar
+    description: >-
+      For every one of the 19 genes (keyed by its HGNC IRI), count the DISTINCT variants that carry a
+      missense consequence (rdf:type SO_0001583) on that gene, using the per-transcript hasConsequence
+      nodes. Pinned to GRAPH <http://togovar.org/variant/annotation/ensembl>, the only graph that holds
+      consequence nodes (provenance probe on MYO5B returned that single graph, 1748 consequence nodes),
+      so DISTINCT-variant counts are not inflated by the cross-graph re-typing of variant IRIs. Ranked
+      descending: MYO5B=445, TJP2=315, ABCB11=258, ATP8B1=231, ABCB4=215, USP53=185, KIF12=170,
+      VPS50=149, SEMA7A=149, SLC25A13=145, ZFYVE19=143, VPS33B=121, CYP7B1=120, SLC51A=110, NR1H4=107,
+      HSD3B7=106, PSKH1=97, AMACR=83, AKR1D1=56. MYO5B (HGNC:7603) wins with 445.
+    query: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?hgnc (COUNT(DISTINCT ?variant) AS ?missense)
+      WHERE {
+        VALUES ?hgnc {
+          <http://identifiers.org/hgnc/42> <http://identifiers.org/hgnc/45>
+          <http://identifiers.org/hgnc/388> <http://identifiers.org/hgnc/451>
+          <http://identifiers.org/hgnc/3706> <http://identifiers.org/hgnc/2652>
+          <http://identifiers.org/hgnc/18324> <http://identifiers.org/hgnc/21495>
+          <http://identifiers.org/hgnc/7603> <http://identifiers.org/hgnc/7967>
+          <http://identifiers.org/hgnc/9529> <http://identifiers.org/hgnc/10741>
+          <http://identifiers.org/hgnc/10983> <http://identifiers.org/hgnc/29955>
+          <http://identifiers.org/hgnc/11828> <http://identifiers.org/hgnc/29255>
+          <http://identifiers.org/hgnc/12712> <http://identifiers.org/hgnc/25956>
+          <http://identifiers.org/hgnc/20758>
+        }
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:hgnc ?hgnc ; a obo:SO_0001583 .
+        }
+      }
+      GROUP BY ?hgnc
+      ORDER BY DESC(?missense)
+    result_count: 19   # per-gene missense counts; MYO5B=445 is the maximum
+
+  - query_number: 4
+    database: togovar
+    description: >-
+      Arithmetic verification (Hard Rule 3). Total DISTINCT variants carrying a missense consequence in
+      ANY of the 19 genes, same graph-pinned criteria as Query 3 but without GROUP BY. Returns 3205,
+      exactly equal to the sum of the 19 per-gene counts (445+315+258+231+215+185+170+149+149+145+143+
+      121+120+110+107+106+97+83+56 = 3205), proving the per-gene partition is exhaustive with no variant
+      shared across two of these genes (the 19 loci are disjoint).
+    query: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT (COUNT(DISTINCT ?variant) AS ?total_distinct)
+      WHERE {
+        VALUES ?hgnc {
+          <http://identifiers.org/hgnc/42> <http://identifiers.org/hgnc/45>
+          <http://identifiers.org/hgnc/388> <http://identifiers.org/hgnc/451>
+          <http://identifiers.org/hgnc/3706> <http://identifiers.org/hgnc/2652>
+          <http://identifiers.org/hgnc/18324> <http://identifiers.org/hgnc/21495>
+          <http://identifiers.org/hgnc/7603> <http://identifiers.org/hgnc/7967>
+          <http://identifiers.org/hgnc/9529> <http://identifiers.org/hgnc/10741>
+          <http://identifiers.org/hgnc/10983> <http://identifiers.org/hgnc/29955>
+          <http://identifiers.org/hgnc/11828> <http://identifiers.org/hgnc/29255>
+          <http://identifiers.org/hgnc/12712> <http://identifiers.org/hgnc/25956>
+          <http://identifiers.org/hgnc/20758>
+        }
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:hgnc ?hgnc ; a obo:SO_0001583 .
+        }
+      }
+    result_count: 1   # total_distinct = 3205 == sum of 19 per-gene counts (Rule 3 exact, no overlap)
+
+rdf_triples: |
+  @prefix ex:   <http://example.org/togovar-cholestasis-analysis#> .
+  @prefix hgnc: <http://identifiers.org/hgnc/> .
+  @prefix obo:  <http://purl.obolibrary.org/obo/> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+  ex:cholestasisGeneSet ex:geneCount "19"^^xsd:integer ; ex:keyword "KW-0988 Intrahepatic cholestasis" .
+  # Database: uniprot | Query: 1 | Comment: KW-0988 resolves to exactly 19 reviewed human genes, the full set compared in this question (Rule 2: all 19 counted, none sampled)
+  ex:cholestasisGeneSet ex:totalMissenseVariants "3205"^^xsd:integer .
+  # Database: togovar | Query: 4 | Comment: 3205 distinct variants carry a missense consequence across the 19 genes; equals the sum of the per-gene counts, so the 19 disjoint loci partition the set with no overlap (Rule 3 exact)
+  obo:SO_0001583 ex:label "missense_variant" .
+  # Database: togovar | Query: 3 | Comment: the counted consequence is Sequence Ontology missense_variant (SO_0001583), the rdf:type of each per-transcript hasConsequence node - an IRI-backed filter, no text search
+  hgnc:7603 ex:symbol "MYO5B" ; ex:missenseVariantCount "445"^^xsd:integer ; ex:rank "1 (the answer)" .
+  # Database: hgnc,togovar | Query: 3 | Comment: MYO5B (HGNC:7603, unconventional myosin-Vb; PFIC6 / microvillus inclusion disease) harbours 445 distinct missense variants - the MOST of the 19 genes (THE ANSWER)
+  hgnc:11828 ex:symbol "TJP2" ; ex:missenseVariantCount "315"^^xsd:integer ; ex:rank "2" .
+  # Database: hgnc,togovar | Query: 3 | Comment: TJP2 (HGNC:11828, tight-junction protein 2; PFIC4) is second with 315 - not offered as an option but shown to bracket the winner
+  hgnc:42 ex:symbol "ABCB11" ; ex:missenseVariantCount "258"^^xsd:integer ; ex:rank "3" .
+  # Database: hgnc,togovar | Query: 3 | Comment: ABCB11 (HGNC:42, bile salt export pump; PFIC2) is a distractor with 258 - the canonical cholestasis gene that a reader would naively pick, but well below MYO5B
+  hgnc:3706 ex:symbol "ATP8B1" ; ex:missenseVariantCount "231"^^xsd:integer ; ex:rank "4" .
+  # Database: hgnc,togovar | Query: 3 | Comment: ATP8B1 (HGNC:3706, phospholipid-transporting ATPase IC; PFIC1) is a distractor with 231
+  hgnc:45 ex:symbol "ABCB4" ; ex:missenseVariantCount "215"^^xsd:integer ; ex:rank "5" .
+  # Database: hgnc,togovar | Query: 3 | Comment: ABCB4 (HGNC:45, phosphatidylcholine translocator; PFIC3) is a distractor with 215
+  hgnc:388 ex:symbol "AKR1D1" ; ex:missenseVariantCount "56"^^xsd:integer ; ex:rank "19 (lowest)" .
+  # Database: hgnc,togovar | Query: 3 | Comment: AKR1D1 (HGNC:388) carries the fewest missense variants of the 19 genes (56), setting the low end of the 56-445 range
+
+exact_answer:
+  - "MYO5B (unconventional myosin-Vb)"
+
+ideal_answer: |
+  Among the four genes offered, MYO5B (HGNC:7603, unconventional myosin-Vb) harbours the greatest number of distinct missense variants - 445 - in the GRCh38 human variation catalogue, comfortably ahead of the three canonical bile-transport pumps that a reader would more readily associate with the disease: ABCB11 (bile salt export pump, PFIC2) with 258, ATP8B1 (PFIC1) with 231, and ABCB4 (PFIC3) with 215. The comparison is drawn over the full curated set of 19 reviewed human genes whose germline defects cause intrahepatic cholestasis, counting for each gene the distinct variants that carry a missense (Sequence Ontology missense_variant, SO_0001583) consequence on one of that gene's transcripts. Across the whole set the counts run from 56 (AKR1D1) to 445 (MYO5B), and MYO5B is in fact the overall maximum - only the tight-junction gene TJP2 (315), which is not offered as a choice, sits between it and the transporters. The 19 per-gene counts sum to exactly 3205 distinct missense variants, equal to the total counted across all genes together, confirming the 19 loci are disjoint and the ranking is exhaustive. The result is a useful corrective to intuition: variant tally scales largely with the coding footprint of the gene, and MYO5B - a very large trafficking myosin whose loss causes PFIC6 and microvillus inclusion disease - simply presents a bigger mutational target than the classic ABC transporters, so it accumulates more observed missense variation despite being the less obvious cholestasis gene.
+
+question_template_used: "Choice extremal aggregation over a disease-defined gene set (per-gene missense-variant count from a genome-wide variation catalogue, gene set defined by a UniProt disease keyword and bridged to the catalogue via stable HGNC IRIs, argmax where the non-obvious large gene beats the canonical disease genes offered as distractors)"
+
+time_spent:
+  exploration: 28 minutes
+  formulation: 12 minutes
+  verification: 10 minutes
+  pubmed_test: 12 minutes
+  extraction: 15 minutes
+  documentation: 20 minutes
+  total: 97 minutes

--- a/benchmark/questions/question_085.yaml
+++ b/benchmark/questions/question_085.yaml
@@ -1,0 +1,300 @@
+id: question_085
+type: list
+body: "Congenital myasthenic syndromes are inherited disorders of neuromuscular transmission caused by germline defects in a curated set of human genes encoding proteins of the neuromuscular junction. Consider the full set of these disease genes. In a comprehensive population-scale catalogue of human genome variation - one that annotates every variant with its per-transcript functional consequence and cross-references clinically curated variant records - some of these genes carry a loss-of-function variant (a stop-gained, frame-shift, or splice donor/acceptor change) that is additionally classified as Pathogenic or Likely pathogenic in the clinical-significance archive. List every one of the disease genes for which at least one such catalogued loss-of-function variant is classified Pathogenic or Likely pathogenic."
+
+inspiration_keyword:
+  keyword_id: KW-1004
+  name: Congenital myasthenic syndrome
+  category: Disease
+
+togomcp_databases_used:
+  - uniprot
+  - hgnc
+  - togovar
+  - clinvar
+
+verification_score:
+  biological_insight: 3
+  multi_database: 3
+  verifiability: 3
+  rdf_necessity: 3
+  total: 12
+  passed: true
+
+pubmed_test:
+  time_spent: 12 minutes
+  method: |
+    Tried to answer the specific question - which congenital-myasthenic-syndrome (CMS) genes carry a
+    loss-of-function variant that is present in a population-scale variation catalogue AND classified
+    Pathogenic/Likely pathogenic in ClinVar - directly from the literature:
+    (1) "congenital myasthenic syndrome genes loss-of-function pathogenic variants population variation
+        catalogue ClinVar list"
+    (2) "congenital myasthenic syndrome which genes truncating loss-of-function pathogenic variants
+        versus missense mechanism"
+    (3) "congenital myasthenic syndrome gene panel diagnosis mutation spectrum" (topic-existence check)
+  result: |
+    The two targeted queries returned zero articles. The third (broad) query returned 5 CMS gene-panel /
+    mutation-spectrum reviews, confirming the topic is studied - but none enumerates the specific set of
+    CMS genes for which a loss-of-function variant is both catalogued in a population variation resource
+    and carries a Pathogenic/Likely-pathogenic ClinVar classification. That partition is a live join of
+    a ~390-million-variant GRCh38 catalogue's per-transcript VEP consequences with ClinVar germline
+    significance, recomputed as both resources update; it is not a figure recorded in any paper.
+  conclusion: PASS (cannot answer from literature; requires a live loss-of-function consequence filter over a population variation catalogue intersected with ClinVar clinical significance across the full disease-gene set)
+
+# STRUCTURED VOCABULARY DISCOVERY
+# UniProt keyword KW-1004 (Congenital myasthenic syndrome) -> 24 reviewed human genes (exact keyword IRI
+#   match, not text search): AGRN, ALG14, ALG2, CHAT, CHRNA1, CHRNB1, CHRND, CHRNE, COL13A1, COLQ, DOK7,
+#   DPAGT1, GFPT1, LRP4, MUSK, MYO9A, PREPL, RAPSN, SCN4A, SLC18A3, SLC25A1, SLC5A7, SYT2, VAMP1 - ALL 24
+#   evaluated (Rule 2, no sampling).
+# Loss-of-function consequence set = 4 Sequence Ontology terms (rdf:type of the per-transcript
+#   hasConsequence node, IRI-backed): SO_0001587 stop_gained, SO_0001589 frameshift_variant,
+#   SO_0001574 splice_acceptor_variant, SO_0001575 splice_donor_variant.
+# ClinVar significance = germline classification cvo:description in {Pathogenic, Likely pathogenic,
+#   Pathogenic/Likely pathogenic} (controlled vocabulary, not text search).
+
+sparql_queries:
+  - query_number: 1
+    database: uniprot
+    description: >-
+      Resolve the disease gene set. All reviewed human (taxon 9606) proteins classified with UniProt
+      keyword KW-1004 (Congenital myasthenic syndrome), with their encoding gene symbols. Returns exactly
+      24 genes: AGRN, ALG14, ALG2, CHAT, CHRNA1, CHRNB1, CHRND, CHRNE, COL13A1, COLQ, DOK7, DPAGT1,
+      GFPT1, LRP4, MUSK, MYO9A, PREPL, RAPSN, SCN4A, SLC18A3, SLC25A1, SLC5A7, SYT2, VAMP1.
+    query: |
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX keywords: <http://purl.uniprot.org/keywords/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
+
+      SELECT ?acc (GROUP_CONCAT(DISTINCT ?gene; SEPARATOR="/") AS ?genes)
+      WHERE {
+        ?protein a up:Protein ;
+                 up:reviewed true ;
+                 up:organism taxon:9606 ;
+                 up:classifiedWith keywords:1004 .
+        BIND(STRAFTER(STR(?protein), "uniprot/") AS ?acc)
+        OPTIONAL { ?protein up:encodedBy ?g . ?g skos:prefLabel ?gene }
+      }
+      GROUP BY ?acc
+      ORDER BY ?genes
+    result_count: 24   # 24 reviewed human congenital-myasthenic-syndrome genes
+
+  - query_number: 2
+    database: hgnc
+    description: >-
+      Bridge the 24 gene symbols to their stable HGNC identifiers (the exact key the variation catalogue
+      attaches VEP consequences to via tgvo:hgnc). Exact rdfs:label match, no text search. All 24 resolve,
+      e.g. CHRNE -> HGNC:1966, DOK7 -> 26594, COLQ -> 2226, RAPSN -> 9863, AGRN -> 329, CHRNA1 -> 1955.
+    query: |
+      PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX dct: <http://purl.org/dc/terms/>
+
+      SELECT ?symbol ?hgnc_id
+      FROM <http://rdfportal.org/dataset/hgnc>
+      WHERE {
+        VALUES ?symbol { "AGRN" "ALG14" "ALG2" "CHAT" "CHRNA1" "CHRNB1" "CHRND" "CHRNE" "COL13A1"
+                         "COLQ" "DOK7" "DPAGT1" "GFPT1" "LRP4" "MUSK" "MYO9A" "PREPL" "RAPSN" "SCN4A"
+                         "SLC18A3" "SLC25A1" "SLC5A7" "SYT2" "VAMP1" }
+        ?gene a m2r:Gene ; rdfs:label ?symbol ; dct:identifier ?hgnc_id .
+      }
+      ORDER BY ?symbol
+    result_count: 24   # all 24 symbols map 1:1 to HGNC IRIs
+
+  - query_number: 3
+    database: togovar
+    description: >-
+      In the population variation catalogue, for each of the 24 genes (keyed by its HGNC IRI), collect the
+      ClinVar VariationIDs of variants that carry a LOSS-OF-FUNCTION consequence on that gene - a
+      hasConsequence node typed stop_gained / frameshift / splice_acceptor / splice_donor
+      (SO_0001587/1589/1574/1575) in GRAPH .../variant/annotation/ensembl - and that also carry a ClinVar
+      cross-link (dcterms:identifier in GRAPH .../variant/annotation/clinvar). Graph-pinned + DISTINCT, so
+      no cross-graph re-typing inflation. Returns 71 (gene, VariationID) pairs spanning 18 of the 24 genes;
+      the other 6 (ALG14, CHRNA1, CHRNB1, SLC18A3, SYT2, VAMP1) have NO catalogued LoF variant carrying a
+      ClinVar cross-link.
+    query: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+
+      SELECT DISTINCT ?hgnc ?vid
+      WHERE {
+        VALUES ?hgnc {
+          <http://identifiers.org/hgnc/329> <http://identifiers.org/hgnc/28287>
+          <http://identifiers.org/hgnc/23159> <http://identifiers.org/hgnc/1912>
+          <http://identifiers.org/hgnc/1955> <http://identifiers.org/hgnc/1961>
+          <http://identifiers.org/hgnc/1965> <http://identifiers.org/hgnc/1966>
+          <http://identifiers.org/hgnc/2190> <http://identifiers.org/hgnc/2226>
+          <http://identifiers.org/hgnc/26594> <http://identifiers.org/hgnc/2995>
+          <http://identifiers.org/hgnc/4241> <http://identifiers.org/hgnc/6696>
+          <http://identifiers.org/hgnc/7525> <http://identifiers.org/hgnc/7608>
+          <http://identifiers.org/hgnc/30228> <http://identifiers.org/hgnc/9863>
+          <http://identifiers.org/hgnc/10591> <http://identifiers.org/hgnc/10936>
+          <http://identifiers.org/hgnc/10979> <http://identifiers.org/hgnc/14025>
+          <http://identifiers.org/hgnc/11510> <http://identifiers.org/hgnc/12642>
+        }
+        VALUES ?lof { obo:SO_0001587 obo:SO_0001589 obo:SO_0001574 obo:SO_0001575 }
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?v tgvo:hasConsequence ?c .
+          ?c tgvo:hgnc ?hgnc ; a ?lof .
+        }
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          ?v dcterms:identifier ?vid .
+        }
+      }
+      ORDER BY ?hgnc ?vid
+    result_count: 71   # 71 (gene, ClinVar VariationID) LoF pairs across 18 of the 24 genes
+
+  - query_number: 4
+    database: clinvar
+    description: >-
+      Clinical-significance filter. For the 71 VariationIDs from Query 3 (their variation IRIs
+      http://ncbi.nlm.nih.gov/clinvar/variation/{id}), retrieve the germline classification and keep only
+      Pathogenic / Likely pathogenic / Pathogenic-Likely-pathogenic (record_type "classified"; split
+      property paths). Returns exactly 46 VariationIDs; the other 25 are Uncertain significance /
+      Conflicting / Benign / Likely benign and are excluded.
+    query: |
+      PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+
+      SELECT ?vid ?significance
+      FROM <http://rdfportal.org/dataset/clinvar>
+      WHERE {
+        VALUES ?variant {
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1458366> <http://ncbi.nlm.nih.gov/clinvar/variation/3020921> <http://ncbi.nlm.nih.gov/clinvar/variation/849707> <http://ncbi.nlm.nih.gov/clinvar/variation/970818>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1710697> <http://ncbi.nlm.nih.gov/clinvar/variation/2580443>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1015765> <http://ncbi.nlm.nih.gov/clinvar/variation/854671>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1452884> <http://ncbi.nlm.nih.gov/clinvar/variation/2680729> <http://ncbi.nlm.nih.gov/clinvar/variation/2680740> <http://ncbi.nlm.nih.gov/clinvar/variation/575316> <http://ncbi.nlm.nih.gov/clinvar/variation/949501>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1324078> <http://ncbi.nlm.nih.gov/clinvar/variation/18367> <http://ncbi.nlm.nih.gov/clinvar/variation/18370>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/2066367> <http://ncbi.nlm.nih.gov/clinvar/variation/2090933> <http://ncbi.nlm.nih.gov/clinvar/variation/2170253> <http://ncbi.nlm.nih.gov/clinvar/variation/2680799> <http://ncbi.nlm.nih.gov/clinvar/variation/2680807> <http://ncbi.nlm.nih.gov/clinvar/variation/2843572> <http://ncbi.nlm.nih.gov/clinvar/variation/465857> <http://ncbi.nlm.nih.gov/clinvar/variation/631777> <http://ncbi.nlm.nih.gov/clinvar/variation/680256> <http://ncbi.nlm.nih.gov/clinvar/variation/731909> <http://ncbi.nlm.nih.gov/clinvar/variation/963385>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1324099> <http://ncbi.nlm.nih.gov/clinvar/variation/3065133> <http://ncbi.nlm.nih.gov/clinvar/variation/717621>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1180688> <http://ncbi.nlm.nih.gov/clinvar/variation/2680852> <http://ncbi.nlm.nih.gov/clinvar/variation/280125> <http://ncbi.nlm.nih.gov/clinvar/variation/631910> <http://ncbi.nlm.nih.gov/clinvar/variation/976238>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1471587>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1273> <http://ncbi.nlm.nih.gov/clinvar/variation/1274> <http://ncbi.nlm.nih.gov/clinvar/variation/209149> <http://ncbi.nlm.nih.gov/clinvar/variation/242521> <http://ncbi.nlm.nih.gov/clinvar/variation/2674886> <http://ncbi.nlm.nih.gov/clinvar/variation/2674895> <http://ncbi.nlm.nih.gov/clinvar/variation/711906> <http://ncbi.nlm.nih.gov/clinvar/variation/813360>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1361337>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1030066> <http://ncbi.nlm.nih.gov/clinvar/variation/649028> <http://ncbi.nlm.nih.gov/clinvar/variation/653242>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1087402> <http://ncbi.nlm.nih.gov/clinvar/variation/1194333> <http://ncbi.nlm.nih.gov/clinvar/variation/1322937> <http://ncbi.nlm.nih.gov/clinvar/variation/1431707> <http://ncbi.nlm.nih.gov/clinvar/variation/2063004> <http://ncbi.nlm.nih.gov/clinvar/variation/541195> <http://ncbi.nlm.nih.gov/clinvar/variation/679581> <http://ncbi.nlm.nih.gov/clinvar/variation/930633>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1070025> <http://ncbi.nlm.nih.gov/clinvar/variation/444502>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/2933365> <http://ncbi.nlm.nih.gov/clinvar/variation/428601>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1452397> <http://ncbi.nlm.nih.gov/clinvar/variation/1971882> <http://ncbi.nlm.nih.gov/clinvar/variation/657565>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/732934>
+          <http://ncbi.nlm.nih.gov/clinvar/variation/1567030> <http://ncbi.nlm.nih.gov/clinvar/variation/2137089> <http://ncbi.nlm.nih.gov/clinvar/variation/2924114> <http://ncbi.nlm.nih.gov/clinvar/variation/632161> <http://ncbi.nlm.nih.gov/clinvar/variation/664620> <http://ncbi.nlm.nih.gov/clinvar/variation/990460> <http://ncbi.nlm.nih.gov/clinvar/variation/990461>
+        }
+        ?variant cvo:variation_id ?vid ;
+                 cvo:record_type "classified" ;
+                 cvo:classified_record ?cr .
+        ?cr cvo:classifications ?cls .
+        ?cls cvo:germline_classification ?germ .
+        ?germ cvo:description ?significance .
+        VALUES ?significance { "Pathogenic" "Likely pathogenic" "Pathogenic/Likely pathogenic" }
+      }
+      ORDER BY ?vid
+    result_count: 46   # 46 of the 71 LoF VariationIDs are Pathogenic/Likely pathogenic
+
+  - query_number: 5
+    database: togovar
+    description: >-
+      Verification + gene mapping (Hard Rule 3). Feed the 46 Pathogenic/Likely-pathogenic VariationIDs
+      from Query 4 back into the catalogue and re-derive their genes via the same LoF + HGNC anchor. Returns
+      exactly 14 genes, and the per-gene pathogenic-LoF counts sum to 46 (CHRNE 8, DOK7 7, COLQ 5, then
+      AGRN/CHAT/MUSK/PREPL/RAPSN/SCN4A 3 each, CHRND/GFPT1/SLC25A1 2 each, COL13A1/LRP4 1 each =
+      8+7+5+3+3+3+3+3+3+2+2+2+1+1 = 46), so every VariationID maps to exactly one gene (no overlap) and the
+      24-gene set partitions as 14 answer genes + 10 excluded (6 with no LoF/ClinVar link + 4 whose LoF
+      variants are all non-pathogenic: ALG2, DPAGT1, MYO9A, SLC5A7).
+    query: |
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+
+      SELECT ?hgnc (COUNT(DISTINCT ?vid) AS ?pathoLof)
+      WHERE {
+        VALUES ?vid {
+          "1273" "1274" "18367" "18370" "209149" "242521" "280125" "428601" "444502" "465857"
+          "631777" "631910" "632161" "649028" "653242" "657565" "664620" "813360" "849707" "930633"
+          "963385" "976238" "1030066" "1070025" "1180688" "1322937" "1324099" "1452397" "1452884" "1458366"
+          "1710697" "1971882" "2063004" "2090933" "2137089" "2170253" "2580443" "2674886" "2674895" "2680729"
+          "2680740" "2680799" "2680807" "2680852" "2843572" "3020921"
+        }
+        VALUES ?lof { obo:SO_0001587 obo:SO_0001589 obo:SO_0001574 obo:SO_0001575 }
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          ?v dcterms:identifier ?vid .
+        }
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?v tgvo:hasConsequence ?c .
+          ?c tgvo:hgnc ?hgnc ; a ?lof .
+        }
+      }
+      GROUP BY ?hgnc
+      ORDER BY DESC(?pathoLof)
+    result_count: 14   # 14 answer genes; per-gene pathogenic-LoF counts sum to 46 (Rule 3 exact)
+
+rdf_triples: |
+  @prefix ex:   <http://example.org/togovar-cms-lof-analysis#> .
+  @prefix hgnc: <http://identifiers.org/hgnc/> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+  ex:cmsGeneSet ex:geneCount "24"^^xsd:integer ; ex:keyword "KW-1004 Congenital myasthenic syndrome" .
+  # Database: uniprot | Query: 1 | Comment: KW-1004 resolves to exactly 24 reviewed human genes, the full set evaluated (Rule 2, no sampling)
+  ex:cmsGeneSet ex:lofClinvarLinkedVariants "71"^^xsd:integer ; ex:lofClinvarLinkedGenes "18"^^xsd:integer .
+  # Database: togovar | Query: 3 | Comment: 71 catalogued loss-of-function variants (stop_gained/frameshift/splice) carry a ClinVar cross-link, spanning 18 of the 24 genes; 6 genes have none
+  ex:cmsGeneSet ex:pathogenicLofVariants "46"^^xsd:integer ; ex:answerGeneCount "14"^^xsd:integer .
+  # Database: clinvar,togovar | Query: 4 | Comment: of the 71, exactly 46 are Pathogenic/Likely pathogenic; these map to 14 genes (24 = 14 answer + 10 excluded; 46 = sum of the 14 per-gene counts, Rule 3)
+  hgnc:1966 ex:symbol "CHRNE" ; ex:pathogenicLofCount "8"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: CHRNE (HGNC:1966, acetylcholine receptor epsilon subunit) has the most - 8 pathogenic/LP loss-of-function variants; the commonest CMS gene
+  hgnc:26594 ex:symbol "DOK7" ; ex:pathogenicLofCount "7"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: DOK7 (HGNC:26594) has 7 pathogenic/LP loss-of-function variants
+  hgnc:2226 ex:symbol "COLQ" ; ex:pathogenicLofCount "5"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: COLQ (HGNC:2226) has 5 pathogenic/LP loss-of-function variants
+  hgnc:329 ex:symbol "AGRN" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: AGRN (HGNC:329) has 3 pathogenic/LP loss-of-function variants
+  hgnc:1912 ex:symbol "CHAT" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: CHAT (HGNC:1912) has 3 pathogenic/LP loss-of-function variants
+  hgnc:7525 ex:symbol "MUSK" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: MUSK (HGNC:7525) has 3 pathogenic/LP loss-of-function variants
+  hgnc:30228 ex:symbol "PREPL" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: PREPL (HGNC:30228) has 3 pathogenic/LP loss-of-function variants
+  hgnc:9863 ex:symbol "RAPSN" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: RAPSN (HGNC:9863) has 3 pathogenic/LP loss-of-function variants
+  hgnc:10591 ex:symbol "SCN4A" ; ex:pathogenicLofCount "3"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: SCN4A (HGNC:10591) has 3 pathogenic/LP loss-of-function variants
+  hgnc:1965 ex:symbol "CHRND" ; ex:pathogenicLofCount "2"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: CHRND (HGNC:1965) has 2 pathogenic/LP loss-of-function variants
+  hgnc:4241 ex:symbol "GFPT1" ; ex:pathogenicLofCount "2"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: GFPT1 (HGNC:4241) has 2 pathogenic/LP loss-of-function variants
+  hgnc:10979 ex:symbol "SLC25A1" ; ex:pathogenicLofCount "2"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: SLC25A1 (HGNC:10979) has 2 pathogenic/LP loss-of-function variants
+  hgnc:6696 ex:symbol "LRP4" ; ex:pathogenicLofCount "1"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: LRP4 (HGNC:6696) has 1 pathogenic/LP loss-of-function variant
+  hgnc:2190 ex:symbol "COL13A1" ; ex:pathogenicLofCount "1"^^xsd:integer .
+  # Database: hgnc,clinvar,togovar | Query: 5 | Comment: COL13A1 (HGNC:2190) has 1 pathogenic/LP loss-of-function variant; per-gene counts 8+7+5+3+3+3+3+3+3+2+2+2+1+1 = 46 (Rule 3)
+  ex:excludedGenes ex:noPathogenicLof "ALG14,ALG2,CHRNA1,CHRNB1,DPAGT1,MYO9A,SLC18A3,SLC5A7,SYT2,VAMP1" .
+  # Database: clinvar,togovar | Query: 5 | Comment: the 10 excluded genes - 6 with no catalogued LoF/ClinVar-linked variant, 4 (ALG2,DPAGT1,MYO9A,SLC5A7) whose LoF variants are all Uncertain/Benign; CMS at these loci is dominated by non-LoF (missense/gain-of-function) mechanisms
+
+exact_answer:
+  - "AGRN"
+  - "CHAT"
+  - "CHRND"
+  - "CHRNE"
+  - "COL13A1"
+  - "COLQ"
+  - "DOK7"
+  - "GFPT1"
+  - "LRP4"
+  - "MUSK"
+  - "PREPL"
+  - "RAPSN"
+  - "SCN4A"
+  - "SLC25A1"
+
+ideal_answer: |
+  Fourteen of the 24 congenital-myasthenic-syndrome genes carry at least one loss-of-function variant (stop-gained, frameshift, or splice donor/acceptor) that is both catalogued in the population variation resource and classified Pathogenic or Likely pathogenic in ClinVar: AGRN, CHAT, CHRND, CHRNE, COL13A1, COLQ, DOK7, GFPT1, LRP4, MUSK, PREPL, RAPSN, SCN4A, and SLC25A1. CHRNE, the single most common CMS gene, leads with eight such pathogenic loss-of-function variants, followed by DOK7 (seven) and COLQ (five); AGRN, CHAT, MUSK, PREPL, RAPSN, and SCN4A each contribute three, CHRND, GFPT1, and SLC25A1 two each, and COL13A1 and LRP4 one each - 46 distinct pathogenic loss-of-function variants in total, each mapping to exactly one gene. The remaining ten genes fall into two groups. Six - ALG14, CHRNA1, CHRNB1, SLC18A3, SYT2, and VAMP1 - have no catalogued loss-of-function variant carrying any ClinVar cross-link at all, and four more - ALG2, DPAGT1, MYO9A, and SLC5A7 - do have such variants but none reaches Pathogenic or Likely-pathogenic (they are Uncertain significance, Conflicting, or Benign). The split is biologically meaningful: the loss-of-function-positive set is dominated by the classic recessive end-plate genes (acetylcholine-receptor subunits, the AChR-clustering pathway AGRN/LRP4/MUSK/DOK7/RAPSN, the acetylcholinesterase anchor COLQ, and the presynaptic CHAT), whereas several excluded genes cause CMS chiefly through non-loss-of-function mechanisms - CHRNA1/CHRNB1 slow-channel disease is dominant gain-of-function missense, SCN4A and the synaptic-vesicle genes act through altered rather than absent protein, and the glycosylation genes ALG2/ALG14/DPAGT1 are largely hypomorphic missense - so truncating pathogenic alleles are correspondingly absent from the catalogue for them.
+
+question_template_used: "List membership via multi-database intersection (disease gene set from a UniProt keyword -> HGNC IRIs -> population-catalogue loss-of-function VEP consequence + ClinVar cross-link -> ClinVar germline-significance filter; a gene is listed iff it has >=1 catalogued pathogenic/likely-pathogenic loss-of-function variant)"
+
+time_spent:
+  exploration: 34 minutes
+  formulation: 16 minutes
+  verification: 14 minutes
+  pubmed_test: 12 minutes
+  extraction: 18 minutes
+  documentation: 24 minutes
+  total: 118 minutes


### PR DESCRIPTION
Brings benchmark questions 081–085 (PR #144) from `dev` to `main`.

- 081 summary · 082 factoid · 083 yes_no · 084 choice · 085 list
- 084/085 are the first two TogoVar questions (registry coverage complete)
- Balanced 85-question milestone: 17 per type
- `verify_questions.py`: 0 errors; Structural Near-Duplicate Guard clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)