### PR TITLE
Sync dev → main: ChEMBL SPARQL search redesign + ablation-harness API auth

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ This directory contains the evaluation benchmark for the paper:
 
 > **TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol**
 
-The benchmark consists of 50 biologically grounded questions spanning five question types and 23 RDF Portal databases, designed to evaluate TogoMCP's ability to answer biological questions that require live access to RDF knowledge graphs.
+The benchmark consists of 100 biologically grounded questions spanning five question types and 34 RDF Portal databases, designed to evaluate TogoMCP's ability to answer biological questions that require live access to RDF knowledge graphs.
 
 ---
 
@@ -20,7 +20,7 @@ benchmark/
 │   ├── coverage_tracker.yaml     # Tracks question type and database coverage
 │   ├── question_001.yaml         # Individual question files
 │   ├── question_002.yaml
-│   └── ... (question_001–question_050.yaml)
+│   └── ... (question_001–question_100.yaml)
 ├── scripts/
 │   ├── automated_test_runner.py  # Collects answers from baseline and TogoMCP agents
 │   ├── add_llm_evaluation.py     # Scores collected answers using Claude Opus as judge
@@ -54,7 +54,7 @@ benchmark/
 
 ### Question Set
 
-The 50 questions were created following a strict type-first protocol (`QA_CREATION_GUIDE.md`), with **10 questions per type**:
+The 100 questions were created following a strict type-first protocol (`QA_CREATION_GUIDE.md`), with **20 questions per type**:
 
 | Type | Description |
 |------|-------------|
@@ -68,7 +68,7 @@ The 50 questions were created following a strict type-first protocol (`QA_CREATI
 - Multi-database questions (2+ databases): ≥ 60%
 - Multi-database questions (3+ databases): ≥ 20%
 - UniProt usage cap: ≤ 70%
-- All 23 RDF Portal databases covered at least once
+- All 34 RDF Portal databases covered at least once
 
 Questions were validated to exclude answers recoverable from pre-training data or the published literature (PubMed test), ensuring that RDF database access is necessary to answer them correctly.
 

--- a/benchmark/ablation/README.md
+++ b/benchmark/ablation/README.md
@@ -71,8 +71,8 @@ cd benchmark/ablation
 # 1. Generate the 11 section-stripped MIE corpora (+ presence matrix).
 python ablate_mie.py
 
-# 2. Pick a DB-spanning pilot subset (~15 questions covering all 30 DBs).
-python select_pilot.py            # or: --full  for all 70
+# 2. Pick a DB-spanning pilot subset (40 questions covering all 34 DBs).
+python select_pilot.py            # or: --full  for all 100
 
 # 3. Validate orchestration without spending API credits (boots each server).
 python run_ablation.py --dry-run --conditions baseline,ablate_shape_expressions
@@ -97,10 +97,16 @@ Outputs land in `results/`:
   default 8971); only one local server is alive at a time.
 - **Contribution** = `mean(baseline) − mean(section removed)` on
   `togomcp_total_score` (0–20), paired per question. Positive ⇒ the section helps.
-- **Scale up**: `python select_pilot.py --full` then re-run the sweep for all 70
+- **Scale up**: `python select_pilot.py --full` then re-run the sweep for all 100
   questions. `--conditions` restricts to a subset of sections.
-- **Cost**: pilot ≈ 12 conditions × ~15 questions × (1 answer + 1 judge). Multiply
-  by ~4.7 for the full 70-question set.
+- **Replicates**: `run_ablation.py --runs R` answers + judges each question R times
+  per condition (replicates in `<cond>-scored-vR.csv`) and averages them per
+  question into the flat `<cond>-scored.csv`. Averaging divides the judge-jitter
+  part of the paired-delta variance by R — the lever that gives a 40-question pilot
+  usable power; a single-shot 40-Q sweep only resolves ~2-point section effects
+  (see `select_pilot.py` docstring). Cost scales ×R.
+- **Cost**: pilot ≈ 12 conditions × 40 questions × R × (1 answer + 1 judge)
+  (R=1 by default). Multiply by ~2.5 for the full 100-question set.
 
 ## Verified / not verified
 

--- a/benchmark/ablation/run_ablation.py
+++ b/benchmark/ablation/run_ablation.py
@@ -246,7 +246,7 @@ def _server_log_tail(log_path: Path, n: int = 15) -> str:
 
 def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
                   model: str, judge_model: str | None, force: bool, dry_run: bool,
-                  python: str, runs: int = 1) -> str:
+                  python: str, runs: int = 1, judge_use_api: bool = False) -> str:
     final_scored = RESULTS_DIR / f"{cond}-scored.csv"
     if final_scored.exists() and not force:
         print(f"[{cond}] scored CSV exists — skipping (delete it or --force to re-run)")
@@ -262,6 +262,15 @@ def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
     env = dict(os.environ)
     env["TOGOMCP_MIE_DIR"] = str(variant_dir)
     env["ABLATION_PORT"] = str(port)
+
+    # With --judge-use-api the judge (add_llm_evaluation --use-api) uses the plain
+    # anthropic SDK + ANTHROPIC_API_KEY; the ANSWERING agent must NOT see that key or
+    # the bundled Claude CLI would bill the API too — strip it so answering stays on
+    # the `claude login` subscription. The two no longer share a quota (the whole
+    # point: judging on the subscription is what got rate-limited).
+    answer_env = env
+    if judge_use_api and "ANTHROPIC_API_KEY" in answer_env:
+        answer_env = {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"}
 
     # runs==1 keeps the flat <cond>-answers/scored.csv names (backward compatible);
     # runs>1 writes -vR replicates and averages them into the flat <cond>-scored.csv.
@@ -311,7 +320,7 @@ def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
                 subprocess.run(
                     [python, str(RUNNER), *questions,
                      "-c", str(cfg_path), "--model", model, "-o", str(p["answers"])],
-                    check=True, cwd=str(SCRIPTS_DIR),
+                    check=True, cwd=str(SCRIPTS_DIR), env=answer_env,
                 )
         finally:
             log_fh.close()
@@ -337,9 +346,11 @@ def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
         eval_cmd = [python, str(EVALUATOR), str(p["answers"]), "-o", str(p["scored"])]
         if judge_model:
             eval_cmd += ["--model", judge_model]
-        # Evaluator inherits the env: the Claude judge (add_llm_evaluation.py default)
-        # authenticates via `claude login`, same as the runner. Do not inject a key.
-        subprocess.run(eval_cmd, check=True, cwd=str(SCRIPTS_DIR))
+        if judge_use_api:
+            eval_cmd += ["--use-api"]     # plain anthropic SDK, forced-tool-call, ANTHROPIC_API_KEY
+        # Judge inherits the full env (incl. ANTHROPIC_API_KEY when --judge-use-api);
+        # the default (no --use-api) authenticates via `claude login` like the runner.
+        subprocess.run(eval_cmd, check=True, cwd=str(SCRIPTS_DIR), env=env)
 
     # --- average replicates into the flat scored CSV ablation_analysis.py reads ---
     if runs > 1:
@@ -365,6 +376,12 @@ def main() -> int:
                          "per question (default 1). Replicates land in <cond>-scored-vN.csv; "
                          "the averaged <cond>-scored.csv feeds ablation_analysis.py. "
                          "Averaging R runs divides judge-jitter variance by R.")
+    ap.add_argument("--judge-use-api", action="store_true",
+                    help="judge via the Anthropic Messages API (plain anthropic SDK, forced "
+                         "record_evaluation tool call) instead of the claude-login agent SDK. "
+                         "Requires ANTHROPIC_API_KEY in the env; that key is passed ONLY to the "
+                         "judge, not the answering agent, so answering stays on the subscription. "
+                         "Use this for long batches where subscription Opus judging gets throttled.")
     ap.add_argument("--port", type=int, default=8971, help="loopback port for the local server")
     ap.add_argument("--python", default=sys.executable,
                     help="interpreter for the server + benchmark subprocesses "
@@ -383,6 +400,10 @@ def main() -> int:
 
     if args.runs < 1:
         raise SystemExit(f"--runs must be >= 1 (got {args.runs})")
+
+    if args.judge_use_api and not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("--judge-use-api requires ANTHROPIC_API_KEY in the environment "
+                         "(e.g. `ANTHROPIC_API_KEY=$MY_ANTHROPIC_API_KEY ...`).")
 
     conditions = [c.strip() for c in args.conditions.split(",") if c.strip()]
     unknown = [c for c in conditions if c not in ALL_CONDITIONS]
@@ -403,9 +424,11 @@ def main() -> int:
         preflight(args.python, required)
 
     runs_note = f" x {args.runs} runs" if args.runs > 1 else ""
+    judge_path = "anthropic API" if args.judge_use_api else "claude-login agent SDK"
     print(f"Ablation sweep: {len(conditions)} conditions x {len(questions)} questions{runs_note}")
-    print(f"  model={args.model}  judge={args.judge_model or '(eval default)'}  "
-          f"port={args.port}  python={args.python}\n")
+    print(f"  answer-model={args.model} (subscription)  "
+          f"judge={args.judge_model or '(eval default)'} via {judge_path}\n"
+          f"  port={args.port}  python={args.python}\n")
 
     summary: dict[str, str] = {}
     started = time.monotonic()
@@ -413,7 +436,8 @@ def main() -> int:
         try:
             summary[cond] = run_condition(cond, questions, base_config, args.port,
                                           args.model, args.judge_model, args.force,
-                                          args.dry_run, args.python, args.runs)
+                                          args.dry_run, args.python, args.runs,
+                                          args.judge_use_api)
         except SystemExit as e:
             print(f"[{cond}] ABORTED: {e}", file=sys.stderr)
             summary[cond] = "error"

--- a/benchmark/ablation/run_ablation.py
+++ b/benchmark/ablation/run_ablation.py
@@ -246,7 +246,8 @@ def _server_log_tail(log_path: Path, n: int = 15) -> str:
 
 def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
                   model: str, judge_model: str | None, force: bool, dry_run: bool,
-                  python: str, runs: int = 1, judge_use_api: bool = False) -> str:
+                  python: str, runs: int = 1, judge_use_api: bool = False,
+                  answer_use_api: bool = False) -> str:
     final_scored = RESULTS_DIR / f"{cond}-scored.csv"
     if final_scored.exists() and not force:
         print(f"[{cond}] scored CSV exists — skipping (delete it or --force to re-run)")
@@ -263,13 +264,15 @@ def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
     env["TOGOMCP_MIE_DIR"] = str(variant_dir)
     env["ABLATION_PORT"] = str(port)
 
-    # With --judge-use-api the judge (add_llm_evaluation --use-api) uses the plain
-    # anthropic SDK + ANTHROPIC_API_KEY; the ANSWERING agent must NOT see that key or
-    # the bundled Claude CLI would bill the API too — strip it so answering stays on
-    # the `claude login` subscription. The two no longer share a quota (the whole
-    # point: judging on the subscription is what got rate-limited).
+    # Answering runs on the claude_agent_sdk bundled CLI. If ANTHROPIC_API_KEY is in
+    # its env, the CLI bills the Anthropic API; if absent, it uses the `claude login`
+    # subscription. The subscription can't sustain a large batch — it degrades into
+    # "Not logged in" login-error stubs (the runner mislabels them success=True) — so
+    # --answer-use-api keeps the key for reliable API answering. Without it (default)
+    # we strip the key so answering stays on the subscription; but then --judge-use-api
+    # must NOT leak the key into answering, hence the same strip.
     answer_env = env
-    if judge_use_api and "ANTHROPIC_API_KEY" in answer_env:
+    if not answer_use_api and "ANTHROPIC_API_KEY" in answer_env:
         answer_env = {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"}
 
     # runs==1 keeps the flat <cond>-answers/scored.csv names (backward compatible);
@@ -379,9 +382,14 @@ def main() -> int:
     ap.add_argument("--judge-use-api", action="store_true",
                     help="judge via the Anthropic Messages API (plain anthropic SDK, forced "
                          "record_evaluation tool call) instead of the claude-login agent SDK. "
-                         "Requires ANTHROPIC_API_KEY in the env; that key is passed ONLY to the "
-                         "judge, not the answering agent, so answering stays on the subscription. "
-                         "Use this for long batches where subscription Opus judging gets throttled.")
+                         "Requires ANTHROPIC_API_KEY. Use for long batches where subscription "
+                         "Opus judging gets throttled.")
+    ap.add_argument("--answer-use-api", action="store_true",
+                    help="answer via the Anthropic API (keep ANTHROPIC_API_KEY in the answering "
+                         "agent's env) instead of the claude-login subscription. Requires "
+                         "ANTHROPIC_API_KEY. Use for long batches: the subscription degrades into "
+                         "'Not logged in' login-error stubs under sustained load. Without this, "
+                         "answering stays on the subscription and the key is withheld from it.")
     ap.add_argument("--port", type=int, default=8971, help="loopback port for the local server")
     ap.add_argument("--python", default=sys.executable,
                     help="interpreter for the server + benchmark subprocesses "
@@ -401,9 +409,9 @@ def main() -> int:
     if args.runs < 1:
         raise SystemExit(f"--runs must be >= 1 (got {args.runs})")
 
-    if args.judge_use_api and not os.environ.get("ANTHROPIC_API_KEY"):
-        raise SystemExit("--judge-use-api requires ANTHROPIC_API_KEY in the environment "
-                         "(e.g. `ANTHROPIC_API_KEY=$MY_ANTHROPIC_API_KEY ...`).")
+    if (args.judge_use_api or args.answer_use_api) and not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("--judge-use-api/--answer-use-api require ANTHROPIC_API_KEY in the "
+                         "environment (e.g. `ANTHROPIC_API_KEY=$MY_ANTHROPIC_API_KEY ...`).")
 
     conditions = [c.strip() for c in args.conditions.split(",") if c.strip()]
     unknown = [c for c in conditions if c not in ALL_CONDITIONS]
@@ -425,8 +433,9 @@ def main() -> int:
 
     runs_note = f" x {args.runs} runs" if args.runs > 1 else ""
     judge_path = "anthropic API" if args.judge_use_api else "claude-login agent SDK"
+    answer_path = "anthropic API" if args.answer_use_api else "claude-login subscription"
     print(f"Ablation sweep: {len(conditions)} conditions x {len(questions)} questions{runs_note}")
-    print(f"  answer-model={args.model} (subscription)  "
+    print(f"  answer={args.model} via {answer_path}  "
           f"judge={args.judge_model or '(eval default)'} via {judge_path}\n"
           f"  port={args.port}  python={args.python}\n")
 
@@ -437,7 +446,7 @@ def main() -> int:
             summary[cond] = run_condition(cond, questions, base_config, args.port,
                                           args.model, args.judge_model, args.force,
                                           args.dry_run, args.python, args.runs,
-                                          args.judge_use_api)
+                                          args.judge_use_api, args.answer_use_api)
         except SystemExit as e:
             print(f"[{cond}] ABORTED: {e}", file=sys.stderr)
             summary[cond] = "error"

--- a/benchmark/ablation/run_ablation.py
+++ b/benchmark/ablation/run_ablation.py
@@ -24,10 +24,18 @@ Usage:
     python run_ablation.py --conditions baseline,ablate_shape_expressions
     python run_ablation.py --questions q1.yaml q2.yaml  # ad-hoc subset
     python run_ablation.py --model claude-sonnet-4-5-20250929 --judge-model claude-opus-4-8
+    python run_ablation.py --runs 5                      # 5 replicates/question, averaged
+
+With --runs N (>1) each question is answered + judged N times per condition; the
+replicates land in <cond>-scored-vR.csv and are averaged per question_id into the
+flat <cond>-scored.csv that ablation_analysis.py consumes. Averaging R runs
+divides the judge-jitter component of the paired-delta variance by R, which is the
+lever that brings the pilot into a usable-power regime (see select_pilot.py).
 """
 from __future__ import annotations
 
 import argparse
+import csv
 import os
 import subprocess
 import sys
@@ -35,6 +43,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
+from statistics import mean
 
 import yaml
 
@@ -129,6 +138,103 @@ def load_pilot(explicit: list[str] | None) -> list[str]:
     return files
 
 
+# Judge-criterion columns (both baseline_* and togomcp_*) where a 0 is the
+# failed-judge sentinel add_llm_evaluation writes — real per-criterion scores clamp
+# to 1–5, totals to 4–20. Matches the metrics ablation_analysis.load_scores nulls
+# out on 0. NOT the *_success 0/1 flags or *_tokens/*_cost, whose 0 is a real value.
+_SCORE_SUFFIXES = ("_recall", "_precision", "_repetition", "_readability", "_total_score")
+
+
+def _is_score_col(col: str) -> bool:
+    return col.endswith(_SCORE_SUFFIXES)
+
+
+def _is_number(x: str | None) -> bool:
+    if x is None or x == "":
+        return False
+    try:
+        float(x)
+        return True
+    except ValueError:
+        return False
+
+
+def merge_scored(run_paths: list[Path], out_path: Path) -> None:
+    """Average per-question scores across replicate scored CSVs into one CSV.
+
+    Numeric columns are averaged per question_id; text columns are copied from the
+    first replicate. For judge-criterion columns (recall/precision/repetition/
+    readability/total_score, both baseline_* and togomcp_*) a 0 is the failed-judge
+    sentinel add_llm_evaluation writes on a crashed call (real totals are 4–20), so
+    zeros are treated as missing in the average — a score is 0 only when EVERY
+    replicate failed. This matches ablation_analysis.load_scores, so the averaged
+    CSV feeds that tool unchanged. Other numerics (``*_success`` flags, tokens,
+    cost) average normally, zeros included. An ``n_runs`` column records how many
+    replicates contributed to each row.
+    """
+    present = [p for p in run_paths if p.exists()]
+    if not present:
+        raise SystemExit(f"merge: no replicate scored CSVs exist for {out_path.name}")
+
+    fieldnames: list[str] = []
+    order: list[str] = []
+    rows_by_qid: dict[str, list[dict]] = {}
+    for p in present:
+        with p.open(encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            if not fieldnames:
+                fieldnames = list(reader.fieldnames or [])
+            for row in reader:
+                qid = row.get("question_id")
+                if not qid:
+                    continue
+                if qid not in rows_by_qid:
+                    order.append(qid)
+                rows_by_qid.setdefault(qid, []).append(row)
+
+    # A column is numeric only if every non-blank value across all replicates parses
+    # as a float (so free-text answer columns are never averaged).
+    numeric_cols = []
+    for col in fieldnames:
+        seen_any = False
+        all_num = True
+        for rows in rows_by_qid.values():
+            for row in rows:
+                v = row.get(col, "")
+                if v in (None, ""):
+                    continue
+                seen_any = True
+                if not _is_number(v):
+                    all_num = False
+                    break
+            if not all_num:
+                break
+        if seen_any and all_num:
+            numeric_cols.append(col)
+
+    merged = []
+    for qid in order:
+        rows = rows_by_qid[qid]
+        rec = dict(rows[0])
+        rec["n_runs"] = len(rows)
+        for col in numeric_cols:
+            nums = [float(row[col]) for row in rows if _is_number(row.get(col, ""))]
+            if _is_score_col(col):
+                nz = [v for v in nums if v != 0]  # drop failed-judge sentinels
+                rec[col] = f"{mean(nz):.4g}" if nz else "0"
+            else:
+                rec[col] = f"{mean(nums):.6g}" if nums else ""
+        merged.append(rec)
+
+    out_fields = list(fieldnames)
+    if "n_runs" not in out_fields:
+        out_fields.append("n_runs")
+    with out_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=out_fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(merged)
+
+
 def _server_log_tail(log_path: Path, n: int = 15) -> str:
     try:
         lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -140,10 +246,9 @@ def _server_log_tail(log_path: Path, n: int = 15) -> str:
 
 def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
                   model: str, judge_model: str | None, force: bool, dry_run: bool,
-                  python: str) -> str:
-    scored = RESULTS_DIR / f"{cond}-scored.csv"
-    answers = RESULTS_DIR / f"{cond}-answers.csv"
-    if scored.exists() and not force:
+                  python: str, runs: int = 1) -> str:
+    final_scored = RESULTS_DIR / f"{cond}-scored.csv"
+    if final_scored.exists() and not force:
         print(f"[{cond}] scored CSV exists — skipping (delete it or --force to re-run)")
         return "skipped"
 
@@ -158,49 +263,88 @@ def run_condition(cond: str, questions: list[str], base_config: Path, port: int,
     env["TOGOMCP_MIE_DIR"] = str(variant_dir)
     env["ABLATION_PORT"] = str(port)
 
-    print(f"[{cond}] booting local server on :{port} (MIE={variant_dir.name})")
-    server_log = RESULTS_DIR / f"{cond}-server.log"
-    log_fh = server_log.open("w", encoding="utf-8")
-    server = subprocess.Popen(
-        [python, str(HERE / "_serve.py")], env=env,
-        stdout=log_fh, stderr=subprocess.STDOUT,
-    )
-    try:
-        if not wait_ready(port, server):
-            died = server.poll() is not None
-            why = "server process exited during startup" if died else f"timed out on :{port}"
-            raise SystemExit(
-                f"[{cond}] server failed to become ready ({why}). Last server output:\n"
-                f"{_server_log_tail(server_log)}\n"
-                f"  (full log: {server_log})"
-            )
-        if dry_run:
-            print(f"[{cond}] DRY-RUN: server ready; would run runner over "
-                  f"{len(questions)} questions with config {cfg_path.name}")
-            return "dry-run"
-        print(f"[{cond}] running benchmark over {len(questions)} questions (model={model})")
-        subprocess.run(
-            [python, str(RUNNER), *questions,
-             "-c", str(cfg_path), "--model", model, "-o", str(answers)],
-            check=True, cwd=str(SCRIPTS_DIR),
-        )
-    finally:
-        log_fh.close()
-        server.terminate()
-        try:
-            server.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            server.kill()
-            server.wait()
-        print(f"[{cond}] server stopped")
+    # runs==1 keeps the flat <cond>-answers/scored.csv names (backward compatible);
+    # runs>1 writes -vR replicates and averages them into the flat <cond>-scored.csv.
+    def run_paths(r: int) -> tuple[Path, Path]:
+        if runs == 1:
+            return (RESULTS_DIR / f"{cond}-answers.csv",
+                    RESULTS_DIR / f"{cond}-scored.csv")
+        return (RESULTS_DIR / f"{cond}-answers-v{r}.csv",
+                RESULTS_DIR / f"{cond}-scored-v{r}.csv")
 
-    print(f"[{cond}] LLM-judging answers -> {scored.name}")
-    eval_cmd = [python, str(EVALUATOR), str(answers), "-o", str(scored)]
-    if judge_model:
-        eval_cmd += ["--model", judge_model]
-    # Evaluator inherits the env: the Claude judge (add_llm_evaluation.py default)
-    # authenticates via `claude login`, same as the runner. Do not inject a key.
-    subprocess.run(eval_cmd, check=True, cwd=str(SCRIPTS_DIR))
+    plan = []
+    for r in range(1, runs + 1):
+        answers, scored = run_paths(r)
+        done = scored.exists() and not force          # this replicate already judged
+        need_answer = (not done) and (force or not answers.exists())
+        plan.append({"r": r, "answers": answers, "scored": scored,
+                     "done": done, "need_answer": need_answer})
+
+    # --- answering passes: one server boot serves every run that needs answers ---
+    if any(p["need_answer"] for p in plan):
+        print(f"[{cond}] booting local server on :{port} (MIE={variant_dir.name})")
+        server_log = RESULTS_DIR / f"{cond}-server.log"
+        log_fh = server_log.open("w", encoding="utf-8")
+        server = subprocess.Popen(
+            [python, str(HERE / "_serve.py")], env=env,
+            stdout=log_fh, stderr=subprocess.STDOUT,
+        )
+        try:
+            if not wait_ready(port, server):
+                died = server.poll() is not None
+                why = "server process exited during startup" if died else f"timed out on :{port}"
+                raise SystemExit(
+                    f"[{cond}] server failed to become ready ({why}). Last server output:\n"
+                    f"{_server_log_tail(server_log)}\n"
+                    f"  (full log: {server_log})"
+                )
+            if dry_run:
+                print(f"[{cond}] DRY-RUN: server ready; would run {runs} pass(es) over "
+                      f"{len(questions)} questions with config {cfg_path.name}")
+                return "dry-run"
+            for p in plan:
+                if not p["need_answer"]:
+                    continue
+                tag = "" if runs == 1 else f" (run {p['r']}/{runs})"
+                print(f"[{cond}] running benchmark over {len(questions)} questions"
+                      f"{tag} (model={model})")
+                subprocess.run(
+                    [python, str(RUNNER), *questions,
+                     "-c", str(cfg_path), "--model", model, "-o", str(p["answers"])],
+                    check=True, cwd=str(SCRIPTS_DIR),
+                )
+        finally:
+            log_fh.close()
+            server.terminate()
+            try:
+                server.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                server.wait()
+            print(f"[{cond}] server stopped")
+    elif dry_run:
+        # every replicate already answered — honor the dry-run contract without a boot
+        print(f"[{cond}] DRY-RUN: all {runs} run(s) already answered; nothing to do")
+        return "dry-run"
+
+    # --- judging passes (no server needed) ---
+    for p in plan:
+        if p["done"]:
+            print(f"[{cond}] run {p['r']} scored CSV exists — skipping judge")
+            continue
+        tag = "" if runs == 1 else f" (run {p['r']}/{runs})"
+        print(f"[{cond}] LLM-judging answers{tag} -> {p['scored'].name}")
+        eval_cmd = [python, str(EVALUATOR), str(p["answers"]), "-o", str(p["scored"])]
+        if judge_model:
+            eval_cmd += ["--model", judge_model]
+        # Evaluator inherits the env: the Claude judge (add_llm_evaluation.py default)
+        # authenticates via `claude login`, same as the runner. Do not inject a key.
+        subprocess.run(eval_cmd, check=True, cwd=str(SCRIPTS_DIR))
+
+    # --- average replicates into the flat scored CSV ablation_analysis.py reads ---
+    if runs > 1:
+        merge_scored([p["scored"] for p in plan], final_scored)
+        print(f"[{cond}] averaged {runs} run(s) -> {final_scored.name}")
     return "done"
 
 
@@ -216,6 +360,11 @@ def main() -> int:
     ap.add_argument("--model", default=DEFAULT_MODEL, help="answering model")
     ap.add_argument("--judge-model", default=None,
                     help="LLM-judge model (default: add_llm_evaluation.py's own default)")
+    ap.add_argument("--runs", type=int, default=1, metavar="N",
+                    help="answer+judge each question N times per condition and average "
+                         "per question (default 1). Replicates land in <cond>-scored-vN.csv; "
+                         "the averaged <cond>-scored.csv feeds ablation_analysis.py. "
+                         "Averaging R runs divides judge-jitter variance by R.")
     ap.add_argument("--port", type=int, default=8971, help="loopback port for the local server")
     ap.add_argument("--python", default=sys.executable,
                     help="interpreter for the server + benchmark subprocesses "
@@ -231,6 +380,9 @@ def main() -> int:
     for tool in (RUNNER, EVALUATOR):
         if not tool.exists():
             raise SystemExit(f"missing dependency script: {tool}")
+
+    if args.runs < 1:
+        raise SystemExit(f"--runs must be >= 1 (got {args.runs})")
 
     conditions = [c.strip() for c in args.conditions.split(",") if c.strip()]
     unknown = [c for c in conditions if c not in ALL_CONDITIONS]
@@ -250,7 +402,8 @@ def main() -> int:
             required.update(BENCH_IMPORTS)
         preflight(args.python, required)
 
-    print(f"Ablation sweep: {len(conditions)} conditions x {len(questions)} questions")
+    runs_note = f" x {args.runs} runs" if args.runs > 1 else ""
+    print(f"Ablation sweep: {len(conditions)} conditions x {len(questions)} questions{runs_note}")
     print(f"  model={args.model}  judge={args.judge_model or '(eval default)'}  "
           f"port={args.port}  python={args.python}\n")
 
@@ -260,7 +413,7 @@ def main() -> int:
         try:
             summary[cond] = run_condition(cond, questions, base_config, args.port,
                                           args.model, args.judge_model, args.force,
-                                          args.dry_run, args.python)
+                                          args.dry_run, args.python, args.runs)
         except SystemExit as e:
             print(f"[{cond}] ABORTED: {e}", file=sys.stderr)
             summary[cond] = "error"

--- a/benchmark/ablation/select_pilot.py
+++ b/benchmark/ablation/select_pilot.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Select a DB-spanning pilot subset of benchmark questions for the ablation sweep.
 
-The full set is presently 75 questions (15 per type), on a planned path to 100
-(20 per type), touching 30+ distinct RDF databases. Running every question across
+The full set is presently 100 questions (20 per type), touching 34 distinct
+RDF databases. Running every question across
 12 ablation conditions is expensive, so the pilot picks a subset that still
 exercises as many databases and question types as possible —
 the ablation signal for a section is only visible on questions whose target DB
@@ -13,15 +13,26 @@ adds the most not-yet-covered databases, breaking ties toward under-represented
 question types then question id. It stops once every database is covered and at
 least --min questions are chosen (capped at --max).
 
-Variance control (why the default target is ~40, not 15)
---------------------------------------------------------
-A paired ablation delta (baseline − ablated) is dominated by two variance
-sources: judge jitter and *ceiling/floor* questions. A question whose with-tools
-baseline is already 20/20 can only move DOWN under any ablation, and one scoring
-very low bounces UP under almost any ablation — both inflate the delta SD without
-carrying real section signal (see benchmark/ablation/README power analysis: two
-such questions doubled the SD and ~doubled the required n). This script drops
-them up front where a prior baseline score is available.
+Variance control & how many questions are enough
+-------------------------------------------------
+A paired ablation delta (baseline − ablated) on the 0–20 judge score is noisy.
+Two things inflate its SD without carrying section signal: judge jitter (the same
+answer rescored varies run-to-run) and *ceiling/floor* questions — a with-tools
+baseline already at 20/20 can only move DOWN under any ablation, and one scoring
+very low bounces UP under almost any ablation. This script drops the ceiling/floor
+questions up front where a prior baseline score is available (only ~2 exist in the
+data so far).
+
+"Enough" is an effect-size question, not a fixed count. On the only sweep run to
+date (15 questions, ONE answer + ONE judge each) the paired-delta SD is ~4.5–5
+points even after the ceiling/floor drop; at that SD a paired t-test (α=.05, 80%
+power) needs n≈60–150 to resolve the ~1-point effects most sections show, and
+n=40 resolves only ~2-point effects. So ~40 is a coverage/type-balance target,
+NOT a proven significance threshold — treat single-shot contributions as
+directional. The lever that makes 40 adequate is REPLICATION, not more questions:
+`run_ablation.py --runs R` averages R runs per question, dividing the judge-jitter
+part of the variance by R (we can't yet separate judge jitter from true
+question-to-question heterogeneity — that needs replicate data).
 
 Important limitation: baselines only exist for questions already run through a
 sweep (results/baseline-scored.csv). Questions never scored yet CANNOT be
@@ -31,7 +42,7 @@ the same ceiling/floor cut post-sweep with:
 so the averaged set lands in the low-variance regime regardless.
 
 Usage:
-    python select_pilot.py                 # ~40 Qs, ceiling/floor pre-filtered
+    python select_pilot.py                 # 40 Qs, ceiling/floor pre-filtered
     python select_pilot.py --min 36 --max 40
     python select_pilot.py --no-score-filter   # coverage only, keep all Qs
     python select_pilot.py --full          # emit all questions (full sweep)
@@ -137,7 +148,9 @@ def main() -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--questions-dir", default=str(DEFAULT_QDIR))
     ap.add_argument("--out", default=str(DEFAULT_OUT))
-    ap.add_argument("--min", type=int, default=36, help="minimum pilot size (power target ~40)")
+    ap.add_argument("--min", type=int, default=40,
+                    help="minimum pilot size (coverage/balance target; NOT a power "
+                         "guarantee — see module docstring on replication)")
     ap.add_argument("--max", type=int, default=40, help="maximum pilot size")
     ap.add_argument("--full", action="store_true", help="emit all questions, not a subset")
     ap.add_argument("--baseline-scores", default=str(DEFAULT_BASELINE),

--- a/benchmark/conditions/README.md
+++ b/benchmark/conditions/README.md
@@ -43,7 +43,7 @@ API-billed Claude judge, run `add_llm_evaluation.py --use-api` directly with
 cd benchmark/conditions
 VENV=/Users/arkinjo/work/GitHub/togomcp/.venv/bin/python
 
-# Full sweep, one Opus judge (all questions — 75 today):
+# Full sweep, one Opus judge (all questions — 100 today):
 python run_conditions.py --python "$VENV" --model claude-sonnet-5
 
 # Multiple judges (Opus + a local Gemma), compared side by side:
@@ -97,5 +97,5 @@ folder. With no `--date`/`--model` it analyzes the newest run; give `--date` (an
   ```bash
   python3 -c "import csv;r=list(csv.DictReader(open('results/<DATE>/<MODEL>/no_mie-answers.csv')));print('LEAK' if any('get_MIE_file' in x['tools_used'] for x in r) else 'clean')"
   ```
-- This is a multi-hour sequential run (all questions — 75 today — × conditions × judges).
+- This is a multi-hour sequential run (all questions — 100 today — × conditions × judges).
   Run under `tmux`/`nohup`; resume via re-run.

--- a/benchmark/scripts/add_llm_evaluation.py
+++ b/benchmark/scripts/add_llm_evaluation.py
@@ -190,6 +190,14 @@ EVAL_TOOL = {
 JUDGE_MAX_ATTEMPTS = 3
 JUDGE_RETRY_BACKOFF = 1.0  # seconds; multiplied by the attempt number
 
+# Abort the whole run after this many CONSECUTIVE rows fail evaluation outright
+# (judge returned nothing parseable even after JUDGE_MAX_ATTEMPTS retries). A lone
+# failed row is tolerated (transient/odd answer), but a sustained streak means the
+# judge is systemically down — throttled subscription, dead host, refusing model —
+# and every remaining row would silently score 0. Better to stop loudly (like
+# FatalJudgeError) than complete a run of all-zeros. Reset on the first success.
+ABORT_AFTER_CONSECUTIVE_FAILURES = 3
+
 
 def _failed_eval(reason: str, explanation: str) -> Dict[str, Any]:
     """Zero-score result used for un-evaluable or failed rows. A total_score of
@@ -507,6 +515,7 @@ class AnswerEvaluator:
     def __init__(self, backend: JudgeBackend):
         self.backend = backend
         self.model = backend.model
+        self._consecutive_failures = 0   # streak of rows the judge couldn't score
         print(f"Initializing {backend.provider} evaluator with model: {backend.model}")
 
     @property
@@ -563,7 +572,22 @@ class AnswerEvaluator:
                 time.sleep(JUDGE_RETRY_BACKOFF * attempt)
 
         if parsed is None:
+            # This row could not be scored after every retry. Track the streak: a
+            # lone failure is per-row (recorded as a 0-sentinel the analyzer drops),
+            # but a sustained run of them means the judge is systemically down and
+            # every remaining row would silently score 0 — abort loudly instead.
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= ABORT_AFTER_CONSECUTIVE_FAILURES:
+                raise FatalJudgeError(
+                    f"Judge failed {self._consecutive_failures} rows in a row "
+                    f"(last: {reason}). The judge is likely rate-limited/throttled, its "
+                    "host is down, or the model is refusing — aborting so the run does not "
+                    "complete as all-zeros. Wait and re-run, reduce concurrent Claude usage, "
+                    "or switch judge (e.g. --use-api with ANTHROPIC_API_KEY, or --provider ollama)."
+                )
             return _failed_eval(reason, explanation)
+
+        self._consecutive_failures = 0   # a good score breaks the failure streak
 
         clamp = lambda v: min(5, max(1, int(v)))
         recall = clamp(parsed.recall)

--- a/benchmark/scripts/verify_questions.py
+++ b/benchmark/scripts/verify_questions.py
@@ -703,11 +703,11 @@ def verify_questions(targets=None):
     print(f"{'=' * 70}")
     print(f"\nTotal Questions: {total_questions}")
 
-    if total_questions >= 50:
-        print(f"  ✓ PASS: 50-question target met")
+    if total_questions >= 100:
+        print(f"  ✓ PASS: 100-question target met")
     else:
-        pct = total_questions / 50 * 100
-        print(f"  ⚠  PROGRESS: {total_questions}/50 ({pct:.0f}%)")
+        pct = total_questions / 100 * 100
+        print(f"  ⚠  PROGRESS: {total_questions}/100 ({pct:.0f}%)")
 
     # -- Type distribution (scales with set size; balanced band ±2) --------
     # Target is total/5 (5 types), not a hard-coded 10, so the check stays

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -10,6 +10,7 @@ import togo_mcp.api_tools as api_tools
 from togo_mcp.api_tools import (
     _UNIPROT_ACCESSION_RE,
     _bif_and,
+    _bif_longest_token,
     _looks_like_structure,
     _resolve_query_alias,
     _sparql_literal,
@@ -135,6 +136,18 @@ class TestBifAnd:
     def test_tokenize(self, text: str, expected: str | None) -> None:
         assert _bif_and(text) == expected
 
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("BSYNRYMUTXBXSQ-UHFFFAOYSA-N", "'bsynrymutxbxsq'"),  # longest block
+            ("InChI=1S/C9H8O4/c1-6", "'c9h8o4'"),  # longest token (6 > 'inchi'=5)
+            ("egfr", "'egfr'"),
+            ("---", None),
+        ],
+    )
+    def test_longest_token(self, text: str, expected: str | None) -> None:
+        assert _bif_longest_token(text) == expected
+
 
 class TestSparqlLiteral:
     """_sparql_literal escapes for a double-quoted SPARQL string literal."""
@@ -216,7 +229,9 @@ class TestSearchChemblMolecule:
         }
 
     @pytest.mark.asyncio
-    async def test_structure_uses_rest_not_sparql(self) -> None:
+    async def test_smiles_uses_rest_flexmatch_not_sparql(self) -> None:
+        # SMILES is toolkit-specific → REST flexmatch (chemistry engine), not
+        # an exact SPARQL string match that would miss most real inputs.
         body = {
             "page_meta": {"total_count": 3},
             "molecules": [{"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"}],
@@ -231,6 +246,42 @@ class TestSearchChemblMolecule:
             result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O", limit=5)
         assert rest.called and not sparql.called
         assert "canonical_smiles__flexmatch" in str(rest.calls[0].request.url)
+        assert result["results"][0]["chembl_id"] == "CHEMBL25"
+
+    @pytest.mark.asyncio
+    async def test_inchikey_resolves_via_sparql(self) -> None:
+        # InChIKey is canonical → exact, CASE-SENSITIVE SPARQL match; no REST.
+        with respx.mock(using="httpx", assert_all_called=False) as router:
+            sparql = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL25,ASPIRIN")
+                )
+            )
+            rest = router.get("https://www.ebi.ac.uk/chembl/api/data/molecule.json")
+            result = await search_chembl_molecule("BSYNRYMUTXBXSQ-UHFFFAOYSA-N")
+        assert sparql.called and not rest.called
+        sent = _sent_query(sparql)
+        assert "CHEMINF_000059" in sent  # InChIKey value-node type
+        assert 'FILTER(STR(?v) = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N")' in sent  # case-sensitive
+        assert "LCASE" not in sent
+        assert "'bsynrymutxbxsq'" in sent  # longest-token prefilter (lowercased)
+        assert result["results"][0]["chembl_id"] == "CHEMBL25"
+
+    @pytest.mark.asyncio
+    async def test_inchi_resolves_via_sparql(self) -> None:
+        inchi = "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)"
+        with respx.mock(using="httpx", assert_all_called=False) as router:
+            sparql = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL25,ASPIRIN")
+                )
+            )
+            rest = router.get("https://www.ebi.ac.uk/chembl/api/data/molecule.json")
+            result = await search_chembl_molecule(inchi)
+        assert sparql.called and not rest.called
+        sent = _sent_query(sparql)
+        assert "CHEMINF_000113" in sent  # InChI value-node type
+        assert f'FILTER(STR(?v) = "{inchi}")' in sent
         assert result["results"][0]["chembl_id"] == "CHEMBL25"
 
     @pytest.mark.asyncio

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -6,8 +6,11 @@ import httpx
 import pytest
 import respx
 
+import togo_mcp.api_tools as api_tools
 from togo_mcp.api_tools import (
+    _looks_like_structure,
     _resolve_query_alias,
+    _strip_html,
     search_chembl_id_lookup,
     search_chembl_molecule,
     search_chembl_target,
@@ -16,6 +19,12 @@ from togo_mcp.api_tools import (
     search_rhea_entity,
     search_uniprot_entity,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_chembl_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero the ChEMBL retry backoff so the retry-then-error tests don't sleep."""
+    monkeypatch.setattr(api_tools, "_CHEMBL_BACKOFF_BASE", 0.0)
 
 
 class TestResolveQueryAlias:
@@ -150,6 +159,201 @@ class TestSearchChemblTarget:
             result = await search_chembl_id_lookup("CHEMBL25")
         assert "error" in result
         assert "total_count" not in result
+
+
+class TestChemblStructureDetection:
+    """_looks_like_structure classifies structure-shaped queries and — crucially
+    — does NOT misclassify drug names / IDs / accessions (a false positive would
+    misroute a real name to the structure endpoint and return nothing)."""
+
+    @pytest.mark.parametrize(
+        "query, expected",
+        [
+            ("CC(=O)Oc1ccccc1C(=O)O", "smiles"),  # aspirin SMILES
+            ("BSYNRYMUTXBXSQ-UHFFFAOYSA-N", "inchikey"),
+            ("InChI=1S/C9H8O4/c1-6(10)13", "inchi"),
+            ("aspirin", None),
+            ("Dopamine receptor", None),  # multi-word name
+            ("EGFR", None),
+            ("CHEMBL25", None),
+            ("P00533", None),  # UniProt accession
+            ("Gleevec", None),
+            ("CCO", None),  # bare-chain SMILES — accepted trade-off, treated as name
+            ("", None),
+        ],
+    )
+    def test_classification(self, query: str, expected: str | None) -> None:
+        assert _looks_like_structure(query) == expected
+
+
+class TestChemblStructureRouting:
+    """search_chembl_molecule routes structure-shaped input to /molecule.json and
+    plain names to /molecule/search.json — parsed into one shared shape."""
+
+    @pytest.mark.asyncio
+    async def test_smiles_routed_to_structure_endpoint(self) -> None:
+        body = {
+            "page_meta": {"total_count": 3},
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"},
+            ],
+        }
+        with respx.mock(using="httpx") as router:
+            route = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
+            ).mock(return_value=httpx.Response(200, json=body))
+            result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O", limit=5)
+        assert route.called
+        # flexmatch structure filter is present, NOT a lexical q= param.
+        sent = str(route.calls[0].request.url)
+        assert "canonical_smiles__flexmatch" in sent
+        assert result["results"][0]["chembl_id"] == "CHEMBL25"
+
+    @pytest.mark.asyncio
+    async def test_name_routed_to_lexical_endpoint(self) -> None:
+        body = {
+            "page_meta": {"total_count": 1},
+            "molecules": [{"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"}],
+        }
+        with respx.mock(using="httpx") as router:
+            lexical = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/molecule/search.json"
+            ).mock(return_value=httpx.Response(200, json=body))
+            result = await search_chembl_molecule("aspirin", limit=5)
+        assert lexical.called
+        assert result["results"][0]["chembl_id"] == "CHEMBL25"
+
+
+class TestChemblIdLookupFields:
+    """id_lookup returns status/resource_url (no name field exists upstream) and
+    supports an entity_type passthrough."""
+
+    @pytest.mark.asyncio
+    async def test_status_and_resource_url_returned(self) -> None:
+        body = {
+            "page_meta": {"total_count": 1},
+            "chembl_id_lookups": [
+                {
+                    "chembl_id": "CHEMBL203",
+                    "entity_type": "TARGET",
+                    "status": "ACTIVE",
+                    "resource_url": "/chembl/api/data/target/CHEMBL203",
+                    "score": 30.0,
+                }
+            ],
+        }
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
+            ).mock(return_value=httpx.Response(200, json=body))
+            result = await search_chembl_id_lookup("EGFR", limit=5)
+        row = result["results"][0]
+        assert row["status"] == "ACTIVE"
+        assert row["resource_url"] == "/chembl/api/data/target/CHEMBL203"
+
+    @pytest.mark.asyncio
+    async def test_entity_type_forwarded(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
+            ).mock(
+                return_value=httpx.Response(
+                    200, json={"page_meta": {"total_count": 0}, "chembl_id_lookups": []}
+                )
+            )
+            await search_chembl_id_lookup("EGFR", entity_type="target")
+        assert "entity_type=TARGET" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    async def test_invalid_entity_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid entity_type"):
+            await search_chembl_id_lookup("EGFR", entity_type="PROTEIN")
+
+
+class TestChemblTargetFloorAndOrganism:
+    """target enforces a limit floor of 10 (the intended hit sits at rank ~5–6)
+    and supports a post-fetch organism filter."""
+
+    @pytest.mark.asyncio
+    async def test_limit_below_ten_raised_to_floor(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(
+                return_value=httpx.Response(
+                    200, json={"page_meta": {"total_count": 0}, "targets": []}
+                )
+            )
+            await search_chembl_target("EGFR", limit=3)
+        assert "limit=10" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    async def test_organism_filter_applied_post_fetch(self) -> None:
+        body = {
+            "page_meta": {"total_count": 2},
+            "targets": [
+                {"target_chembl_id": "CHEMBL203", "organism": "Homo sapiens"},
+                {"target_chembl_id": "CHEMBL3608", "organism": "Mus musculus"},
+            ],
+        }
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(return_value=httpx.Response(200, json=body))
+            result = await search_chembl_target("EGFR", organism="Homo sapiens")
+        assert [r["chembl_id"] for r in result["results"]] == ["CHEMBL203"]
+        # total_count still reflects the full upstream match count, not the filtered page.
+        assert result["total_count"] == 2
+
+
+class TestChemblRetryAndErrorCleaning:
+    """_chembl_get_json retries transient 5xx, gives up on 4xx, and strips HTML
+    from error payloads."""
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self) -> None:
+        body = {"page_meta": {"total_count": 1}, "targets": []}
+        with respx.mock(using="httpx") as router:
+            route = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(
+                side_effect=[
+                    httpx.Response(500, text="<html>err</html>"),
+                    httpx.Response(200, json=body),
+                ]
+            )
+            result = await search_chembl_target("EGFR")
+        assert route.call_count == 2
+        assert result["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_4xx_not_retried(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(return_value=httpx.Response(404, text="<html>nope</html>"))
+            result = await search_chembl_target("EGFR")
+        assert route.call_count == 1  # terminal, no retry
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_error_body_is_html_free(self) -> None:
+        html = (
+            "<!doctype html><html><head><script>x=1</script>"
+            "<style>a{color:red}</style></head><body>500 Internal Error</body></html>"
+        )
+        with respx.mock(using="httpx") as router:
+            router.get(
+                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+            ).mock(return_value=httpx.Response(500, text=html))
+            result = await search_chembl_target("EGFR")
+        assert "<" not in result["error"] and ">" not in result["error"]
+        assert len(result["error"]) < 500
+
+    def test_strip_html_collapses_and_truncates(self) -> None:
+        html = "<div>  hello   <b>world</b> </div>"
+        assert _strip_html(html) == "hello world"
+        assert _strip_html("<p>" + "x" * 500 + "</p>", max_len=50).endswith("…")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -8,8 +8,11 @@ import respx
 
 import togo_mcp.api_tools as api_tools
 from togo_mcp.api_tools import (
+    _UNIPROT_ACCESSION_RE,
+    _bif_and,
     _looks_like_structure,
     _resolve_query_alias,
+    _sparql_literal,
     _strip_html,
     search_chembl_id_lookup,
     search_chembl_molecule,
@@ -19,6 +22,22 @@ from togo_mcp.api_tools import (
     search_rhea_entity,
     search_uniprot_entity,
 )
+
+# The RDF Portal SPARQL endpoint the ChEMBL tools now resolve names against.
+CHEMBL_SPARQL_URL = "https://rdfportal.org/ebi/sparql"
+
+
+def _csv(header: str, *rows: str) -> str:
+    """Build a SPARQL CSV response body (header line + data rows)."""
+    return "\n".join([header, *rows]) + ("\n" if rows else "")
+
+
+def _sent_query(route) -> str:
+    """Decode the SPARQL text from a captured form-encoded POST body."""
+    import urllib.parse
+
+    body = route.calls[0].request.content.decode()
+    return urllib.parse.parse_qs(body)["query"][0]
 
 
 @pytest.fixture(autouse=True)
@@ -94,71 +113,56 @@ class TestSearchUniprotEntity:
 # ---------------------------------------------------------------------------
 
 
-class TestSearchChemblTarget:
-    """Tests for search_chembl_target with mocked HTTP."""
+class TestBifAnd:
+    """_bif_and turns caller text into a robust bif:contains argument: each
+    alphanumeric token single-quoted, AND-joined. This survives what the raw
+    forms 500 on — bare numerics and punctuation."""
 
-    @pytest.mark.asyncio
-    async def test_basic_search(self) -> None:
-        """Successful ChEMBL target search returns parsed results."""
-        body = {
-            "page_meta": {"total_count": 1},
-            "targets": [
-                {
-                    "target_chembl_id": "CHEMBL203",
-                    "pref_name": "EGFR",
-                    "organism": "Homo sapiens",
-                    "target_type": "SINGLE PROTEIN",
-                    "score": 10.0,
-                }
-            ],
-        }
-        with respx.mock(using="httpx") as router:
-            router.get("https://www.ebi.ac.uk/chembl/api/data/target/search.json").mock(
-                return_value=httpx.Response(200, json=body)
-            )
-            result = await search_chembl_target("EGFR", limit=5)
-        assert result["total_count"] == 1
-        assert result["results"][0]["chembl_id"] == "CHEMBL203"
-        assert result["results"][0]["name"] == "EGFR"
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("egfr", "'egfr'"),
+            ("EGFR", "'egfr'"),  # lowercased
+            ("epidermal growth factor", "'epidermal' AND 'growth' AND 'factor'"),
+            ("5'-nucleotidase", "'5' AND 'nucleotidase'"),  # numeric + apostrophe
+            ("HER2/neu", "'her2' AND 'neu'"),  # slash
+            ("ar", "'ar'"),  # 2-char
+            ("", None),
+            ("---", None),  # pure punctuation → no token
+            ("   ", None),
+        ],
+    )
+    def test_tokenize(self, text: str, expected: str | None) -> None:
+        assert _bif_and(text) == expected
 
-    @pytest.mark.asyncio
-    async def test_http_error_propagates_error_key(self) -> None:
-        """An upstream failure must surface as {'error': ...}, NOT collapse into
-        an empty {'total_count': 0, 'results': []} that reads as 'no matches'.
 
-        Regression: previously the caller did bulk.get('targets', []) on the
-        error dict, swallowing the failure.
-        """
-        with respx.mock(using="httpx") as router:
-            router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
-            ).mock(return_value=httpx.Response(500, text="Server Error"))
-            result = await search_chembl_target("EGFR")
-        assert "error" in result
-        assert "ChEMBL REST API request failed" in result["error"]
-        assert "total_count" not in result
+class TestSparqlLiteral:
+    """_sparql_literal escapes for a double-quoted SPARQL string literal."""
 
-    @pytest.mark.asyncio
-    async def test_molecule_http_error_propagates_error_key(self) -> None:
-        """search_chembl_molecule propagates the upstream-failure payload."""
-        with respx.mock(using="httpx") as router:
-            router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/molecule/search.json"
-            ).mock(return_value=httpx.Response(500, text="Server Error"))
-            result = await search_chembl_molecule("aspirin")
-        assert "error" in result
-        assert "total_count" not in result
+    def test_escapes_quote_and_backslash(self) -> None:
+        assert _sparql_literal('a"b') == 'a\\"b'
+        assert _sparql_literal("a\\b") == "a\\\\b"
+        assert _sparql_literal("plain") == "plain"
 
-    @pytest.mark.asyncio
-    async def test_id_lookup_http_error_propagates_error_key(self) -> None:
-        """search_chembl_id_lookup propagates the upstream-failure payload."""
-        with respx.mock(using="httpx") as router:
-            router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
-            ).mock(return_value=httpx.Response(500, text="Server Error"))
-            result = await search_chembl_id_lookup("CHEMBL25")
-        assert "error" in result
-        assert "total_count" not in result
+
+class TestUniprotAccessionRegex:
+    """The accession regex routes target queries to the structured exactMatch
+    path; it must accept real accessions and reject symbols / names / IDs."""
+
+    @pytest.mark.parametrize(
+        "text, is_accession",
+        [
+            ("P00533", True),
+            ("Q9Y6K9", True),
+            ("A0A024R161", True),  # 10-char form
+            ("EGFR", False),
+            ("TP53", False),
+            ("CHEMBL25", False),
+            ("aspirin", False),
+        ],
+    )
+    def test_match(self, text: str, is_accession: bool) -> None:
+        assert bool(_UNIPROT_ACCESSION_RE.match(text.upper())) is is_accession
 
 
 class TestChemblStructureDetection:
@@ -186,154 +190,213 @@ class TestChemblStructureDetection:
         assert _looks_like_structure(query) == expected
 
 
-class TestChemblStructureRouting:
-    """search_chembl_molecule routes structure-shaped input to /molecule.json and
-    plain names to /molecule/search.json — parsed into one shared shape."""
+class TestSearchChemblMolecule:
+    """Molecule resolution: names go to SPARQL (exact altLabel); structure-shaped
+    input goes to the REST chemistry engine."""
 
     @pytest.mark.asyncio
-    async def test_smiles_routed_to_structure_endpoint(self) -> None:
+    async def test_name_resolves_via_sparql(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL941,IMATINIB")
+                )
+            )
+            result = await search_chembl_molecule("Gleevec")
+        assert route.called
+        sent = _sent_query(route)
+        assert "skos:altLabel" in sent and "bif:contains" in sent
+        assert "'gleevec'" in sent  # normalized bif token
+        assert 'FILTER(LCASE(STR(?alt)) = "gleevec")' in sent  # exactness
+        assert result["total_count"] == 1
+        assert result["results"][0] == {
+            "chembl_id": "CHEMBL941",
+            "name": "IMATINIB",
+            "score": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_structure_uses_rest_not_sparql(self) -> None:
         body = {
             "page_meta": {"total_count": 3},
-            "molecules": [
-                {"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"},
-            ],
+            "molecules": [{"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"}],
         }
-        with respx.mock(using="httpx") as router:
-            route = router.get(
+        with respx.mock(using="httpx", assert_all_called=False) as router:
+            rest = router.get(
                 "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
             ).mock(return_value=httpx.Response(200, json=body))
+            sparql = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(200, text=_csv("chembl_id,name"))
+            )
             result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O", limit=5)
-        assert route.called
-        # flexmatch structure filter is present, NOT a lexical q= param.
-        sent = str(route.calls[0].request.url)
-        assert "canonical_smiles__flexmatch" in sent
+        assert rest.called and not sparql.called
+        assert "canonical_smiles__flexmatch" in str(rest.calls[0].request.url)
         assert result["results"][0]["chembl_id"] == "CHEMBL25"
 
     @pytest.mark.asyncio
-    async def test_name_routed_to_lexical_endpoint(self) -> None:
+    async def test_sparql_failure_returns_error_key(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(500, text="boom")
+            )
+            result = await search_chembl_molecule("aspirin")
+        assert "error" in result and "total_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_untokenizable_query_returns_empty(self) -> None:
+        # Pure punctuation → no bif token → empty, without hitting the endpoint.
+        with respx.mock(using="httpx", assert_all_called=False) as router:
+            route = router.post(CHEMBL_SPARQL_URL)
+            result = await search_chembl_molecule("---")
+        assert not route.called
+        assert result == {"total_count": 0, "results": []}
+
+
+class TestSearchChemblTarget:
+    """Target resolution: UniProt accession → structured skos:exactMatch; gene
+    symbol / protein name → exact altLabel; both via SPARQL, no ranking."""
+
+    @pytest.mark.asyncio
+    async def test_accession_uses_exactmatch(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,name,organism,type",
+                        "CHEMBL203,Epidermal growth factor receptor,Homo sapiens,SINGLE PROTEIN",
+                    ),
+                )
+            )
+            result = await search_chembl_target("P00533", target_type="SINGLE PROTEIN")
+        sent = _sent_query(route)
+        assert "skos:exactMatch <http://purl.uniprot.org/uniprot/P00533>" in sent
+        assert "bif:contains" not in sent  # accession path skips text search
+        assert 'FILTER(LCASE(STR(?type)) = "single protein")' in sent
+        assert result["results"][0] == {
+            "chembl_id": "CHEMBL203",
+            "name": "Epidermal growth factor receptor",
+            "organism": "Homo sapiens",
+            "type": "SINGLE PROTEIN",
+            "score": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_symbol_uses_altlabel(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,name,organism,type",
+                        "CHEMBL203,Epidermal growth factor receptor,Homo sapiens,SINGLE PROTEIN",
+                    ),
+                )
+            )
+            result = await search_chembl_target("EGFR", organism="Homo sapiens")
+        sent = _sent_query(route)
+        assert "skos:altLabel" in sent and "'egfr'" in sent
+        assert 'FILTER(LCASE(STR(?alt)) = "egfr")' in sent
+        assert 'CONTAINS(LCASE(STR(?organism)), "homo sapiens")' in sent
+        assert result["results"][0]["chembl_id"] == "CHEMBL203"
+
+    @pytest.mark.asyncio
+    async def test_empty_organism_cell_becomes_none(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,name,organism,type",
+                        "CHEMBL999,Some target,,SINGLE PROTEIN",
+                    ),
+                )
+            )
+            result = await search_chembl_target("Something")
+        assert result["results"][0]["organism"] is None
+
+    @pytest.mark.asyncio
+    async def test_sparql_failure_returns_error_key(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(500, text="boom")
+            )
+            result = await search_chembl_target("EGFR")
+        assert "error" in result and "total_count" not in result
+
+
+class TestSearchChemblIdLookup:
+    """Cross-entity resolution: UNION over compound + target branches, each an
+    exact altLabel match; entity_type narrows to one branch."""
+
+    @pytest.mark.asyncio
+    async def test_default_unions_both(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,entity_type,name",
+                        "CHEMBL203,TARGET,Epidermal growth factor receptor",
+                    ),
+                )
+            )
+            result = await search_chembl_id_lookup("EGFR")
+        sent = _sent_query(route)
+        assert "UNION" in sent
+        assert "cco:SmallMolecule" in sent and "cco:hasTargetComponent" in sent
+        assert result["results"][0]["entity_type"] == "TARGET"
+
+    @pytest.mark.asyncio
+    async def test_entity_type_compound_single_branch(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,entity_type,name")
+                )
+            )
+            await search_chembl_id_lookup("aspirin", entity_type="compound")
+        sent = _sent_query(route)
+        assert "UNION" not in sent
+        assert "cco:SmallMolecule" in sent and "cco:hasTargetComponent" not in sent
+
+    @pytest.mark.asyncio
+    async def test_invalid_entity_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid entity_type"):
+            await search_chembl_id_lookup("EGFR", entity_type="ASSAY")
+
+
+class TestChemblStructureRetryAndErrorCleaning:
+    """The REST structure path keeps the retry/HTML-strip plumbing (EBI is flaky).
+    Reached via a structure-shaped molecule query hitting /molecule.json."""
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self) -> None:
         body = {
             "page_meta": {"total_count": 1},
             "molecules": [{"molecule_chembl_id": "CHEMBL25", "pref_name": "ASPIRIN"}],
         }
         with respx.mock(using="httpx") as router:
-            lexical = router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/molecule/search.json"
-            ).mock(return_value=httpx.Response(200, json=body))
-            result = await search_chembl_molecule("aspirin", limit=5)
-        assert lexical.called
-        assert result["results"][0]["chembl_id"] == "CHEMBL25"
-
-
-class TestChemblIdLookupFields:
-    """id_lookup returns status/resource_url (no name field exists upstream) and
-    supports an entity_type passthrough."""
-
-    @pytest.mark.asyncio
-    async def test_status_and_resource_url_returned(self) -> None:
-        body = {
-            "page_meta": {"total_count": 1},
-            "chembl_id_lookups": [
-                {
-                    "chembl_id": "CHEMBL203",
-                    "entity_type": "TARGET",
-                    "status": "ACTIVE",
-                    "resource_url": "/chembl/api/data/target/CHEMBL203",
-                    "score": 30.0,
-                }
-            ],
-        }
-        with respx.mock(using="httpx") as router:
-            router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
-            ).mock(return_value=httpx.Response(200, json=body))
-            result = await search_chembl_id_lookup("EGFR", limit=5)
-        row = result["results"][0]
-        assert row["status"] == "ACTIVE"
-        assert row["resource_url"] == "/chembl/api/data/target/CHEMBL203"
-
-    @pytest.mark.asyncio
-    async def test_entity_type_forwarded(self) -> None:
-        with respx.mock(using="httpx") as router:
             route = router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/chembl_id_lookup/search.json"
-            ).mock(
-                return_value=httpx.Response(
-                    200, json={"page_meta": {"total_count": 0}, "chembl_id_lookups": []}
-                )
-            )
-            await search_chembl_id_lookup("EGFR", entity_type="target")
-        assert "entity_type=TARGET" in str(route.calls[0].request.url)
-
-    @pytest.mark.asyncio
-    async def test_invalid_entity_type_raises(self) -> None:
-        with pytest.raises(ValueError, match="Invalid entity_type"):
-            await search_chembl_id_lookup("EGFR", entity_type="PROTEIN")
-
-
-class TestChemblTargetFloorAndOrganism:
-    """target enforces a limit floor of 10 (the intended hit sits at rank ~5–6)
-    and supports a post-fetch organism filter."""
-
-    @pytest.mark.asyncio
-    async def test_limit_below_ten_raised_to_floor(self) -> None:
-        with respx.mock(using="httpx") as router:
-            route = router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
-            ).mock(
-                return_value=httpx.Response(
-                    200, json={"page_meta": {"total_count": 0}, "targets": []}
-                )
-            )
-            await search_chembl_target("EGFR", limit=3)
-        assert "limit=10" in str(route.calls[0].request.url)
-
-    @pytest.mark.asyncio
-    async def test_organism_filter_applied_post_fetch(self) -> None:
-        body = {
-            "page_meta": {"total_count": 2},
-            "targets": [
-                {"target_chembl_id": "CHEMBL203", "organism": "Homo sapiens"},
-                {"target_chembl_id": "CHEMBL3608", "organism": "Mus musculus"},
-            ],
-        }
-        with respx.mock(using="httpx") as router:
-            router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
-            ).mock(return_value=httpx.Response(200, json=body))
-            result = await search_chembl_target("EGFR", organism="Homo sapiens")
-        assert [r["chembl_id"] for r in result["results"]] == ["CHEMBL203"]
-        # total_count still reflects the full upstream match count, not the filtered page.
-        assert result["total_count"] == 2
-
-
-class TestChemblRetryAndErrorCleaning:
-    """_chembl_get_json retries transient 5xx, gives up on 4xx, and strips HTML
-    from error payloads."""
-
-    @pytest.mark.asyncio
-    async def test_retry_then_success(self) -> None:
-        body = {"page_meta": {"total_count": 1}, "targets": []}
-        with respx.mock(using="httpx") as router:
-            route = router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+                "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
             ).mock(
                 side_effect=[
                     httpx.Response(500, text="<html>err</html>"),
                     httpx.Response(200, json=body),
                 ]
             )
-            result = await search_chembl_target("EGFR")
+            result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O")
         assert route.call_count == 2
-        assert result["total_count"] == 1
+        assert result["results"][0]["chembl_id"] == "CHEMBL25"
 
     @pytest.mark.asyncio
     async def test_4xx_not_retried(self) -> None:
         with respx.mock(using="httpx") as router:
             route = router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+                "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
             ).mock(return_value=httpx.Response(404, text="<html>nope</html>"))
-            result = await search_chembl_target("EGFR")
-        assert route.call_count == 1  # terminal, no retry
+            result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O")
+        assert route.call_count == 1
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -344,9 +407,9 @@ class TestChemblRetryAndErrorCleaning:
         )
         with respx.mock(using="httpx") as router:
             router.get(
-                "https://www.ebi.ac.uk/chembl/api/data/target/search.json"
+                "https://www.ebi.ac.uk/chembl/api/data/molecule.json"
             ).mock(return_value=httpx.Response(500, text=html))
-            result = await search_chembl_target("EGFR")
+            result = await search_chembl_molecule("CC(=O)Oc1ccccc1C(=O)O")
         assert "<" not in result["error"] and ">" not in result["error"]
         assert len(result["error"]) < 500
 

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -1,4 +1,6 @@
 import asyncio
+import csv
+import io
 import json
 import re
 from typing import Annotated, Literal
@@ -200,10 +202,18 @@ async def search_uniprot_entity(
 
 
 # DB: ChEMBL
-# EBI's ChEMBL REST index is broadly flaky: roughly one call in three returns a
-# transient HTTP 500 or times out, non-deterministically and independent of the
-# input. Its error pages are also full HTML documents. The helpers below absorb
-# both: automatic retry on 5xx/timeout, and HTML stripped out of error strings.
+#
+# Text → ChEMBL-ID resolution runs as SPARQL against the RDF Portal graph, NOT
+# the EBI REST lexical index. Reasons: (1) the REST /search.json index is
+# token-OR ranked and buries the intended entity below orthologs/ligands/synonym
+# noise (EGFR → the receptor is only rank ~6; a protein-name query returns
+# thousands); (2) EBI REST is ~1/3 flaky. The RDF graph resolves deterministically
+# in one indexed query, returning label + organism + type. Synonyms/brands/gene
+# symbols live on skos:altLabel (on the molecule, and on the target COMPONENT).
+# REST is retained ONLY for chemical STRUCTURE search (SMILES/InChI/InChIKey →
+# flexmatch/similarity/substructure), which needs ChEMBL's chemistry engine and
+# cannot be expressed in SPARQL. Those REST helpers keep the retry/HTML-strip
+# plumbing below; EBI REST is flaky (~1/3 of calls 500 or time out).
 _CHEMBL_MAX_ATTEMPTS = 3  # 1 initial try + 2 retries
 _CHEMBL_BACKOFF_BASE = 1.0  # seconds; nth retry waits base*n (patched to 0 in tests)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
@@ -276,31 +286,78 @@ async def _chembl_get_json(path: str, params: dict, *, context: str) -> dict:
     }
 
 
-async def search_chembl_generic(
-    entity_type: str, query: str, limit: int = 20, extra_params: dict | None = None
-) -> dict:
-    """
-    Search a ChEMBL lexical index (``/{entity_type}/search.json``) by query.
+# --- name/symbol → ID resolution over the RDF graph (skos:altLabel) ---
 
-    Args:
-        entity_type (str): The type of entity to search for.
-        query (str): The query string to search for.
-        limit (int): The maximum number of results to return.
-        extra_params (dict | None): Extra query-string params (e.g.
-            ``entity_type`` on the chembl_id_lookup index).
+_CHEMBL_GRAPH = "http://rdf.ebi.ac.uk/dataset/chembl"
+_CHEMBL_PREFIXES = (
+    "PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>\n"
+    "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n"
+    "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
+)
+# UniProt accession (canonical pattern). A target query matching this routes to
+# the structured skos:exactMatch UniProt link instead of altLabel text search.
+_UNIPROT_ACCESSION_RE = re.compile(
+    r"^(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})$"
+)
 
-    Returns:
-        A dictionary parsed from the JSON response, or ``{"error": ...}`` on
-        terminal upstream failure.
+
+def _bif_and(text: str) -> str | None:
+    """Build a ``bif:contains`` argument from arbitrary caller text.
+
+    Tokenizes to alphanumeric runs, single-quotes each token, and joins with AND
+    (e.g. ``5'-nucleotidase`` → ``'5' AND 'nucleotidase'``). This is robust where
+    the raw forms make Virtuoso 500: a bare numeric token (``5``) or a
+    multi-word/punctuated phrase breaks the free-text parser, but quoting every
+    token does not. It is only a *prefilter* — the exact FILTER on the label
+    guarantees precision — so dropping apostrophes/slashes/hyphens is safe.
+    Returns ``None`` when there is no alphanumeric token to search on.
     """
-    params = {"q": query, "limit": limit}
-    if extra_params:
-        params.update(extra_params)
-    return await _chembl_get_json(
-        f"/chembl/api/data/{entity_type}/search.json",
-        params,
-        context=f"ChEMBL {entity_type} search",
+    toks = re.findall(r"[a-z0-9]+", text.lower())
+    if not toks:
+        return None
+    return " AND ".join(f"'{t}'" for t in toks)
+
+
+def _sparql_literal(text: str) -> str:
+    """Escape ``text`` for inclusion in a double-quoted SPARQL string literal."""
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _altlabel_match_block(query: str) -> str | None:
+    """WHERE-clause fragment matching ``?entity`` (or ?comp) by exact synonym.
+
+    Binds ?alt via skos:altLabel FIRST (bif:contains needs its var bound), fast-
+    prefilters with the text index, then FILTERs for the exact (case-insensitive)
+    label. Caller supplies the ``?entity skos:altLabel ?alt`` subject. Returns
+    None if the query has no searchable token.
+    """
+    bif = _bif_and(query)
+    if bif is None:
+        return None
+    return (
+        f'  ?alt bif:contains "{bif}" .\n'
+        f'  FILTER(LCASE(STR(?alt)) = "{_sparql_literal(query.lower())}")'
     )
+
+
+async def _run_chembl_sparql(query: str) -> list[dict] | dict:
+    """Execute a ChEMBL SPARQL query, returning CSV rows as ``list[dict]``.
+
+    On endpoint failure returns ``{"error": ...}`` (never raises) to preserve
+    the module's REST-wrapper contract. ``execute_sparql`` returns CSV text.
+    """
+    try:
+        csv_text = await execute_sparql(query, database="chembl")
+    except (ValueError, httpx.HTTPError) as e:
+        first = str(e).splitlines()[0] if str(e).strip() else type(e).__name__
+        logger.warning(f"ChEMBL SPARQL failed: {type(e).__name__}: {first}")
+        return {
+            "error": (
+                f"ChEMBL SPARQL query failed ({first[:200]}). If this persists, "
+                "run the query yourself via run_sparql(database='chembl', ...)."
+            )
+        }
+    return list(csv.DictReader(io.StringIO(csv_text)))
 
 
 # Structure-search routing for search_chembl_molecule.
@@ -366,10 +423,8 @@ async def search_chembl_id_lookup(
         str,
         Field(
             description=(
-                "Optional filter restricting results to one ChEMBL entity kind: "
-                "COMPOUND, TARGET, ASSAY, DOCUMENT, CELL_LINE, or TISSUE. "
-                "Strongly recommended — without it, results of every kind are "
-                "interleaved by lexical score."
+                "Optional filter: COMPOUND (molecules) or TARGET (proteins). "
+                "Omit to search both."
             ),
             default="",
         ),
@@ -382,39 +437,30 @@ async def search_chembl_id_lookup(
     name: str = "",
 ) -> dict:
     """
-    Look up ChEMBL IDs across ALL entity kinds by a lexical (text) query.
+    Resolve a name/synonym to ChEMBL IDs across compounds AND targets.
 
-    This is a cross-entity keyword index. For a target (protein/gene) or a
-    drug/compound specifically, prefer `search_chembl_target` /
-    `search_chembl_molecule` — they return labelled records. For precise,
-    label-carrying target resolution, SPARQL is better still
-    (run_sparql(database='chembl', ...)).
+    Cross-entity convenience wrapper: it runs the same exact-synonym SPARQL
+    resolution as `search_chembl_molecule` and `search_chembl_target` and UNIONs
+    the two, so one call covers "what ChEMBL entity is <text>?". Prefer the
+    entity-specific tools when you already know you want a drug or a target — they
+    carry the extra fields (organism/type). Only COMPOUND and TARGET are covered
+    (the two synonym-rich entity kinds); for assays/documents/cell-lines/tissues,
+    query SPARQL directly via run_sparql(database='chembl', ...).
 
-    The search string can be passed as any of: `query` (canonical),
-    `search`, `term`, `keyword`, `keywords`, `search_term`, or `name`.
+    Matching is EXACT (case-insensitive) against skos:altLabel synonyms — brands,
+    generic names, gene symbols — not fuzzy/substring. Fix typos in the query
+    before calling.
 
-    Filtering & limit:
-        - Pass `entity_type` (e.g. "TARGET") to drop the COMPOUND/ASSAY/DOCUMENT
-          noise a bare name query otherwise returns. It also measurably reduces
-          upstream 500s by narrowing the query.
-        - `limit` below 10 is raised to 10 internally: the intended hit for a
-          name/symbol query routinely sits at rank 5–6, so a small limit would
-          silently drop it. Ranking is lexical and unreliable — inspect
-          `entity_type`/`status` rather than trusting rank order.
+    The search string can be passed as any of: `query` (canonical), `search`,
+    `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Returns:
-        dict: {'total_count' (int), 'results' (list)}. Each result has
-        'chembl_id', 'entity_type', 'status' (ACTIVE / OBSOLETE),
-        'resource_url', and 'score'.
+        dict: {'total_count' (int, rows returned — capped by `limit`),
+        'results' (list)}. Each result has 'chembl_id', 'entity_type'
+        (COMPOUND / TARGET), and 'name' (the entity's rdfs:label).
 
-        NOTE: this upstream endpoint does NOT return a human-readable name —
-        there is no `pref_name` field on the id-lookup index. Use `entity_type`
-        + `resource_url` to disambiguate, or resolve the ID with the
-        entity-specific tool (`search_chembl_target`/`_molecule`) or SPARQL.
-
-        On upstream/HTTP failure this tool does NOT raise — it returns a dict
-        with a single 'error' key instead. Check for 'error' before reading
-        'results'.
+        On endpoint failure this tool does NOT raise — it returns a dict with a
+        single 'error' key instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -430,37 +476,57 @@ async def search_chembl_id_lookup(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    extra_params = None
-    if entity_type:
-        allowed = {"COMPOUND", "TARGET", "ASSAY", "DOCUMENT", "CELL_LINE", "TISSUE"}
-        et = entity_type.strip().upper()
-        if et not in allowed:
-            raise ValueError(
-                f"Invalid entity_type {entity_type!r}. Use one of: "
-                f"{', '.join(sorted(allowed))} (or omit it to search all kinds)."
-            )
-        extra_params = {"entity_type": et}
-    bulk = await search_chembl_generic(
-        "chembl_id_lookup", query, max(limit, 10), extra_params=extra_params
-    )
-    if "error" in bulk:
-        # Propagate the upstream-failure payload rather than silently
-        # collapsing it into an empty {'total_count': 0, 'results': []}.
-        return bulk
-    total_count = bulk.get("page_meta", {}).get("total_count", 0)
-    parsed_results = []
-    for result in bulk.get("chembl_id_lookups", []):
-        parsed_results.append(
-            {
-                "chembl_id": result.get("chembl_id"),
-                "entity_type": result.get("entity_type"),
-                "status": result.get("status"),
-                "resource_url": result.get("resource_url"),
-                "score": result.get("score"),
-            }
+    et = entity_type.strip().upper() if entity_type else ""
+    if et and et not in {"COMPOUND", "TARGET"}:
+        raise ValueError(
+            f"Invalid entity_type {entity_type!r}. Use COMPOUND or TARGET (this "
+            "SPARQL-backed lookup covers those two synonym-rich kinds; for "
+            "assays/documents/cell-lines/tissues query SPARQL directly)."
         )
-
-    return {"total_count": total_count, "results": parsed_results}
+    match = _altlabel_match_block(query)
+    if match is None:
+        return {"total_count": 0, "results": []}
+    compound_branch = (
+        "  {\n"
+        "    ?e skos:altLabel ?alt .\n"
+        f"{match}\n"
+        "    ?e a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        '    BIND("COMPOUND" AS ?entity_type)\n'
+        "  }"
+    )
+    target_branch = (
+        "  {\n"
+        "    ?comp skos:altLabel ?alt .\n"
+        f"{match}\n"
+        "    ?e cco:hasTargetComponent ?comp ;\n"
+        "       cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        '    BIND("TARGET" AS ?entity_type)\n'
+        "  }"
+    )
+    if et == "COMPOUND":
+        body = compound_branch
+    elif et == "TARGET":
+        body = target_branch
+    else:
+        body = f"{compound_branch}\n  UNION\n{target_branch}"
+    sparql = (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"SELECT DISTINCT ?chembl_id ?entity_type ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"{body}\n"
+        f"}} LIMIT {int(limit)}"
+    )
+    rows = await _run_chembl_sparql(sparql)
+    if isinstance(rows, dict):
+        return rows  # {"error": ...}
+    parsed_results = [
+        {
+            "chembl_id": r.get("chembl_id"),
+            "entity_type": r.get("entity_type"),
+            "name": r.get("name"),
+        }
+        for r in rows
+    ]
+    return {"total_count": len(parsed_results), "results": parsed_results}
 
 
 @mcp.tool()
@@ -468,6 +534,7 @@ async def search_chembl_target(
     query: str = "",
     limit: int = 20,
     organism: str = "",
+    target_type: str = "",
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -476,70 +543,51 @@ async def search_chembl_target(
     name: str = "",
 ) -> dict:
     """
-    Search for a biological TARGET (protein/receptor/enzyme) in ChEMBL.
+    Resolve a biological TARGET (protein/receptor/enzyme) to a ChEMBL ID.
 
     ⚠️ DO NOT use this tool to look up drugs, compounds, or molecules by name.
        For drug/compound/molecule names (e.g., "sorafenib", "imatinib", "aspirin"),
        use `search_chembl_molecule` instead.
 
-    ⭐ IF YOU HAVE A UNIPROT ACCESSION, USE IT. An accession (e.g. "P00533")
-       is dramatically more precise than a target name or gene symbol: for human
-       EGFR it returns the correct target CHEMBL203 at rank 1, whereas the full
-       name ranks it 6th (below a mouse ortholog and a ligand) and the symbol
-       "EGFR" ranks it 5th.
+    Resolution is deterministic SPARQL against the ChEMBL RDF graph, not a lexical
+    search — there is no ranking to second-guess:
+      • UNIPROT ACCESSION (e.g. "P00533") → the structured skos:exactMatch link.
+        Returns every target containing that protein (the single protein plus any
+        complex/family/chimera it participates in) — filter `target_type` to get
+        just one.
+      • GENE SYMBOL / PROTEIN NAME (e.g. "EGFR", "epidermal growth factor
+        receptor") → EXACT (case-insensitive) match on the target component's
+        skos:altLabel synonyms. Not fuzzy/substring — fix typos before calling.
 
-    ⚠️ RANK ORDER IS UNRELIABLE. Upstream ranking is lexical and coarse (integer
-       scores, many ties) and does NOT privilege exact-name or human-organism
-       matches. A name/symbol query returns orthologs (mouse, rat), ligands, and
-       PROTEIN-PROTEIN INTERACTION complexes interleaved with the intended
-       target. You MUST inspect `organism` and `type` — do not trust the top
-       hit. For exact, label-carrying resolution, SPARQL is better still:
-       run_sparql(database='chembl', ...) filtering on rdfs:label + organismName.
-
-    This tool searches for biological entities that drugs act upon — proteins,
-    protein complexes, nucleic acids, organisms, tissues, and cell lines.
-    "Target" here means *drug target*, NOT "the thing I am looking up".
+    Every result carries `organism` and `type`, so a symbol shared across species
+    or complexes is disambiguated by inspecting those fields (or by passing the
+    `organism`/`target_type` filters) — NOT by trusting order.
 
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Args:
-        query (str): Search query string referring to a biological target. Examples:
-            - UniProt accession (e.g., "P00734") — PREFERRED, most precise
-            - Target name (e.g., "Thrombin", "EGFR", "Dopamine receptor")
-            - Gene name (e.g., "BRCA1", "TP53")
-            - Organism name (e.g., "Homo sapiens")
-        limit (int, optional): Maximum number of results to return. Defaults to 20.
-            Values below 10 are raised to 10 internally, because the intended
-            target routinely sits at rank 5–6 and a small limit would drop it.
-        organism (str, optional): If given, results are filtered (case-insensitive
-            substring, e.g. "Homo sapiens") to that organism AFTER fetching. Note
-            this filters the returned page only; `total_count` still reflects the
-            full unfiltered match count upstream.
+        query (str): UniProt accession (preferred), gene symbol, or exact protein
+            name. Examples: "P00533", "EGFR", "Thrombin".
+        limit (int, optional): Max results. Defaults to 20.
+        organism (str, optional): Case-insensitive substring filter on organism,
+            e.g. "Homo sapiens". Applied inside the query.
+        target_type (str, optional): Exact (case-insensitive) filter on target
+            type, e.g. "SINGLE PROTEIN" — pass this to collapse an accession/symbol
+            match to the canonical single protein and drop complexes/families.
+
+    Target Types (values of `type`): SINGLE PROTEIN, PROTEIN COMPLEX,
+        PROTEIN FAMILY, PROTEIN-PROTEIN INTERACTION, CHIMERIC PROTEIN,
+        NUCLEIC-ACID, CELL-LINE, TISSUE, ORGANISM, …
 
     Returns:
-        dict: Dictionary containing:
-            - 'total_count' (int): Total number of matching targets found upstream
-            - 'results' (list): List of target dictionaries, each containing:
-                - 'chembl_id' (str): ChEMBL target identifier (e.g., "CHEMBL1824")
-                - 'name' (str): Preferred target name
-                - 'organism' (str): Organism name (e.g., "Homo sapiens")
-                - 'type' (str): Target type (e.g., "SINGLE PROTEIN", "PROTEIN COMPLEX")
-                - 'score' (float): Relevance score for the search query
+        dict: {'total_count' (int, rows returned — capped by `limit`),
+        'results' (list)}. Each result has 'chembl_id', 'name' (rdfs:label),
+        'organism', 'type', and 'score' (always None — SPARQL exact match has no
+        relevance score; kept for shape stability).
 
-    Target Types:
-        - SINGLE PROTEIN: Individual protein target
-        - PROTEIN COMPLEX: Multi-protein complex
-        - PROTEIN FAMILY: Group of related proteins
-        - NUCLEIC-ACID: DNA/RNA targets
-        - TISSUE: Tissue-level target
-        - CELL-LINE: Cell line target
-        - ORGANISM: Whole organism target
-
-    On upstream/HTTP failure this tool does NOT raise — it returns a dict with a
-    single 'error' key (a message plus a "fall back to SPARQL" hint) instead of
-    the usual {'total_count', 'results'} shape. Check for 'error' before reading
-    'results'.
+        On endpoint failure this tool does NOT raise — it returns a dict with a
+        single 'error' key instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -555,30 +603,54 @@ async def search_chembl_target(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    bulk = await search_chembl_generic("target", query, max(limit, 10))
-    if "error" in bulk:
-        # Propagate the upstream-failure payload rather than silently
-        # collapsing it into an empty {'total_count': 0, 'results': []}.
-        return bulk
-    total_count = bulk.get("page_meta", {}).get("total_count", 0)
-
-    organism_filter = organism.strip().lower()
-    parsed_results = []
-    for target in bulk.get("targets", []):
-        target_organism = target.get("organism")
-        if organism_filter and organism_filter not in (target_organism or "").lower():
-            continue
-        parsed_results.append(
-            {
-                "chembl_id": target.get("target_chembl_id"),
-                "name": target.get("pref_name"),
-                "organism": target_organism,
-                "type": target.get("target_type"),
-                "score": target.get("score"),
-            }
+    # Route: UniProt accession → structured skos:exactMatch; else exact altLabel.
+    acc = query.strip().upper()
+    if _UNIPROT_ACCESSION_RE.match(acc):
+        match_block = (
+            f"  ?comp skos:exactMatch "
+            f"<http://purl.uniprot.org/uniprot/{acc}> ."
         )
+    else:
+        alt = _altlabel_match_block(query)
+        if alt is None:
+            return {"total_count": 0, "results": []}
+        match_block = f"  ?comp skos:altLabel ?alt .\n{alt}"
 
-    return {"total_count": total_count, "results": parsed_results}
+    filters = ""
+    if organism.strip():
+        filters += (
+            f'\n  FILTER(CONTAINS(LCASE(STR(?organism)), '
+            f'"{_sparql_literal(organism.strip().lower())}"))'
+        )
+    if target_type.strip():
+        filters += (
+            f'\n  FILTER(LCASE(STR(?type)) = '
+            f'"{_sparql_literal(target_type.strip().lower())}")'
+        )
+    sparql = (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"SELECT DISTINCT ?chembl_id ?name ?organism ?type "
+        f"FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"{match_block}\n"
+        f"  ?target cco:hasTargetComponent ?comp ;\n"
+        f"          cco:chemblId ?chembl_id ; rdfs:label ?name ; cco:targetType ?type .\n"
+        f"  OPTIONAL {{ ?target cco:organismName ?organism . }}{filters}\n"
+        f"}} LIMIT {int(limit)}"
+    )
+    rows = await _run_chembl_sparql(sparql)
+    if isinstance(rows, dict):
+        return rows  # {"error": ...}
+    parsed_results = [
+        {
+            "chembl_id": r.get("chembl_id"),
+            "name": r.get("name"),
+            "organism": r.get("organism") or None,
+            "type": r.get("type"),
+            "score": None,
+        }
+        for r in rows
+    ]
+    return {"total_count": len(parsed_results), "results": parsed_results}
 
 
 @mcp.tool()
@@ -593,56 +665,44 @@ async def search_chembl_molecule(
     name: str = "",
 ) -> dict:
     """
-    Search for a DRUG / COMPOUND / MOLECULE by name or structure in ChEMBL.
+    Resolve a DRUG / COMPOUND / MOLECULE (by name or structure) to a ChEMBL ID.
 
     ✅ Use this tool for drug, compound, or molecule names
        (e.g., "sorafenib", "imatinib", "aspirin", "Gleevec").
     ⚠️ For biological targets (proteins, receptors, enzymes, genes such as
-       EGFR, BRCA1, TP53), use `search_chembl_target` instead. Passing a
-       target/gene name here (e.g. "EGFR") does NOT fail — it returns drugs
-       that act AGAINST that target, not the target itself. If you want the
-       target, that is the wrong tool.
+       EGFR, BRCA1, TP53), use `search_chembl_target` instead.
 
-    Molecules in ChEMBL are small-molecule drugs, drug candidates, and
-    bioactive compounds — including approved drugs, clinical candidates,
-    and research compounds.
+    Two resolution paths, auto-selected from the query shape:
 
-    Structure search (SMILES / InChI / InChIKey) IS supported: a structure-
-    shaped query is auto-detected and routed to the ChEMBL structure endpoint
-    (exact/flex match), NOT the lexical name index — so e.g. aspirin's SMILES
-    "CC(=O)Oc1ccccc1C(=O)O" correctly returns CHEMBL25. Plain names still go to
-    the name/synonym index. Detection is conservative (multi-word input and
-    input without structural punctuation is treated as a name), so a bare-chain
-    SMILES like "CCO" is treated as a name.
+    • NAME / BRAND / SYNONYM → deterministic SPARQL, EXACT (case-insensitive)
+      match on the molecule's skos:altLabel synonyms (which include brand and
+      trade names — "Gleevec" → CHEMBL941 IMATINIB). Not fuzzy/substring: fix
+      typos before calling. No relevance ranking to second-guess.
+
+    • STRUCTURE (SMILES / InChI / InChIKey) → the ChEMBL REST chemistry engine
+      (flexmatch), which SPARQL cannot do. Auto-detected from structural
+      punctuation / the "InChI=" prefix / the InChIKey pattern, e.g. aspirin's
+      SMILES "CC(=O)Oc1ccccc1C(=O)O" → CHEMBL25. Detection is conservative
+      (multi-word input, or input without structural punctuation, is treated as
+      a name), so a bare-chain SMILES like "CCO" is treated as a name.
 
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Args:
-        query (str): Search query string referring to a drug or compound. Examples:
-            - Generic or brand drug name (e.g., "Aspirin", "Gleevec", "Paracetamol")
-            - Research compound name / synonyms
-            - SMILES notation (e.g., "CC(=O)Oc1ccccc1C(=O)O") — structure search
-            - InChI (starts with "InChI=") or InChIKey (e.g.,
-              "BSYNRYMUTXBXSQ-UHFFFAOYSA-N") — structure search
+        query (str): Drug/compound name, brand, synonym, or a structure string.
+            Examples: "Aspirin", "Gleevec", "CC(=O)Oc1ccccc1C(=O)O",
+            "BSYNRYMUTXBXSQ-UHFFFAOYSA-N".
         limit (int, optional): Maximum number of results to return. Defaults to 20.
 
     Returns:
-        dict: Dictionary containing:
-            - 'total_count' (int): Total number of matching molecules found
-            - 'results' (list): List of molecule dictionaries, each containing:
-                - 'chembl_id' (str): ChEMBL molecule identifier (e.g., "CHEMBL25")
-                - 'name' (str): Preferred molecule name (may be None for some compounds)
-                - 'score' (float): Relevance score (None for structure-search hits)
+        dict: {'total_count' (int, rows returned — capped by `limit`),
+        'results' (list)}. Each result has 'chembl_id' (e.g. "CHEMBL25"), 'name'
+        (rdfs:label, may be None for some structure hits), and 'score' (always
+        None; kept for shape stability).
 
-    Note:
-        - Some molecules may not have a preferred name and 'name' field will be None
-        - Higher scores indicate better matches (name search only)
-
-    On upstream/HTTP failure this tool does NOT raise — it returns a dict with a
-    single 'error' key (a message plus a "fall back to SPARQL" hint) instead of
-    the usual {'total_count', 'results'} shape. Check for 'error' before reading
-    'results'.
+        On endpoint/HTTP failure this tool does NOT raise — it returns a dict with
+        a single 'error' key instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -658,27 +718,43 @@ async def search_chembl_molecule(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
+    # Structure-shaped input → REST chemistry engine (SPARQL cannot do this).
     structure_kind = _looks_like_structure(query)
     if structure_kind:
         bulk = await _search_chembl_structure(structure_kind, query, limit)
-    else:
-        bulk = await search_chembl_generic("molecule", query, limit)
-    if "error" in bulk:
-        # Propagate the upstream-failure payload rather than silently
-        # collapsing it into an empty {'total_count': 0, 'results': []}.
-        return bulk
-    total_count = bulk.get("page_meta", {}).get("total_count", 0)
-    parsed_results = []
-    for molecule in bulk.get("molecules", []):
-        parsed_results.append(
+        if "error" in bulk:
+            return bulk
+        total_count = bulk.get("page_meta", {}).get("total_count", 0)
+        parsed_results = [
             {
-                "chembl_id": molecule.get("molecule_chembl_id"),
-                "name": molecule.get("pref_name"),
-                "score": molecule.get("score"),
+                "chembl_id": m.get("molecule_chembl_id"),
+                "name": m.get("pref_name"),
+                "score": None,
             }
-        )
+            for m in bulk.get("molecules", [])
+        ]
+        return {"total_count": total_count, "results": parsed_results}
 
-    return {"total_count": total_count, "results": parsed_results}
+    # Name/brand/synonym → deterministic SPARQL exact match on skos:altLabel.
+    match = _altlabel_match_block(query)
+    if match is None:
+        return {"total_count": 0, "results": []}
+    sparql = (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"SELECT DISTINCT ?chembl_id ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"  ?m skos:altLabel ?alt .\n"
+        f"{match}\n"
+        f"  ?m a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        f"}} LIMIT {int(limit)}"
+    )
+    rows = await _run_chembl_sparql(sparql)
+    if isinstance(rows, dict):
+        return rows  # {"error": ...}
+    parsed_results = [
+        {"chembl_id": r.get("chembl_id"), "name": r.get("name"), "score": None}
+        for r in rows
+    ]
+    return {"total_count": len(parsed_results), "results": parsed_results}
 
 
 # DB: PubChem

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 from typing import Annotated, Literal
@@ -199,35 +200,158 @@ async def search_uniprot_entity(
 
 
 # DB: ChEMBL
-async def search_chembl_generic(entity_type: str, query: str, limit: int = 20) -> dict:
+# EBI's ChEMBL REST index is broadly flaky: roughly one call in three returns a
+# transient HTTP 500 or times out, non-deterministically and independent of the
+# input. Its error pages are also full HTML documents. The helpers below absorb
+# both: automatic retry on 5xx/timeout, and HTML stripped out of error strings.
+_CHEMBL_MAX_ATTEMPTS = 3  # 1 initial try + 2 retries
+_CHEMBL_BACKOFF_BASE = 1.0  # seconds; nth retry waits base*n (patched to 0 in tests)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str, max_len: int = 200) -> str:
+    """Collapse an HTML error page into a short plain-text snippet.
+
+    EBI returns full HTML documents (doctype, <script>/<style> blocks, favicon
+    links) on failure — hundreds of tokens of noise with no diagnostic value.
+    Drop scripts/styles wholesale, strip remaining tags, collapse whitespace,
+    and truncate.
     """
-    Search for ChEMBL ID by query.
+    text = re.sub(
+        r"<(script|style)\b[^>]*>.*?</\1>", " ", text, flags=re.IGNORECASE | re.DOTALL
+    )
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > max_len:
+        text = text[:max_len].rstrip() + "…"
+    return text
+
+
+async def _chembl_get_json(path: str, params: dict, *, context: str) -> dict:
+    """GET a ChEMBL JSON endpoint, retrying transient 5xx/timeout failures.
+
+    Returns the parsed JSON on success. On terminal failure returns
+    ``{"error": <clean message>}`` — it never raises for HTTP/transport
+    errors (the module's REST-wrapper contract). 4xx client errors are
+    terminal (no retry); 5xx and read timeouts are retried up to
+    ``_CHEMBL_MAX_ATTEMPTS`` times with a short linear backoff. HTML error
+    bodies are stripped to a short snippet.
+    """
+    last_error = "unknown error"
+    for attempt in range(_CHEMBL_MAX_ATTEMPTS):
+        last = attempt == _CHEMBL_MAX_ATTEMPTS - 1
+        try:
+            response = await _chembl_client.get(path, params=params)
+        except httpx.HTTPError as e:  # includes TimeoutException
+            last_error = f"{type(e).__name__}: {e}"
+            logger.warning(f"{context} attempt {attempt + 1} failed: {last_error}")
+            if last:
+                break
+            await asyncio.sleep(_CHEMBL_BACKOFF_BASE * (attempt + 1))
+            continue
+        if response.is_success:
+            try:
+                return response.json()
+            except (json.JSONDecodeError, ValueError):
+                # 200 with a non-JSON body — an upstream anomaly. Degrade
+                # gracefully rather than raising (REST-wrapper contract).
+                last_error = f"malformed JSON body: {_strip_html(response.text)}"
+                logger.warning(f"{context} failed (terminal): {last_error}")
+                break
+        if 500 <= response.status_code < 600 and not last:
+            last_error = f"HTTP {response.status_code}"
+            logger.warning(f"{context} attempt {attempt + 1}: {last_error}, retrying")
+            await asyncio.sleep(_CHEMBL_BACKOFF_BASE * (attempt + 1))
+            continue
+        # Terminal: a 4xx, or a 5xx after retries are exhausted.
+        last_error = f"HTTP {response.status_code}: {_strip_html(response.text)}"
+        logger.warning(f"{context} failed (terminal): {last_error}")
+        break
+    return {
+        "error": (
+            f"ChEMBL REST API request failed ({last_error}). Transient errors "
+            "were already retried automatically. If it keeps failing, fall back "
+            "to SPARQL: run_sparql(database='chembl', sparql_query=...)."
+        )
+    }
+
+
+async def search_chembl_generic(
+    entity_type: str, query: str, limit: int = 20, extra_params: dict | None = None
+) -> dict:
+    """
+    Search a ChEMBL lexical index (``/{entity_type}/search.json``) by query.
 
     Args:
         entity_type (str): The type of entity to search for.
         query (str): The query string to search for.
         limit (int): The maximum number of results to return.
+        extra_params (dict | None): Extra query-string params (e.g.
+            ``entity_type`` on the chembl_id_lookup index).
 
     Returns:
-        A dictionary parsed from the JSON response.
+        A dictionary parsed from the JSON response, or ``{"error": ...}`` on
+        terminal upstream failure.
     """
     params = {"q": query, "limit": limit}
-    try:
-        response = await _chembl_client.get(
-            f"/chembl/api/data/{entity_type}/search.json", params=params
-        )
-        raise_for_status_with_body(response, context="ChEMBL search")
-        return response.json()
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(f"ChEMBL {entity_type} search failed: {type(e).__name__}: {e}")
-        return {
-            "error": (
-                f"ChEMBL REST API request failed ({type(e).__name__}: {e}). "
-                "Usually transient — retry once after a brief delay. If it "
-                "keeps failing, fall back to SPARQL: "
-                "run_sparql(database='chembl', sparql_query=...)."
-            )
-        }
+    if extra_params:
+        params.update(extra_params)
+    return await _chembl_get_json(
+        f"/chembl/api/data/{entity_type}/search.json",
+        params,
+        context=f"ChEMBL {entity_type} search",
+    )
+
+
+# Structure-search routing for search_chembl_molecule.
+# /molecule/search.json is a LEXICAL text index — a SMILES string matched
+# against it returns meaningless name/synonym hits. Structure-shaped input must
+# instead go to /molecule.json with a structure filter. The detector is
+# deliberately conservative: a false positive misroutes a real drug name.
+_INCHIKEY_RE = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$")
+
+
+def _looks_like_structure(query: str) -> str | None:
+    """Classify ``query`` as a chemical structure string.
+
+    Returns ``"inchi"``, ``"inchikey"``, or ``"smiles"`` when the input is
+    structure-shaped, else ``None`` (route to the lexical name index).
+
+    Conservative by design — a name misrouted to the structure endpoint
+    returns nothing, so anything with whitespace (multi-word names) or without
+    unambiguous structural punctuation stays on the lexical path. This means a
+    bare-chain SMILES like ``CCO`` (ethanol) is NOT detected; that is the
+    accepted trade-off for not misrouting drug names.
+    """
+    s = query.strip()
+    if not s or " " in s:
+        return None
+    if s.startswith("InChI="):
+        return "inchi"
+    if _INCHIKEY_RE.match(s):
+        return "inchikey"
+    # SMILES: require structural punctuation that essentially never appears in a
+    # drug name or accession (excludes "aspirin", "EGFR", "CHEMBL25", "P00533").
+    if any(c in s for c in "=#()[]"):
+        return "smiles"
+    return None
+
+
+async def _search_chembl_structure(kind: str, query: str, limit: int) -> dict:
+    """Query the ``/molecule.json`` structure endpoint (SMILES/InChI/InChIKey).
+
+    Returns the same ``{"page_meta", "molecules"}`` shape as the lexical search
+    endpoint, so callers parse both identically.
+    """
+    field = {
+        "smiles": "molecule_structures__canonical_smiles__flexmatch",
+        "inchikey": "molecule_structures__standard_inchi_key",
+        "inchi": "molecule_structures__standard_inchi",
+    }[kind]
+    filt = {field: query, "limit": limit}
+    return await _chembl_get_json(
+        "/chembl/api/data/molecule.json", filt, context="ChEMBL structure search"
+    )
 
 
 @mcp.tool()
@@ -238,6 +362,18 @@ async def search_chembl_id_lookup(
     limit: Annotated[
         int, Field(description="The maximum number of results to return.")
     ] = 20,
+    entity_type: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional filter restricting results to one ChEMBL entity kind: "
+                "COMPOUND, TARGET, ASSAY, DOCUMENT, CELL_LINE, or TISSUE. "
+                "Strongly recommended — without it, results of every kind are "
+                "interleaved by lexical score."
+            ),
+            default="",
+        ),
+    ] = "",
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -246,16 +382,39 @@ async def search_chembl_id_lookup(
     name: str = "",
 ) -> dict:
     """
-    Search for ChEMBL ID by query.
+    Look up ChEMBL IDs across ALL entity kinds by a lexical (text) query.
+
+    This is a cross-entity keyword index. For a target (protein/gene) or a
+    drug/compound specifically, prefer `search_chembl_target` /
+    `search_chembl_molecule` — they return labelled records. For precise,
+    label-carrying target resolution, SPARQL is better still
+    (run_sparql(database='chembl', ...)).
 
     The search string can be passed as any of: `query` (canonical),
     `search`, `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
+    Filtering & limit:
+        - Pass `entity_type` (e.g. "TARGET") to drop the COMPOUND/ASSAY/DOCUMENT
+          noise a bare name query otherwise returns. It also measurably reduces
+          upstream 500s by narrowing the query.
+        - `limit` below 10 is raised to 10 internally: the intended hit for a
+          name/symbol query routinely sits at rank 5–6, so a small limit would
+          silently drop it. Ranking is lexical and unreliable — inspect
+          `entity_type`/`status` rather than trusting rank order.
+
     Returns:
-        dict: {'total_count' (int), 'results' (list)} where each result has
-        'chembl_id', 'entity_type', and 'score'. On upstream/HTTP failure this
-        tool does NOT raise — it returns a dict with a single 'error' key
-        instead. Check for 'error' before reading 'results'.
+        dict: {'total_count' (int), 'results' (list)}. Each result has
+        'chembl_id', 'entity_type', 'status' (ACTIVE / OBSOLETE),
+        'resource_url', and 'score'.
+
+        NOTE: this upstream endpoint does NOT return a human-readable name —
+        there is no `pref_name` field on the id-lookup index. Use `entity_type`
+        + `resource_url` to disambiguate, or resolve the ID with the
+        entity-specific tool (`search_chembl_target`/`_molecule`) or SPARQL.
+
+        On upstream/HTTP failure this tool does NOT raise — it returns a dict
+        with a single 'error' key instead. Check for 'error' before reading
+        'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -271,7 +430,19 @@ async def search_chembl_id_lookup(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    bulk = await search_chembl_generic("chembl_id_lookup", query, limit)
+    extra_params = None
+    if entity_type:
+        allowed = {"COMPOUND", "TARGET", "ASSAY", "DOCUMENT", "CELL_LINE", "TISSUE"}
+        et = entity_type.strip().upper()
+        if et not in allowed:
+            raise ValueError(
+                f"Invalid entity_type {entity_type!r}. Use one of: "
+                f"{', '.join(sorted(allowed))} (or omit it to search all kinds)."
+            )
+        extra_params = {"entity_type": et}
+    bulk = await search_chembl_generic(
+        "chembl_id_lookup", query, max(limit, 10), extra_params=extra_params
+    )
     if "error" in bulk:
         # Propagate the upstream-failure payload rather than silently
         # collapsing it into an empty {'total_count': 0, 'results': []}.
@@ -283,6 +454,8 @@ async def search_chembl_id_lookup(
             {
                 "chembl_id": result.get("chembl_id"),
                 "entity_type": result.get("entity_type"),
+                "status": result.get("status"),
+                "resource_url": result.get("resource_url"),
                 "score": result.get("score"),
             }
         )
@@ -294,6 +467,7 @@ async def search_chembl_id_lookup(
 async def search_chembl_target(
     query: str = "",
     limit: int = 20,
+    organism: str = "",
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -308,41 +482,50 @@ async def search_chembl_target(
        For drug/compound/molecule names (e.g., "sorafenib", "imatinib", "aspirin"),
        use `search_chembl_molecule` instead.
 
+    ⭐ IF YOU HAVE A UNIPROT ACCESSION, USE IT. An accession (e.g. "P00533")
+       is dramatically more precise than a target name or gene symbol: for human
+       EGFR it returns the correct target CHEMBL203 at rank 1, whereas the full
+       name ranks it 6th (below a mouse ortholog and a ligand) and the symbol
+       "EGFR" ranks it 5th.
+
+    ⚠️ RANK ORDER IS UNRELIABLE. Upstream ranking is lexical and coarse (integer
+       scores, many ties) and does NOT privilege exact-name or human-organism
+       matches. A name/symbol query returns orthologs (mouse, rat), ligands, and
+       PROTEIN-PROTEIN INTERACTION complexes interleaved with the intended
+       target. You MUST inspect `organism` and `type` — do not trust the top
+       hit. For exact, label-carrying resolution, SPARQL is better still:
+       run_sparql(database='chembl', ...) filtering on rdfs:label + organismName.
+
     This tool searches for biological entities that drugs act upon — proteins,
     protein complexes, nucleic acids, organisms, tissues, and cell lines.
     "Target" here means *drug target*, NOT "the thing I am looking up".
 
-    Only the search string and `limit` are supported. The search string can be
-    passed as any of: `query` (canonical), `search`, `term`, `keyword`,
-    `keywords`, `search_term`, or `name`.
+    The search string can be passed as any of: `query` (canonical), `search`,
+    `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Args:
         query (str): Search query string referring to a biological target. Examples:
+            - UniProt accession (e.g., "P00734") — PREFERRED, most precise
             - Target name (e.g., "Thrombin", "EGFR", "Dopamine receptor")
             - Gene name (e.g., "BRCA1", "TP53")
-            - UniProt accession (e.g., "P00734")
             - Organism name (e.g., "Homo sapiens")
         limit (int, optional): Maximum number of results to return. Defaults to 20.
+            Values below 10 are raised to 10 internally, because the intended
+            target routinely sits at rank 5–6 and a small limit would drop it.
+        organism (str, optional): If given, results are filtered (case-insensitive
+            substring, e.g. "Homo sapiens") to that organism AFTER fetching. Note
+            this filters the returned page only; `total_count` still reflects the
+            full unfiltered match count upstream.
 
     Returns:
         dict: Dictionary containing:
-            - 'total_count' (int): Total number of matching targets found
+            - 'total_count' (int): Total number of matching targets found upstream
             - 'results' (list): List of target dictionaries, each containing:
                 - 'chembl_id' (str): ChEMBL target identifier (e.g., "CHEMBL1824")
                 - 'name' (str): Preferred target name
                 - 'organism' (str): Organism name (e.g., "Homo sapiens")
                 - 'type' (str): Target type (e.g., "SINGLE PROTEIN", "PROTEIN COMPLEX")
                 - 'score' (float): Relevance score for the search query
-
-    Example:
-        >>> results = await search_chembl_target("EGFR human", limit=5)
-        >>> print(f"Found {results['total_count']} targets")
-        >>> for target in results['results']:
-        ...     print(f"{target['chembl_id']}: {target['name']} ({target['organism']})")
-
-        Output:
-        Found 15 targets
-        CHEMBL203: Epidermal growth factor receptor (Homo sapiens)
 
     Target Types:
         - SINGLE PROTEIN: Individual protein target
@@ -372,20 +555,24 @@ async def search_chembl_target(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    bulk = await search_chembl_generic("target", query, limit)
+    bulk = await search_chembl_generic("target", query, max(limit, 10))
     if "error" in bulk:
         # Propagate the upstream-failure payload rather than silently
         # collapsing it into an empty {'total_count': 0, 'results': []}.
         return bulk
     total_count = bulk.get("page_meta", {}).get("total_count", 0)
 
+    organism_filter = organism.strip().lower()
     parsed_results = []
     for target in bulk.get("targets", []):
+        target_organism = target.get("organism")
+        if organism_filter and organism_filter not in (target_organism or "").lower():
+            continue
         parsed_results.append(
             {
                 "chembl_id": target.get("target_chembl_id"),
                 "name": target.get("pref_name"),
-                "organism": target.get("organism"),
+                "organism": target_organism,
                 "type": target.get("target_type"),
                 "score": target.get("score"),
             }
@@ -411,23 +598,33 @@ async def search_chembl_molecule(
     ✅ Use this tool for drug, compound, or molecule names
        (e.g., "sorafenib", "imatinib", "aspirin", "Gleevec").
     ⚠️ For biological targets (proteins, receptors, enzymes, genes such as
-       EGFR, BRCA1, TP53), use `search_chembl_target` instead.
+       EGFR, BRCA1, TP53), use `search_chembl_target` instead. Passing a
+       target/gene name here (e.g. "EGFR") does NOT fail — it returns drugs
+       that act AGAINST that target, not the target itself. If you want the
+       target, that is the wrong tool.
 
     Molecules in ChEMBL are small-molecule drugs, drug candidates, and
     bioactive compounds — including approved drugs, clinical candidates,
     and research compounds.
 
-    Only the search string and `limit` are supported. The search string can be
-    passed as any of: `query` (canonical), `search`, `term`, `keyword`,
-    `keywords`, `search_term`, or `name`.
+    Structure search (SMILES / InChI / InChIKey) IS supported: a structure-
+    shaped query is auto-detected and routed to the ChEMBL structure endpoint
+    (exact/flex match), NOT the lexical name index — so e.g. aspirin's SMILES
+    "CC(=O)Oc1ccccc1C(=O)O" correctly returns CHEMBL25. Plain names still go to
+    the name/synonym index. Detection is conservative (multi-word input and
+    input without structural punctuation is treated as a name), so a bare-chain
+    SMILES like "CCO" is treated as a name.
+
+    The search string can be passed as any of: `query` (canonical), `search`,
+    `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
     Args:
         query (str): Search query string referring to a drug or compound. Examples:
             - Generic or brand drug name (e.g., "Aspirin", "Gleevec", "Paracetamol")
-            - Research compound name
-            - Synonyms or alternative names
-            - SMILES notation (chemical structure string)
-            - InChI or InChI Key
+            - Research compound name / synonyms
+            - SMILES notation (e.g., "CC(=O)Oc1ccccc1C(=O)O") — structure search
+            - InChI (starts with "InChI=") or InChIKey (e.g.,
+              "BSYNRYMUTXBXSQ-UHFFFAOYSA-N") — structure search
         limit (int, optional): Maximum number of results to return. Defaults to 20.
 
     Returns:
@@ -436,29 +633,11 @@ async def search_chembl_molecule(
             - 'results' (list): List of molecule dictionaries, each containing:
                 - 'chembl_id' (str): ChEMBL molecule identifier (e.g., "CHEMBL25")
                 - 'name' (str): Preferred molecule name (may be None for some compounds)
-                - 'score' (float): Relevance score for the search query
-
-    Example:
-        >>> results = await search_chembl_molecule("aspirin", limit=5)
-        >>> print(f"Found {results['total_count']} molecules")
-        >>> for molecule in results['results']:
-        ...     print(f"{molecule['chembl_id']}: {molecule['name']} (score: {molecule['score']})")
-
-        Output:
-        Found 3 molecules
-        CHEMBL25: Aspirin (score: 23.5)
-        CHEMBL1456: Acetylsalicylic acid derivative (score: 12.3)
-
-    Use Cases:
-        - Finding ChEMBL IDs for known drugs or compounds
-        - Discovering molecules with similar names
-        - Searching for bioactive compounds by structure (using SMILES/InChI)
-        - Identifying research compounds and clinical candidates
+                - 'score' (float): Relevance score (None for structure-search hits)
 
     Note:
         - Some molecules may not have a preferred name and 'name' field will be None
-        - Higher scores indicate better matches to the query
-        - For structure-based searches, use SMILES or InChI notation
+        - Higher scores indicate better matches (name search only)
 
     On upstream/HTTP failure this tool does NOT raise — it returns a dict with a
     single 'error' key (a message plus a "fall back to SPARQL" hint) instead of
@@ -479,7 +658,11 @@ async def search_chembl_molecule(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    bulk = await search_chembl_generic("molecule", query, limit)
+    structure_kind = _looks_like_structure(query)
+    if structure_kind:
+        bulk = await _search_chembl_structure(structure_kind, query, limit)
+    else:
+        bulk = await search_chembl_generic("molecule", query, limit)
     if "error" in bulk:
         # Propagate the upstream-failure payload rather than silently
         # collapsing it into an empty {'total_count': 0, 'results': []}.

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -210,10 +210,13 @@ async def search_uniprot_entity(
 # thousands); (2) EBI REST is ~1/3 flaky. The RDF graph resolves deterministically
 # in one indexed query, returning label + organism + type. Synonyms/brands/gene
 # symbols live on skos:altLabel (on the molecule, and on the target COMPONENT).
-# REST is retained ONLY for chemical STRUCTURE search (SMILES/InChI/InChIKey →
-# flexmatch/similarity/substructure), which needs ChEMBL's chemistry engine and
-# cannot be expressed in SPARQL. Those REST helpers keep the retry/HTML-strip
-# plumbing below; EBI REST is flaky (~1/3 of calls 500 or time out).
+# Canonical structure IDENTIFIERS (InChIKey/InChI) are stored as RDF literals, so
+# they too resolve by exact SPARQL match. REST is retained ONLY for SMILES
+# (flexmatch) — a SMILES is written differently by each toolkit, so it needs the
+# chemistry engine's structural normalization, not an exact string match — and
+# would be needed for similarity/substructure search. Those REST helpers keep the
+# retry/HTML-strip plumbing below; EBI REST is flaky (~1/3 of calls 500 or time
+# out).
 _CHEMBL_MAX_ATTEMPTS = 3  # 1 initial try + 2 retries
 _CHEMBL_BACKOFF_BASE = 1.0  # seconds; nth retry waits base*n (patched to 0 in tests)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
@@ -361,22 +364,33 @@ async def _run_chembl_sparql(query: str) -> list[dict] | dict:
 
 
 # Structure-search routing for search_chembl_molecule.
-# /molecule/search.json is a LEXICAL text index — a SMILES string matched
-# against it returns meaningless name/synonym hits. Structure-shaped input must
-# instead go to /molecule.json with a structure filter. The detector is
-# deliberately conservative: a false positive misroutes a real drug name.
+# Structure IDENTIFIERS split by whether an exact string match is meaningful:
+#   • InChIKey / InChI are CANONICAL — every toolkit emits the identical string
+#     for a molecule — so an exact match on the RDF-stored value is correct and
+#     resolves in SPARQL (fast, on the reliable endpoint).
+#   • Canonical SMILES is toolkit-SPECIFIC — a user's SMILES is usually written
+#     differently than ChEMBL's stored canonical form, so an exact string match
+#     silently misses. It needs the REST chemistry engine's flexmatch, which
+#     normalizes tautomers/salts/charges before matching. (Similarity and
+#     substructure search would likewise need the chemistry engine.)
 _INCHIKEY_RE = re.compile(r"^[A-Z]{14}-[A-Z]{10}-[A-Z]$")
+# CHEMINF value-node types under the SIO qualified-value pattern
+# (?m sio:SIO_000008 ?node; ?node a <CHEMINF_*>; ?node sio:SIO_000300 ?value).
+_CHEMINF = {
+    "inchikey": "http://semanticscience.org/resource/CHEMINF_000059",
+    "inchi": "http://semanticscience.org/resource/CHEMINF_000113",
+}
 
 
 def _looks_like_structure(query: str) -> str | None:
     """Classify ``query`` as a chemical structure string.
 
     Returns ``"inchi"``, ``"inchikey"``, or ``"smiles"`` when the input is
-    structure-shaped, else ``None`` (route to the lexical name index).
+    structure-shaped, else ``None`` (route to name resolution).
 
-    Conservative by design — a name misrouted to the structure endpoint
-    returns nothing, so anything with whitespace (multi-word names) or without
-    unambiguous structural punctuation stays on the lexical path. This means a
+    Conservative by design — a name misrouted to a structure path returns
+    nothing, so anything with whitespace (multi-word names) or without
+    unambiguous structural punctuation stays on the name path. This means a
     bare-chain SMILES like ``CCO`` (ethanol) is NOT detected; that is the
     accepted trade-off for not misrouting drug names.
     """
@@ -394,21 +408,61 @@ def _looks_like_structure(query: str) -> str | None:
     return None
 
 
-async def _search_chembl_structure(kind: str, query: str, limit: int) -> dict:
-    """Query the ``/molecule.json`` structure endpoint (SMILES/InChI/InChIKey).
+def _bif_longest_token(text: str) -> str | None:
+    """Single-quoted bif:contains prefilter using the longest alphanumeric token.
 
-    Returns the same ``{"page_meta", "molecules"}`` shape as the lexical search
-    endpoint, so callers parse both identically.
+    For a canonical identifier (InChIKey/InChI) one long distinctive token is a
+    highly selective, always-present prefilter; the exact FILTER then guarantees
+    the match. Returns None if there is no alphanumeric token.
     """
-    field = {
-        "smiles": "molecule_structures__canonical_smiles__flexmatch",
-        "inchikey": "molecule_structures__standard_inchi_key",
-        "inchi": "molecule_structures__standard_inchi",
-    }[kind]
-    filt = {field: query, "limit": limit}
+    toks = re.findall(r"[a-z0-9]+", text.lower())
+    if not toks:
+        return None
+    return f"'{max(toks, key=len)}'"
+
+
+async def _search_chembl_smiles_flexmatch(query: str, limit: int) -> dict:
+    """SMILES → molecule via the ChEMBL REST chemistry engine (flexmatch).
+
+    Returns the ``{"page_meta", "molecules"}`` REST shape. Used only for SMILES:
+    flexmatch normalizes the structure first, so it tolerates the toolkit-specific
+    ways the same molecule's canonical SMILES may be written. (InChIKey/InChI are
+    canonical and resolved via SPARQL — see _search_chembl_inchi_sparql.)
+    """
+    filt = {
+        "molecule_structures__canonical_smiles__flexmatch": query,
+        "limit": limit,
+    }
     return await _chembl_get_json(
-        "/chembl/api/data/molecule.json", filt, context="ChEMBL structure search"
+        "/chembl/api/data/molecule.json", filt, context="ChEMBL SMILES flexmatch"
     )
+
+
+async def _search_chembl_inchi_sparql(
+    kind: str, query: str, limit: int
+) -> list[dict] | dict:
+    """Exact InChIKey / InChI → molecule lookup over the RDF graph.
+
+    These identifiers are canonical, so an exact (CASE-SENSITIVE — InChIKeys are
+    canonical uppercase) match on the stored SIO_000300 value is correct and
+    toolkit-independent. bif:contains on the longest token prefilters via the
+    Virtuoso text index. Returns CSV rows as list[dict], or {"error": ...}.
+    """
+    prefilter = _bif_longest_token(query)
+    if prefilter is None:
+        return []
+    sparql = (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"PREFIX sio: <http://semanticscience.org/resource/>\n"
+        f"SELECT DISTINCT ?chembl_id ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"  ?node a <{_CHEMINF[kind]}> ; sio:SIO_000300 ?v .\n"
+        f'  ?v bif:contains "{prefilter}" .\n'
+        f'  FILTER(STR(?v) = "{_sparql_literal(query)}")\n'
+        f"  ?m sio:SIO_000008 ?node ; a cco:SmallMolecule ;\n"
+        f"     cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        f"}} LIMIT {int(limit)}"
+    )
+    return await _run_chembl_sparql(sparql)
 
 
 @mcp.tool()
@@ -672,19 +726,24 @@ async def search_chembl_molecule(
     ⚠️ For biological targets (proteins, receptors, enzymes, genes such as
        EGFR, BRCA1, TP53), use `search_chembl_target` instead.
 
-    Two resolution paths, auto-selected from the query shape:
+    Resolution path is auto-selected from the query shape:
 
     • NAME / BRAND / SYNONYM → deterministic SPARQL, EXACT (case-insensitive)
       match on the molecule's skos:altLabel synonyms (which include brand and
       trade names — "Gleevec" → CHEMBL941 IMATINIB). Not fuzzy/substring: fix
       typos before calling. No relevance ranking to second-guess.
 
-    • STRUCTURE (SMILES / InChI / InChIKey) → the ChEMBL REST chemistry engine
-      (flexmatch), which SPARQL cannot do. Auto-detected from structural
-      punctuation / the "InChI=" prefix / the InChIKey pattern, e.g. aspirin's
-      SMILES "CC(=O)Oc1ccccc1C(=O)O" → CHEMBL25. Detection is conservative
-      (multi-word input, or input without structural punctuation, is treated as
-      a name), so a bare-chain SMILES like "CCO" is treated as a name.
+    • InChIKey / InChI → deterministic SPARQL, EXACT (case-SENSITIVE) match on the
+      RDF-stored identifier. These are canonical (toolkit-independent), so exact
+      match is correct, e.g. "BSYNRYMUTXBXSQ-UHFFFAOYSA-N" → CHEMBL25.
+
+    • SMILES → the ChEMBL REST chemistry engine (flexmatch), NOT exact match: a
+      SMILES is written differently by each toolkit, so flexmatch normalizes the
+      structure first, e.g. "CC(=O)Oc1ccccc1C(=O)O" → CHEMBL25.
+
+    Structure detection is conservative (multi-word input, or input without the
+    "InChI=" prefix / InChIKey pattern / structural punctuation, is treated as a
+    name), so a bare-chain SMILES like "CCO" is treated as a name.
 
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
@@ -718,10 +777,11 @@ async def search_chembl_molecule(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
-    # Structure-shaped input → REST chemistry engine (SPARQL cannot do this).
+    # Structure-shaped input.
     structure_kind = _looks_like_structure(query)
-    if structure_kind:
-        bulk = await _search_chembl_structure(structure_kind, query, limit)
+    if structure_kind == "smiles":
+        # SMILES canonical form is toolkit-specific → REST flexmatch normalizes.
+        bulk = await _search_chembl_smiles_flexmatch(query.strip(), limit)
         if "error" in bulk:
             return bulk
         total_count = bulk.get("page_meta", {}).get("total_count", 0)
@@ -734,6 +794,16 @@ async def search_chembl_molecule(
             for m in bulk.get("molecules", [])
         ]
         return {"total_count": total_count, "results": parsed_results}
+    if structure_kind in ("inchikey", "inchi"):
+        # Canonical identifiers → exact SPARQL lookup (reliable endpoint).
+        rows = await _search_chembl_inchi_sparql(structure_kind, query.strip(), limit)
+        if isinstance(rows, dict):
+            return rows  # {"error": ...}
+        parsed_results = [
+            {"chembl_id": r.get("chembl_id"), "name": r.get("name"), "score": None}
+            for r in rows
+        ]
+        return {"total_count": len(parsed_results), "results": parsed_results}
 
     # Name/brand/synonym → deterministic SPARQL exact match on skos:altLabel.
     match = _altlabel_match_block(query)

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -247,7 +247,10 @@ sparql_query_examples:
     sparql: |
       PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
 
-      # Workflow: search_chembl_target("EGFR") → CHEMBL203; search_chembl_target("VEGFR2") → CHEMBL279
+      # Workflow: resolve targets to IRIs first. By UniProt accession this is exact
+      # (search_chembl_target("P00533") → CHEMBL203 rank 1). By name/symbol the intended
+      # target ranks below orthologs/ligands (EGFR → CHEMBL203 is rank ~6), so verify
+      # organism/type. Here: CHEMBL203 = EGFR (P00533), CHEMBL279 = VEGFR2 (P35968).
       SELECT ?targetLabel ?molecule ?moleculeLabel
       FROM <http://rdf.ebi.ac.uk/dataset/chembl>
       WHERE {
@@ -588,6 +591,7 @@ architectural_notes:
   query_strategy:
     - "MANDATORY FIRST STEP: get_MIE_file('chembl') and read critical_warnings + shape_expressions"
     - "Exploratory: search_chembl_molecule() and search_chembl_target() to find examples and extract IRIs"
+    - "Target resolution: prefer search_chembl_target() with a UniProt accession (e.g. 'P00533' → CHEMBL203 at rank 1). Name/symbol queries rank the intended target below orthologs/ligands/PPI complexes (EGFR name → CHEMBL203 is only rank ~6), so inspect organism/type — do not trust rank. For exact resolution, SPARQL on rdfs:label + cco:organismName is most reliable."
     - "Inspection: SELECT * WHERE { VALUES ?entity {...} ?entity ?p ?o } to confirm properties"
     - "Comprehensive: use specific IRIs in VALUES or typed predicates — NOT search result IDs in VALUES"
     - "MeSH: exploratory FILTER(CONTAINS(LCASE(?meshHeading),'disease')) to find IRI, then switch to specific IRI"

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -34,9 +34,9 @@ schema_info:
     - search_chembl_molecule
     - search_chembl_target
   version:
-    mie_version: "3.1"
+    mie_version: "3.2"
     mie_created: "2025-02-10"
-    mie_updated: "2026-07-07"
+    mie_updated: "2026-07-14"
     data_version: ChEMBL 34.0
     update_frequency: Quarterly
   license:
@@ -65,6 +65,17 @@ critical_warnings: |
   - PERFORMANCE: Combining cco:taxonomy IRI with cco:hasProteinClassification in one query
     times out (verified 2026-04-21). Use the typed predicate cco:organismName "Homo sapiens"
     for organism filtering in combined queries instead of the taxonomy IRI.
+  - NAME → ID RESOLUTION (skos:altLabel): synonyms/brands (molecule) and gene symbols
+    (target component) live on skos:altLabel — NOT rdfs:label/skos:prefLabel, which hold only the
+    single canonical name. A name/brand/symbol lookup that filters rdfs:label misses them silently.
+    MECHANISM MATTERS: FILTER(LCASE(?alt)="gleevec") or FILTER(CONTAINS(...)) scans all ~1.8M
+    altLabels and takes ~11s (near timeout). Use the Virtuoso text index instead — bind the label,
+    prefilter with bif:contains, then FILTER for exactness (~0.1s):
+      ?m skos:altLabel ?alt . ?alt bif:contains "Gleevec" . FILTER(LCASE(STR(?alt)) = "gleevec")
+    bif:contains needs ?alt already bound by a triple pattern (put the skos:altLabel triple FIRST,
+    else HTTP 400). Target symbols sit on the component: ?t cco:hasTargetComponent ?c . ?c
+    skos:altLabel ?alt . ?alt bif:contains "EGFR" . Add cco:targetType "SINGLE PROTEIN" +
+    cco:organismName "Homo sapiens" to collapse orthologs/complexes to the one intended target.
 
 shape_expressions: |
   PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
@@ -75,6 +86,7 @@ shape_expressions: |
     a [ cco:SmallMolecule ] ;
     rdfs:label xsd:string ;
     skos:prefLabel xsd:string ;
+    skos:altLabel xsd:string * ;
     cco:chemblId xsd:string ;
     cco:highestDevelopmentPhase xsd:integer ? ;
     cco:atcClassification xsd:string * ;
@@ -83,6 +95,10 @@ shape_expressions: |
     cco:hasDrugIndication @<DrugIndicationShape> * ;
     cco:hasMechanism @<DrugMechanismShape> * ;
     cco:moleculeXref IRI *
+  # NOTE: skos:altLabel holds synonyms — generic + brand/trade names (e.g. "Gleevec",
+  #       "Glivec"), research codes (NSC-/SID-), and IUPAC names. It is the predicate for
+  #       name/brand → molecule ID resolution. See critical_warnings for the fast idiom.
+  #       1,839,581 SmallMolecule (~96%) carry ≥1 altLabel (verified 2026-07-14).
   # NOTE: Molecule→ChEBI links use cco:moleculeXref (EBI URL format, requires IRI conversion)
   # NOTE: skos:exactMatch is ONLY on TargetComponent (UniProt link), NOT on SmallMolecule
   # COUNTS: 1,920,603 SmallMolecule instances (verified 2026-04-21)
@@ -127,7 +143,14 @@ shape_expressions: |
   <TargetComponentShape> {
     a [ cco:TargetComponent ] ;
     cco:chemblId xsd:string ;
+    skos:altLabel xsd:string * ;
     skos:exactMatch IRI *
+  # NOTE: skos:altLabel holds component synonyms — GENE SYMBOL (e.g. "EGFR"), the UniProt
+  #       accession AS A STRING (e.g. "P00533"), the full protein name, and PDB codes. It is
+  #       the predicate for gene-symbol/protein-name → target ID resolution, and it sits on the
+  #       COMPONENT, not the Target (the cco:SingleProtein/etc. entity has NO altLabel). Reach it
+  #       via ?target cco:hasTargetComponent/skos:altLabel ?syn. 12,782 components carry altLabel.
+  #       For the accession specifically, prefer the structured skos:exactMatch IRI (below).
   # NOTE: skos:exactMatch on TargetComponent links to UniProt (http://purl.uniprot.org/uniprot/[ID])
   # COUNTS: ~11k UniProt cross-references
   }
@@ -239,6 +262,33 @@ sparql_query_examples:
       }
       ORDER BY ?label
       LIMIT 50
+
+  - title: Resolve a Gene Symbol / Brand Name to a ChEMBL ID via skos:altLabel
+    description: "Name/symbol/brand → ID resolution. Synonyms live on skos:altLabel (gene symbols on the target COMPONENT, brands on the molecule), not rdfs:label. Uses the bif:contains text index (prefilter) + exact FILTER — fast (~0.1s); a bare FILTER(CONTAINS()) scans all altLabels and takes ~11s. Constrains to human SINGLE PROTEIN to collapse orthologs/complexes to the one intended target."
+    question: Which ChEMBL target is the gene EGFR? (and, in comment, which molecule is 'Gleevec'?)
+    complexity: basic
+    sparql: |
+      PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      # Gene symbol → target ID. altLabel is on the COMPONENT; symbol also appears as accession
+      # string "P00533" and PDB codes there. Put the skos:altLabel triple BEFORE bif:contains
+      # (else HTTP 400). SINGLE PROTEIN + Homo sapiens → exactly CHEMBL203, no orthologs/complexes.
+      SELECT DISTINCT ?target ?label
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        ?component skos:altLabel ?alt .
+        ?alt bif:contains "EGFR" .
+        FILTER(LCASE(STR(?alt)) = "egfr")
+        ?target cco:hasTargetComponent ?component ;
+                rdfs:label ?label ;
+                cco:targetType "SINGLE PROTEIN" ;
+                cco:organismName "Homo sapiens" .
+      }
+      LIMIT 10
+      # Molecule brand/synonym → ID (same idiom, altLabel on the molecule itself):
+      #   ?m a cco:SmallMolecule ; skos:altLabel ?alt . ?alt bif:contains "Gleevec" .
+      #   FILTER(LCASE(STR(?alt)) = "gleevec")   → CHEMBL941 (IMATINIB) + CHEMBL1642 (mesylate)
 
   - title: Get IC50 Measurements for Specific Targets Using VALUES with IRIs
     description: "Retrieves IC50 data for EGFR and VEGFR2 using specific target IRIs (from search_chembl_target) and typed predicate cco:standardType."
@@ -591,7 +641,7 @@ architectural_notes:
   query_strategy:
     - "MANDATORY FIRST STEP: get_MIE_file('chembl') and read critical_warnings + shape_expressions"
     - "Exploratory: search_chembl_molecule() and search_chembl_target() to find examples and extract IRIs"
-    - "Target resolution: prefer search_chembl_target() with a UniProt accession (e.g. 'P00533' → CHEMBL203 at rank 1). Name/symbol queries rank the intended target below orthologs/ligands/PPI complexes (EGFR name → CHEMBL203 is only rank ~6), so inspect organism/type — do not trust rank. For exact resolution, SPARQL on rdfs:label + cco:organismName is most reliable."
+    - "Target resolution: prefer search_chembl_target() with a UniProt accession (e.g. 'P00533' → CHEMBL203 at rank 1). Name/symbol queries rank the intended target below orthologs/ligands/PPI complexes (EGFR name → CHEMBL203 is only rank ~6), so inspect organism/type — do not trust rank. For exact, deterministic resolution, SPARQL is most reliable: gene symbols/brands live on skos:altLabel (component for targets, molecule for drugs) — resolve via bif:contains + exact FILTER + SINGLE PROTEIN/Homo sapiens (see critical_warnings and the altLabel example). rdfs:label/skos:prefLabel hold ONLY the canonical name and miss synonyms."
     - "Inspection: SELECT * WHERE { VALUES ?entity {...} ?entity ?p ?o } to confirm properties"
     - "Comprehensive: use specific IRIs in VALUES or typed predicates — NOT search result IDs in VALUES"
     - "MeSH: exploratory FILTER(CONTAINS(LCASE(?meshHeading),'disease')) to find IRI, then switch to specific IRI"


### PR DESCRIPTION
Sync of `dev` → `main`. 8 commits, 10 files, +1222/−292.

## ChEMBL search redesign (headline)

The three `search_chembl_*` tools now resolve text → ChEMBL ID via **deterministic SPARQL** against the RDF Portal graph instead of the EBI REST lexical index. The lexical index ranked the intended entity below orthologs/ligands/synonym noise (EGFR → the receptor was rank ~6; a protein-name query returned thousands) and EBI REST is ~1/3 flaky; SPARQL resolves exactly in one indexed query returning label + organism + type.

- **`fb4e0b5`** — first-pass wrapper hardening: structure routing, transient-5xx retry, HTML-stripped errors, richer lookups + docs.
- **`794854c`** — MIE fix: document `skos:altLabel` (the name/symbol→ID predicate the MIE had omitted — brands on the molecule, gene symbols/accession on the target component; 1.84M / 12.8k entities), with the fast `bif:contains`-prefilter idiom vs the ~11s `FILTER` trap.
- **`5c5fd7a`** — SPARQL-backed resolution for all three tools: names/synonyms/gene-symbols via `skos:altLabel` exact match, UniProt accession via `skos:exactMatch`, `organism`/`target_type` filters in-query. Removes the lexical path, limit-floor, and rank warnings. REST kept only for chemical structure.
- **`0ad3703`** — InChIKey/InChI resolve via SPARQL too (they're canonical identifiers → exact match is correct); REST retained only for SMILES flexmatch (toolkit-specific canonical form needs the chemistry engine).

Net: everything canonical — names, symbols, accessions, InChIKey, InChI — is on the one reliable SPARQL endpoint; REST is down to SMILES flexmatch. Match is exact (case-insensitive for names, case-sensitive for structure IDs); a small pure `_bif_and`/`_bif_longest_token` normalizer makes `bif:contains` robust to numerics/punctuation/apostrophes.

## Ablation-harness API auth

- **`f711481`** — scale benchmark scripts/docs to 100 questions + ablation replication.
- **`9107f05`** — `--judge-use-api`: judge via the Anthropic API with the key scoped to the judge subprocess.
- **`b522921`** — abort after N consecutive fully-failed rows instead of silently writing all-zero scores.
- **`f677d18`** — `--answer-use-api`: answer via the Anthropic API rather than the subscription/agent-SDK path.

## Tests

Full suite passing (165). ChEMBL tests rewritten for SPARQL routing (respx POST mocks) + pure-helper units (`_bif_and`, `_bif_longest_token`, `_sparql_literal`, accession regex, structure detection); structure→REST and error/empty paths covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)