### PR TITLE
Sync dev → main: ChEMBL id_lookup breadth, MIE v3.3, response-contract fixes + server version

### DIFF
--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -222,11 +222,7 @@ class TestSearchChemblMolecule:
         assert "'gleevec'" in sent  # normalized bif token
         assert 'FILTER(LCASE(STR(?alt)) = "gleevec")' in sent  # exactness
         assert result["total_count"] == 1
-        assert result["results"][0] == {
-            "chembl_id": "CHEMBL941",
-            "name": "IMATINIB",
-            "score": None,
-        }
+        assert result["results"][0] == {"chembl_id": "CHEMBL941", "name": "IMATINIB"}
 
     @pytest.mark.asyncio
     async def test_smiles_uses_rest_flexmatch_not_sparql(self) -> None:
@@ -329,8 +325,13 @@ class TestSearchChemblTarget:
             "name": "Epidermal growth factor receptor",
             "organism": "Homo sapiens",
             "type": "SINGLE PROTEIN",
-            "score": None,
         }
+
+    @pytest.mark.asyncio
+    async def test_invalid_target_type_raises(self) -> None:
+        # An unrecognized enum value must fail loudly, not silently match 0 rows.
+        with pytest.raises(ValueError, match="Invalid target_type"):
+            await search_chembl_target("EGFR", target_type="BOGUS_TYPE")
 
     @pytest.mark.asyncio
     async def test_symbol_uses_altlabel(self) -> None:
@@ -387,8 +388,8 @@ class TestSearchChemblIdLookup:
                 return_value=httpx.Response(
                     200,
                     text=_csv(
-                        "chembl_id,entity_type,name",
-                        "CHEMBL203,TARGET,Epidermal growth factor receptor",
+                        "chembl_id,entity_type,name,organism",
+                        "CHEMBL203,TARGET,Epidermal growth factor receptor,Homo sapiens",
                     ),
                 )
             )
@@ -399,7 +400,25 @@ class TestSearchChemblIdLookup:
                      "cco:Tissue"):
             assert frag in sent
         assert "cco:Assay" not in sent  # ASSAY excluded from the default UNION
+        assert "cco:organismName" in sent  # organism carried for disambiguation
         assert result["results"][0]["entity_type"] == "TARGET"
+        assert result["results"][0]["organism"] == "Homo sapiens"
+
+    @pytest.mark.asyncio
+    async def test_compound_organism_is_null(self) -> None:
+        # Molecules have no organism → the branch must not bind it (null in output).
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv("chembl_id,entity_type,name,organism", "CHEMBL25,COMPOUND,ASPIRIN,"),
+                )
+            )
+            result = await search_chembl_id_lookup("aspirin", entity_type="compound")
+        sent = _sent_query(route)
+        # only the non-compound branches carry organism; here there is one branch (compound)
+        assert "cco:organismName" not in sent
+        assert result["results"][0]["organism"] is None
 
     @pytest.mark.asyncio
     async def test_entity_type_compound_single_branch(self) -> None:
@@ -450,8 +469,11 @@ class TestSearchChemblIdLookup:
             )
         sent = _sent_query(route)
         assert "cco:Assay" in sent and "dcterms:description" in sent
-        assert 'bif:contains "\'acetylcholinesterase\'"' in sent
         assert "FILTER(LCASE" not in sent  # keyword match, not exact
+        # relevance-ranked via the bif:contains score
+        assert "option (score ?sc)" in sent
+        assert "ORDER BY DESC(?sc)" in sent
+        assert "DISTINCT" not in sent  # DISTINCT would conflict with ORDER BY ?sc
         assert result["results"][0]["entity_type"] == "ASSAY"
 
     @pytest.mark.asyncio

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -377,11 +377,11 @@ class TestSearchChemblTarget:
 
 
 class TestSearchChemblIdLookup:
-    """Cross-entity resolution: UNION over compound + target branches, each an
-    exact altLabel match; entity_type narrows to one branch."""
+    """Cross-entity resolution. Default UNIONs the four EXACT-name kinds
+    (compound/target/cell_line/tissue); ASSAY is opt-in keyword-in-description."""
 
     @pytest.mark.asyncio
-    async def test_default_unions_both(self) -> None:
+    async def test_default_unions_four_name_kinds(self) -> None:
         with respx.mock(using="httpx") as router:
             route = router.post(CHEMBL_SPARQL_URL).mock(
                 return_value=httpx.Response(
@@ -394,8 +394,11 @@ class TestSearchChemblIdLookup:
             )
             result = await search_chembl_id_lookup("EGFR")
         sent = _sent_query(route)
-        assert "UNION" in sent
-        assert "cco:SmallMolecule" in sent and "cco:hasTargetComponent" in sent
+        assert sent.count("UNION") == 3  # 4 branches
+        for frag in ("cco:SmallMolecule", "cco:hasTargetComponent", "cco:CellLine",
+                     "cco:Tissue"):
+            assert frag in sent
+        assert "cco:Assay" not in sent  # ASSAY excluded from the default UNION
         assert result["results"][0]["entity_type"] == "TARGET"
 
     @pytest.mark.asyncio
@@ -412,9 +415,50 @@ class TestSearchChemblIdLookup:
         assert "cco:SmallMolecule" in sent and "cco:hasTargetComponent" not in sent
 
     @pytest.mark.asyncio
+    async def test_cell_line_uses_label_filter_no_prefilter(self) -> None:
+        # Small type-constrained set → plain exact FILTER on rdfs:label, no
+        # bif:contains prefilter needed.
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,entity_type,name", "CHEMBL3307278,CELL_LINE,CCRF S-180")
+                )
+            )
+            result = await search_chembl_id_lookup("CCRF S-180", entity_type="cell_line")
+        sent = _sent_query(route)
+        assert "cco:CellLine" in sent
+        assert "bif:contains" not in sent  # no prefilter for the small set
+        assert 'FILTER(LCASE(STR(?alt)) = "ccrf s-180")' in sent
+        assert result["results"][0]["chembl_id"] == "CHEMBL3307278"
+
+    @pytest.mark.asyncio
+    async def test_assay_keyword_in_description(self) -> None:
+        # ASSAY does a keyword match on dcterms:description — bif:contains, and
+        # crucially NO exact FILTER (descriptions are free text, not names).
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,entity_type,name",
+                        "CHEMBL641506,ASSAY,Inhibition of human acetylcholinesterase",
+                    ),
+                )
+            )
+            result = await search_chembl_id_lookup(
+                "acetylcholinesterase", entity_type="assay"
+            )
+        sent = _sent_query(route)
+        assert "cco:Assay" in sent and "dcterms:description" in sent
+        assert 'bif:contains "\'acetylcholinesterase\'"' in sent
+        assert "FILTER(LCASE" not in sent  # keyword match, not exact
+        assert result["results"][0]["entity_type"] == "ASSAY"
+
+    @pytest.mark.asyncio
     async def test_invalid_entity_type_raises(self) -> None:
+        # DOCUMENT is explicitly unsupported; ASSAY is now valid.
         with pytest.raises(ValueError, match="Invalid entity_type"):
-            await search_chembl_id_lookup("EGFR", entity_type="ASSAY")
+            await search_chembl_id_lookup("EGFR", entity_type="DOCUMENT")
 
 
 class TestChemblStructureRetryAndErrorCleaning:

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -296,7 +296,7 @@ class TestSearchChemblMolecule:
             route = router.post(CHEMBL_SPARQL_URL)
             result = await search_chembl_molecule("---")
         assert not route.called
-        assert result == {"total_count": 0, "results": []}
+        assert result == {"total_count": 0, "has_more": False, "results": []}
 
 
 class TestSearchChemblTarget:
@@ -453,14 +453,16 @@ class TestSearchChemblIdLookup:
     @pytest.mark.asyncio
     async def test_assay_keyword_in_description(self) -> None:
         # ASSAY does a keyword match on dcterms:description — bif:contains, and
-        # crucially NO exact FILTER (descriptions are free text, not names).
+        # crucially NO exact FILTER (descriptions are free text, not names). It
+        # exposes `description` (not `name`) + a relevance `score`, ranked.
         with respx.mock(using="httpx") as router:
             route = router.post(CHEMBL_SPARQL_URL).mock(
                 return_value=httpx.Response(
                     200,
                     text=_csv(
-                        "chembl_id,entity_type,name",
-                        "CHEMBL641506,ASSAY,Inhibition of human acetylcholinesterase",
+                        "chembl_id,entity_type,description,organism,sc",
+                        "CHEMBL641506,ASSAY,Inhibition of human acetylcholinesterase,,28",
+                        "CHEMBL9,ASSAY,weaker match,,12",
                     ),
                 )
             )
@@ -474,7 +476,32 @@ class TestSearchChemblIdLookup:
         assert "option (score ?sc)" in sent
         assert "ORDER BY DESC(?sc)" in sent
         assert "DISTINCT" not in sent  # DISTINCT would conflict with ORDER BY ?sc
-        assert result["results"][0]["entity_type"] == "ASSAY"
+        row = result["results"][0]
+        assert row["entity_type"] == "ASSAY"
+        assert row["name"] is None  # assays have no name
+        assert row["description"] == "Inhibition of human acetylcholinesterase"
+        assert row["score"] == 28  # populated + non-increasing
+        assert result["results"][1]["score"] == 12
+
+    @pytest.mark.asyncio
+    async def test_has_more_true_when_over_limit(self) -> None:
+        # Over-fetch by one: limit+1 rows returned → has_more True, page capped.
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,entity_type,name,organism",
+                        "CHEMBL1,TISSUE,Liver,Rattus norvegicus",
+                        "CHEMBL2,TISSUE,Liver,Homo sapiens",
+                        "CHEMBL3,TISSUE,Liver,Mus musculus",  # the +1 over limit=2
+                    ),
+                )
+            )
+            result = await search_chembl_id_lookup("Liver", limit=2)
+        assert result["has_more"] is True
+        assert result["total_count"] == 2  # capped to limit
+        assert len(result["results"]) == 2
 
     @pytest.mark.asyncio
     async def test_invalid_entity_type_raises(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -328,3 +328,17 @@ class TestIgnoreUnknownSearchKwargs:
         asyncio.run(mw.on_call_tool(context, call_next))
         # The made-up kwarg is dropped; the declared one survives.
         assert seen["args"] == {"query": "ALDH2"}
+
+
+class TestServerVersion:
+    """serverInfo.version must be TogoMCP's own version, not FastMCP's default."""
+
+    def test_reports_togomcp_version_not_fastmcp(self) -> None:
+        from importlib.metadata import version
+
+        from togo_mcp.server import mcp
+
+        assert mcp.version == version("togo-mcp")
+        # Sanity: it's a real version string, not the "0+unknown" source fallback
+        # (the package is installed in the test env).
+        assert mcp.version and mcp.version != "0+unknown"

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -477,8 +477,9 @@ async def search_chembl_id_lookup(
         str,
         Field(
             description=(
-                "Optional filter: COMPOUND (molecules) or TARGET (proteins). "
-                "Omit to search both."
+                "Optional: COMPOUND, TARGET, CELL_LINE, TISSUE, or ASSAY. Omit to "
+                "search the four name kinds together. ASSAY (keyword match on the "
+                "assay description) is opt-in only."
             ),
             default="",
         ),
@@ -491,27 +492,39 @@ async def search_chembl_id_lookup(
     name: str = "",
 ) -> dict:
     """
-    Resolve a name/synonym to ChEMBL IDs across compounds AND targets.
+    Resolve a name to ChEMBL IDs across several entity kinds in one call.
 
-    Cross-entity convenience wrapper: it runs the same exact-synonym SPARQL
-    resolution as `search_chembl_molecule` and `search_chembl_target` and UNIONs
-    the two, so one call covers "what ChEMBL entity is <text>?". Prefer the
-    entity-specific tools when you already know you want a drug or a target — they
-    carry the extra fields (organism/type). Only COMPOUND and TARGET are covered
-    (the two synonym-rich entity kinds); for assays/documents/cell-lines/tissues,
-    query SPARQL directly via run_sparql(database='chembl', ...).
+    Cross-entity convenience wrapper over the ChEMBL RDF graph. Two matching
+    regimes, because the entity kinds carry different searchable text:
 
-    Matching is EXACT (case-insensitive) against skos:altLabel synonyms — brands,
-    generic names, gene symbols — not fuzzy/substring. Fix typos in the query
-    before calling.
+    • EXACT (case-insensitive) NAME match — COMPOUND (skos:altLabel: brands,
+      generics, synonyms), TARGET (component skos:altLabel: gene symbols, protein
+      names), CELL_LINE and TISSUE (rdfs:label, e.g. "Liver", "CCRF S-180"). Not
+      fuzzy/substring — fix typos before calling. Prefer the entity-specific tools
+      (`search_chembl_molecule` / `search_chembl_target`) when you know the kind;
+      they carry extra fields (organism/type).
+
+    • KEYWORD-IN-DESCRIPTION — ASSAY. Assays have no name; their searchable text
+      is a free-text dcterms:description, so ASSAY does a keyword (token) match on
+      that description, NOT an exact match, e.g. entity_type="ASSAY",
+      query="acetylcholinesterase" → every assay whose description mentions it.
+
+    Default (no `entity_type`) searches the four EXACT-name kinds and UNIONs them.
+    ASSAY is opt-in via entity_type="ASSAY" — its keyword semantics and high hit
+    counts would otherwise swamp a name lookup. (DOCUMENT is not supported; query
+    SPARQL directly for it.)
 
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
+    Args:
+        entity_type (str, optional): One of COMPOUND, TARGET, CELL_LINE, TISSUE,
+            ASSAY. Omit to search the four name kinds together.
+
     Returns:
         dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id', 'entity_type'
-        (COMPOUND / TARGET), and 'name' (the entity's rdfs:label).
+        'results' (list)}. Each result has 'chembl_id', 'entity_type', and
+        'name' (rdfs:label for the name kinds; the description for ASSAY).
 
         On endpoint failure this tool does NOT raise — it returns a dict with a
         single 'error' key instead. Check for 'error' before reading 'results'.
@@ -531,40 +544,75 @@ async def search_chembl_id_lookup(
             "search, term, keyword, keywords, search_term, name."
         )
     et = entity_type.strip().upper() if entity_type else ""
-    if et and et not in {"COMPOUND", "TARGET"}:
+    allowed = {"COMPOUND", "TARGET", "CELL_LINE", "TISSUE", "ASSAY"}
+    if et and et not in allowed:
         raise ValueError(
-            f"Invalid entity_type {entity_type!r}. Use COMPOUND or TARGET (this "
-            "SPARQL-backed lookup covers those two synonym-rich kinds; for "
-            "assays/documents/cell-lines/tissues query SPARQL directly)."
+            f"Invalid entity_type {entity_type!r}. Use one of: "
+            f"{', '.join(sorted(allowed))} (DOCUMENT is not supported — query "
+            "SPARQL directly). Omit it to search the four name kinds together."
         )
-    match = _altlabel_match_block(query)
-    if match is None:
+    bif = _bif_and(query)
+    if bif is None:
         return {"total_count": 0, "results": []}
-    compound_branch = (
-        "  {\n"
-        "    ?e skos:altLabel ?alt .\n"
-        f"{match}\n"
-        "    ?e a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
-        '    BIND("COMPOUND" AS ?entity_type)\n'
-        "  }"
-    )
-    target_branch = (
-        "  {\n"
-        "    ?comp skos:altLabel ?alt .\n"
-        f"{match}\n"
-        "    ?e cco:hasTargetComponent ?comp ;\n"
-        "       cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
-        '    BIND("TARGET" AS ?entity_type)\n'
-        "  }"
-    )
-    if et == "COMPOUND":
-        body = compound_branch
-    elif et == "TARGET":
-        body = target_branch
+    exact = _sparql_literal(query.lower())
+
+    def exact_branch(label: str, bind: str, rest: str, prefilter: bool) -> str:
+        # bind → binds ?alt (+ ?chembl_id); prefilter uses the text index (needed
+        # for the huge altLabel sets, skipped for the small type-constrained ones).
+        lines = ["  {", f"    {bind}"]
+        if prefilter:
+            lines.append(f'    ?alt bif:contains "{bif}" .')
+        lines.append(f'    FILTER(LCASE(STR(?alt)) = "{exact}")')
+        lines.append(f"    {rest}")
+        lines.append(f'    BIND("{label}" AS ?entity_type)')
+        lines.append("  }")
+        return "\n".join(lines)
+
+    branches = {
+        "COMPOUND": exact_branch(
+            "COMPOUND",
+            "?e skos:altLabel ?alt .",
+            "?e a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .",
+            prefilter=True,
+        ),
+        "TARGET": exact_branch(
+            "TARGET",
+            "?comp skos:altLabel ?alt .",
+            "?e cco:hasTargetComponent ?comp ; cco:chemblId ?chembl_id ; "
+            "rdfs:label ?name .",
+            prefilter=True,
+        ),
+        "CELL_LINE": exact_branch(
+            "CELL_LINE",
+            "?e a cco:CellLine ; rdfs:label ?alt ; cco:chemblId ?chembl_id .",
+            "BIND(STR(?alt) AS ?name)",
+            prefilter=False,
+        ),
+        "TISSUE": exact_branch(
+            "TISSUE",
+            "?e a cco:Tissue ; rdfs:label ?alt ; cco:chemblId ?chembl_id .",
+            "BIND(STR(?alt) AS ?name)",
+            prefilter=False,
+        ),
+        "ASSAY": (
+            "  {\n"
+            "    ?e a cco:Assay ; dcterms:description ?desc ; cco:chemblId ?chembl_id .\n"
+            f'    ?desc bif:contains "{bif}" .\n'
+            "    BIND(STR(?desc) AS ?name)\n"
+            '    BIND("ASSAY" AS ?entity_type)\n'
+            "  }"
+        ),
+    }
+    if et:
+        body = branches[et]
     else:
-        body = f"{compound_branch}\n  UNION\n{target_branch}"
+        # Default: the four exact-name kinds (ASSAY's keyword match is opt-in).
+        body = "\n  UNION\n".join(
+            branches[t] for t in ("COMPOUND", "TARGET", "CELL_LINE", "TISSUE")
+        )
     sparql = (
         f"{_CHEMBL_PREFIXES}\n"
+        "PREFIX dcterms: <http://purl.org/dc/terms/>\n"
         f"SELECT DISTINCT ?chembl_id ?entity_type ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
         f"{body}\n"
         f"}} LIMIT {int(limit)}"

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -376,6 +376,16 @@ async def _run_chembl_sparql(query: str) -> list[dict] | dict:
     return list(csv.DictReader(io.StringIO(csv_text)))
 
 
+def _paginate(rows: list, limit: int) -> tuple[list, bool]:
+    """Split a limit+1 fetch into (page, has_more).
+
+    Query with LIMIT limit+1; if the extra row came back, more results exist
+    beyond this page. Lets a caller tell "N of N" from "N of many" — otherwise
+    total_count == limit is indistinguishable from a silent truncation.
+    """
+    return rows[:limit], len(rows) > limit
+
+
 # Structure-search routing for search_chembl_molecule.
 # Structure IDENTIFIERS split by whether an exact string match is meaningful:
 #   • InChIKey / InChI are CANONICAL — every toolkit emits the identical string
@@ -531,19 +541,20 @@ async def search_chembl_id_lookup(
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
+    RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is the
+    number of rows RETURNED (capped by `limit`), NOT the full match count; check
+    `has_more` (true = more results exist beyond this page — relevant mainly for
+    ASSAY, whose keyword search can have many hits). Each result carries
+    'chembl_id', 'entity_type', and 'organism' (null for COMPOUND / where absent —
+    use it to tell e.g. human from mouse targets). Name kinds also carry 'name'
+    (rdfs:label); ASSAY rows instead carry 'description' (the free-text assay
+    description, name=null) and a relevance 'score' (higher = better match).
+    On endpoint failure this tool does NOT raise — it returns a dict with a single
+    'error' key instead; CHECK FOR 'error' BEFORE READING 'results'.
+
     Args:
         entity_type (str, optional): One of COMPOUND, TARGET, CELL_LINE, TISSUE,
             ASSAY. Omit to search the four name kinds together.
-
-    Returns:
-        dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id', 'entity_type', 'name'
-        (rdfs:label for the name kinds; the description for ASSAY), and 'organism'
-        (null for COMPOUND and where absent) — the organism disambiguates a name
-        shared across species, e.g. human vs mouse targets.
-
-        On endpoint failure this tool does NOT raise — it returns a dict with a
-        single 'error' key instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -569,7 +580,7 @@ async def search_chembl_id_lookup(
         )
     bif = _bif_and(query)
     if bif is None:
-        return {"total_count": 0, "results": []}
+        return {"total_count": 0, "has_more": False, "results": []}
     exact = _sparql_literal(query.lower())
 
     def exact_branch(
@@ -622,25 +633,28 @@ async def search_chembl_id_lookup(
         ),
         # ASSAY: keyword match on the free-text description, relevance-ranked via the
         # bif:contains score (ORDER BY below); no exact FILTER, no DISTINCT.
+        # ASSAY has no name — the searchable text is the free-text description,
+        # exposed as `description` (not overloaded onto `name`), with a relevance
+        # `score` (the whole point of keyword search). Ranked by that score.
         "ASSAY": (
             "  {\n"
-            "    ?e a cco:Assay ; dcterms:description ?desc ; cco:chemblId ?chembl_id .\n"
-            f'    ?desc bif:contains "{bif}" option (score ?sc) .\n'
+            "    ?e a cco:Assay ; dcterms:description ?description ; cco:chemblId ?chembl_id .\n"
+            f'    ?description bif:contains "{bif}" option (score ?sc) .\n'
             "    OPTIONAL { ?e cco:organismName ?organism }\n"
-            "    BIND(STR(?desc) AS ?name)\n"
             '    BIND("ASSAY" AS ?entity_type)\n'
             "  }"
         ),
     }
     prefixes = f"{_CHEMBL_PREFIXES}\nPREFIX dcterms: <http://purl.org/dc/terms/>"
-    select = "?chembl_id ?entity_type ?name ?organism"
+    fetch = int(limit) + 1  # over-fetch by one to detect truncation (has_more)
     if et == "ASSAY":
         # Rank by description-match score; DISTINCT would conflict with ORDER BY ?sc.
         sparql = (
             f"{prefixes}\n"
-            f"SELECT {select} FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+            f"SELECT ?chembl_id ?entity_type (STR(?description) AS ?description) "
+            f"?organism ?sc FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
             f"{branches['ASSAY']}\n"
-            f"}} ORDER BY DESC(?sc) LIMIT {int(limit)}"
+            f"}} ORDER BY DESC(?sc) LIMIT {fetch}"
         )
     else:
         if et:
@@ -652,23 +666,42 @@ async def search_chembl_id_lookup(
             )
         sparql = (
             f"{prefixes}\n"
-            f"SELECT DISTINCT {select} FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+            f"SELECT DISTINCT ?chembl_id ?entity_type ?name ?organism "
+            f"FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
             f"{body}\n"
-            f"}} LIMIT {int(limit)}"
+            f"}} LIMIT {fetch}"
         )
     rows = await _run_chembl_sparql(sparql)
     if isinstance(rows, dict):
         return rows  # {"error": ...}
-    parsed_results = [
-        {
-            "chembl_id": r.get("chembl_id"),
-            "entity_type": r.get("entity_type"),
-            "name": r.get("name"),
-            "organism": r.get("organism") or None,
-        }
-        for r in rows
-    ]
-    return {"total_count": len(parsed_results), "results": parsed_results}
+    rows, has_more = _paginate(rows, int(limit))
+    if et == "ASSAY":
+        parsed_results = [
+            {
+                "chembl_id": r.get("chembl_id"),
+                "entity_type": "ASSAY",
+                "name": None,  # assays have no name — see `description`
+                "description": r.get("description"),
+                "organism": r.get("organism") or None,
+                "score": int(r["sc"]) if (r.get("sc") or "").strip().isdigit() else None,
+            }
+            for r in rows
+        ]
+    else:
+        parsed_results = [
+            {
+                "chembl_id": r.get("chembl_id"),
+                "entity_type": r.get("entity_type"),
+                "name": r.get("name"),
+                "organism": r.get("organism") or None,
+            }
+            for r in rows
+        ]
+    return {
+        "total_count": len(parsed_results),
+        "has_more": has_more,
+        "results": parsed_results,
+    }
 
 
 @mcp.tool()
@@ -705,8 +738,21 @@ async def search_chembl_target(
     or complexes is disambiguated by inspecting those fields (or by passing the
     `organism`/`target_type` filters) — NOT by trusting order.
 
+    Target-type values (for `type` and the `target_type` filter): SINGLE PROTEIN,
+    PROTEIN COMPLEX, PROTEIN FAMILY, PROTEIN-PROTEIN INTERACTION, CHIMERIC PROTEIN,
+    NUCLEIC-ACID, CELL-LINE, TISSUE, ORGANISM, SELECTIVITY GROUP, SMALL MOLECULE,
+    OLIGOSACCHARIDE, LIPID, METAL, and other rarer kinds. An unrecognized
+    `target_type` raises rather than silently matching nothing.
+
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
+
+    RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is rows
+    RETURNED (capped by `limit`), not the full match count; `has_more` is true if
+    more exist beyond this page. Each result has 'chembl_id', 'name' (rdfs:label),
+    'organism', and 'type'. On endpoint failure this tool does NOT raise — it
+    returns a dict with a single 'error' key instead; CHECK FOR 'error' BEFORE
+    READING 'results'.
 
     Args:
         query (str): UniProt accession (preferred), gene symbol, or exact protein
@@ -715,23 +761,8 @@ async def search_chembl_target(
         organism (str, optional): Case-insensitive substring filter on organism,
             e.g. "Homo sapiens". Applied inside the query.
         target_type (str, optional): Exact (case-insensitive) filter on target
-            type, e.g. "SINGLE PROTEIN" — pass this to collapse an accession/symbol
-            match to the canonical single protein and drop complexes/families. Must
-            be a value from the ChEMBL target-type vocabulary (see below); an
-            unrecognized value raises rather than silently matching nothing.
-
-    Target Types (values of `type`): SINGLE PROTEIN, PROTEIN COMPLEX,
-        PROTEIN FAMILY, PROTEIN-PROTEIN INTERACTION, CHIMERIC PROTEIN,
-        NUCLEIC-ACID, CELL-LINE, TISSUE, ORGANISM, SELECTIVITY GROUP,
-        SMALL MOLECULE, OLIGOSACCHARIDE, LIPID, METAL, and other rarer kinds.
-
-    Returns:
-        dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id', 'name' (rdfs:label),
-        'organism', and 'type'.
-
-        On endpoint failure this tool does NOT raise — it returns a dict with a
-        single 'error' key instead. Check for 'error' before reading 'results'.
+            type, e.g. "SINGLE PROTEIN" — collapses an accession/symbol match to the
+            canonical single protein and drops complexes/families.
     """
     query = _resolve_query_alias(
         query,
@@ -763,7 +794,7 @@ async def search_chembl_target(
     else:
         alt = _altlabel_match_block(query)
         if alt is None:
-            return {"total_count": 0, "results": []}
+            return {"total_count": 0, "has_more": False, "results": []}
         match_block = f"  ?comp skos:altLabel ?alt .\n{alt}"
 
     filters = ""
@@ -785,11 +816,12 @@ async def search_chembl_target(
         f"  ?target cco:hasTargetComponent ?comp ;\n"
         f"          cco:chemblId ?chembl_id ; rdfs:label ?name ; cco:targetType ?type .\n"
         f"  OPTIONAL {{ ?target cco:organismName ?organism . }}{filters}\n"
-        f"}} LIMIT {int(limit)}"
+        f"}} LIMIT {int(limit) + 1}"
     )
     rows = await _run_chembl_sparql(sparql)
     if isinstance(rows, dict):
         return rows  # {"error": ...}
+    rows, has_more = _paginate(rows, int(limit))
     parsed_results = [
         {
             "chembl_id": r.get("chembl_id"),
@@ -799,7 +831,11 @@ async def search_chembl_target(
         }
         for r in rows
     ]
-    return {"total_count": len(parsed_results), "results": parsed_results}
+    return {
+        "total_count": len(parsed_results),
+        "has_more": has_more,
+        "results": parsed_results,
+    }
 
 
 @mcp.tool()
@@ -843,19 +879,18 @@ async def search_chembl_molecule(
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
+    RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is rows
+    RETURNED (capped by `limit`), not the full match count; `has_more` is true if
+    more exist beyond this page. Each result has 'chembl_id' (e.g. "CHEMBL25") and
+    'name' (rdfs:label, may be None for some structure hits). On endpoint/HTTP
+    failure this tool does NOT raise — it returns a dict with a single 'error' key
+    instead; CHECK FOR 'error' BEFORE READING 'results'.
+
     Args:
         query (str): Drug/compound name, brand, synonym, or a structure string.
             Examples: "Aspirin", "Gleevec", "CC(=O)Oc1ccccc1C(=O)O",
             "BSYNRYMUTXBXSQ-UHFFFAOYSA-N".
         limit (int, optional): Maximum number of results to return. Defaults to 20.
-
-    Returns:
-        dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id' (e.g. "CHEMBL25") and
-        'name' (rdfs:label, may be None for some structure hits).
-
-        On endpoint/HTTP failure this tool does NOT raise — it returns a dict with
-        a single 'error' key instead. Check for 'error' before reading 'results'.
     """
     query = _resolve_query_alias(
         query,
@@ -878,7 +913,8 @@ async def search_chembl_molecule(
         bulk = await _search_chembl_smiles_flexmatch(query.strip(), limit)
         if "error" in bulk:
             return bulk
-        total_count = bulk.get("page_meta", {}).get("total_count", 0)
+        # REST page_meta.total_count is the TRUE match count; has_more from it.
+        upstream_total = bulk.get("page_meta", {}).get("total_count", 0)
         parsed_results = [
             {
                 "chembl_id": m.get("molecule_chembl_id"),
@@ -886,38 +922,54 @@ async def search_chembl_molecule(
             }
             for m in bulk.get("molecules", [])
         ]
-        return {"total_count": total_count, "results": parsed_results}
+        return {
+            "total_count": len(parsed_results),
+            "has_more": upstream_total > len(parsed_results),
+            "results": parsed_results,
+        }
     if structure_kind in ("inchikey", "inchi"):
         # Canonical identifiers → exact SPARQL lookup (reliable endpoint).
-        rows = await _search_chembl_inchi_sparql(structure_kind, query.strip(), limit)
+        rows = await _search_chembl_inchi_sparql(
+            structure_kind, query.strip(), int(limit) + 1
+        )
         if isinstance(rows, dict):
             return rows  # {"error": ...}
+        rows, has_more = _paginate(rows, int(limit))
         parsed_results = [
             {"chembl_id": r.get("chembl_id"), "name": r.get("name")}
             for r in rows
         ]
-        return {"total_count": len(parsed_results), "results": parsed_results}
+        return {
+            "total_count": len(parsed_results),
+            "has_more": has_more,
+            "results": parsed_results,
+        }
 
     # Name/brand/synonym → deterministic SPARQL exact match on skos:altLabel.
     match = _altlabel_match_block(query)
     if match is None:
-        return {"total_count": 0, "results": []}
+        return {"total_count": 0, "has_more": False, "results": []}
     sparql = (
         f"{_CHEMBL_PREFIXES}\n"
         f"SELECT DISTINCT ?chembl_id ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
         f"  ?m skos:altLabel ?alt .\n"
         f"{match}\n"
         f"  ?m a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
-        f"}} LIMIT {int(limit)}"
+        f"}} LIMIT {int(limit) + 1}"
     )
     rows = await _run_chembl_sparql(sparql)
     if isinstance(rows, dict):
         return rows  # {"error": ...}
+    rows, has_more = _paginate(rows, int(limit))
     parsed_results = [
         {"chembl_id": r.get("chembl_id"), "name": r.get("name")}
         for r in rows
     ]
-    return {"total_count": len(parsed_results), "results": parsed_results}
+    return {
+        "total_count": len(parsed_results),
+        "has_more": has_more,
+        "results": parsed_results,
+    }
 
 
 # DB: PubChem

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -302,6 +302,19 @@ _CHEMBL_PREFIXES = (
 _UNIPROT_ACCESSION_RE = re.compile(
     r"^(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2})$"
 )
+# The full cco:targetType controlled vocabulary (enumerated live 2026-07-14), used
+# to validate the target_type filter so a typo fails loudly instead of as 0 rows.
+_CHEMBL_TARGET_TYPES = frozenset(
+    {
+        "SINGLE PROTEIN", "ORGANISM", "CELL-LINE", "PROTEIN COMPLEX",
+        "PROTEIN-PROTEIN INTERACTION", "PROTEIN FAMILY", "TISSUE",
+        "SELECTIVITY GROUP", "NUCLEIC-ACID", "PROTEIN COMPLEX GROUP",
+        "SMALL MOLECULE", "CHIMERIC PROTEIN", "OLIGOSACCHARIDE", "UNKNOWN",
+        "MACROMOLECULE", "SUBCELLULAR", "LIPID", "PROTEIN NUCLEIC-ACID COMPLEX",
+        "METAL", "3D CELL CULTURE", "PHENOTYPE", "UNCHECKED", "NO TARGET",
+        "ADMET", "NON-MOLECULAR",
+    }
+)
 
 
 def _bif_and(text: str) -> str | None:
@@ -508,6 +521,7 @@ async def search_chembl_id_lookup(
       is a free-text dcterms:description, so ASSAY does a keyword (token) match on
       that description, NOT an exact match, e.g. entity_type="ASSAY",
       query="acetylcholinesterase" → every assay whose description mentions it.
+      ASSAY results are relevance-ranked (best description match first).
 
     Default (no `entity_type`) searches the four EXACT-name kinds and UNIONs them.
     ASSAY is opt-in via entity_type="ASSAY" — its keyword semantics and high hit
@@ -523,8 +537,10 @@ async def search_chembl_id_lookup(
 
     Returns:
         dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id', 'entity_type', and
-        'name' (rdfs:label for the name kinds; the description for ASSAY).
+        'results' (list)}. Each result has 'chembl_id', 'entity_type', 'name'
+        (rdfs:label for the name kinds; the description for ASSAY), and 'organism'
+        (null for COMPOUND and where absent) — the organism disambiguates a name
+        shared across species, e.g. human vs mouse targets.
 
         On endpoint failure this tool does NOT raise — it returns a dict with a
         single 'error' key instead. Check for 'error' before reading 'results'.
@@ -556,14 +572,20 @@ async def search_chembl_id_lookup(
         return {"total_count": 0, "results": []}
     exact = _sparql_literal(query.lower())
 
-    def exact_branch(label: str, bind: str, rest: str, prefilter: bool) -> str:
+    def exact_branch(
+        label: str, bind: str, rest: str, prefilter: bool, has_organism: bool
+    ) -> str:
         # bind → binds ?alt (+ ?chembl_id); prefilter uses the text index (needed
         # for the huge altLabel sets, skipped for the small type-constrained ones).
+        # has_organism → carry cco:organismName so callers can disambiguate a name
+        # shared across species (e.g. mouse CHEMBL3608 vs human CHEMBL203).
         lines = ["  {", f"    {bind}"]
         if prefilter:
             lines.append(f'    ?alt bif:contains "{bif}" .')
         lines.append(f'    FILTER(LCASE(STR(?alt)) = "{exact}")')
         lines.append(f"    {rest}")
+        if has_organism:
+            lines.append("    OPTIONAL { ?e cco:organismName ?organism }")
         lines.append(f'    BIND("{label}" AS ?entity_type)')
         lines.append("  }")
         return "\n".join(lines)
@@ -574,6 +596,7 @@ async def search_chembl_id_lookup(
             "?e skos:altLabel ?alt .",
             "?e a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .",
             prefilter=True,
+            has_organism=False,  # molecules have no organism
         ),
         "TARGET": exact_branch(
             "TARGET",
@@ -581,42 +604,58 @@ async def search_chembl_id_lookup(
             "?e cco:hasTargetComponent ?comp ; cco:chemblId ?chembl_id ; "
             "rdfs:label ?name .",
             prefilter=True,
+            has_organism=True,
         ),
         "CELL_LINE": exact_branch(
             "CELL_LINE",
             "?e a cco:CellLine ; rdfs:label ?alt ; cco:chemblId ?chembl_id .",
             "BIND(STR(?alt) AS ?name)",
             prefilter=False,
+            has_organism=True,
         ),
         "TISSUE": exact_branch(
             "TISSUE",
             "?e a cco:Tissue ; rdfs:label ?alt ; cco:chemblId ?chembl_id .",
             "BIND(STR(?alt) AS ?name)",
             prefilter=False,
+            has_organism=True,
         ),
+        # ASSAY: keyword match on the free-text description, relevance-ranked via the
+        # bif:contains score (ORDER BY below); no exact FILTER, no DISTINCT.
         "ASSAY": (
             "  {\n"
             "    ?e a cco:Assay ; dcterms:description ?desc ; cco:chemblId ?chembl_id .\n"
-            f'    ?desc bif:contains "{bif}" .\n'
+            f'    ?desc bif:contains "{bif}" option (score ?sc) .\n'
+            "    OPTIONAL { ?e cco:organismName ?organism }\n"
             "    BIND(STR(?desc) AS ?name)\n"
             '    BIND("ASSAY" AS ?entity_type)\n'
             "  }"
         ),
     }
-    if et:
-        body = branches[et]
-    else:
-        # Default: the four exact-name kinds (ASSAY's keyword match is opt-in).
-        body = "\n  UNION\n".join(
-            branches[t] for t in ("COMPOUND", "TARGET", "CELL_LINE", "TISSUE")
+    prefixes = f"{_CHEMBL_PREFIXES}\nPREFIX dcterms: <http://purl.org/dc/terms/>"
+    select = "?chembl_id ?entity_type ?name ?organism"
+    if et == "ASSAY":
+        # Rank by description-match score; DISTINCT would conflict with ORDER BY ?sc.
+        sparql = (
+            f"{prefixes}\n"
+            f"SELECT {select} FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+            f"{branches['ASSAY']}\n"
+            f"}} ORDER BY DESC(?sc) LIMIT {int(limit)}"
         )
-    sparql = (
-        f"{_CHEMBL_PREFIXES}\n"
-        "PREFIX dcterms: <http://purl.org/dc/terms/>\n"
-        f"SELECT DISTINCT ?chembl_id ?entity_type ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
-        f"{body}\n"
-        f"}} LIMIT {int(limit)}"
-    )
+    else:
+        if et:
+            body = branches[et]
+        else:
+            # Default: the four exact-name kinds (ASSAY's keyword match is opt-in).
+            body = "\n  UNION\n".join(
+                branches[t] for t in ("COMPOUND", "TARGET", "CELL_LINE", "TISSUE")
+            )
+        sparql = (
+            f"{prefixes}\n"
+            f"SELECT DISTINCT {select} FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+            f"{body}\n"
+            f"}} LIMIT {int(limit)}"
+        )
     rows = await _run_chembl_sparql(sparql)
     if isinstance(rows, dict):
         return rows  # {"error": ...}
@@ -625,6 +664,7 @@ async def search_chembl_id_lookup(
             "chembl_id": r.get("chembl_id"),
             "entity_type": r.get("entity_type"),
             "name": r.get("name"),
+            "organism": r.get("organism") or None,
         }
         for r in rows
     ]
@@ -676,17 +716,19 @@ async def search_chembl_target(
             e.g. "Homo sapiens". Applied inside the query.
         target_type (str, optional): Exact (case-insensitive) filter on target
             type, e.g. "SINGLE PROTEIN" — pass this to collapse an accession/symbol
-            match to the canonical single protein and drop complexes/families.
+            match to the canonical single protein and drop complexes/families. Must
+            be a value from the ChEMBL target-type vocabulary (see below); an
+            unrecognized value raises rather than silently matching nothing.
 
     Target Types (values of `type`): SINGLE PROTEIN, PROTEIN COMPLEX,
         PROTEIN FAMILY, PROTEIN-PROTEIN INTERACTION, CHIMERIC PROTEIN,
-        NUCLEIC-ACID, CELL-LINE, TISSUE, ORGANISM, …
+        NUCLEIC-ACID, CELL-LINE, TISSUE, ORGANISM, SELECTIVITY GROUP,
+        SMALL MOLECULE, OLIGOSACCHARIDE, LIPID, METAL, and other rarer kinds.
 
     Returns:
         dict: {'total_count' (int, rows returned — capped by `limit`),
         'results' (list)}. Each result has 'chembl_id', 'name' (rdfs:label),
-        'organism', 'type', and 'score' (always None — SPARQL exact match has no
-        relevance score; kept for shape stability).
+        'organism', and 'type'.
 
         On endpoint failure this tool does NOT raise — it returns a dict with a
         single 'error' key instead. Check for 'error' before reading 'results'.
@@ -704,6 +746,12 @@ async def search_chembl_target(
         raise ValueError(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
+        )
+    if target_type.strip() and target_type.strip().upper() not in _CHEMBL_TARGET_TYPES:
+        raise ValueError(
+            f"Invalid target_type {target_type!r}. It must be one of the ChEMBL "
+            f"target-type vocabulary: {', '.join(sorted(_CHEMBL_TARGET_TYPES))}. "
+            "(An unrecognized value would otherwise silently match nothing.)"
         )
     # Route: UniProt accession → structured skos:exactMatch; else exact altLabel.
     acc = query.strip().upper()
@@ -748,7 +796,6 @@ async def search_chembl_target(
             "name": r.get("name"),
             "organism": r.get("organism") or None,
             "type": r.get("type"),
-            "score": None,
         }
         for r in rows
     ]
@@ -804,9 +851,8 @@ async def search_chembl_molecule(
 
     Returns:
         dict: {'total_count' (int, rows returned — capped by `limit`),
-        'results' (list)}. Each result has 'chembl_id' (e.g. "CHEMBL25"), 'name'
-        (rdfs:label, may be None for some structure hits), and 'score' (always
-        None; kept for shape stability).
+        'results' (list)}. Each result has 'chembl_id' (e.g. "CHEMBL25") and
+        'name' (rdfs:label, may be None for some structure hits).
 
         On endpoint/HTTP failure this tool does NOT raise — it returns a dict with
         a single 'error' key instead. Check for 'error' before reading 'results'.
@@ -837,7 +883,6 @@ async def search_chembl_molecule(
             {
                 "chembl_id": m.get("molecule_chembl_id"),
                 "name": m.get("pref_name"),
-                "score": None,
             }
             for m in bulk.get("molecules", [])
         ]
@@ -848,7 +893,7 @@ async def search_chembl_molecule(
         if isinstance(rows, dict):
             return rows  # {"error": ...}
         parsed_results = [
-            {"chembl_id": r.get("chembl_id"), "name": r.get("name"), "score": None}
+            {"chembl_id": r.get("chembl_id"), "name": r.get("name")}
             for r in rows
         ]
         return {"total_count": len(parsed_results), "results": parsed_results}
@@ -869,7 +914,7 @@ async def search_chembl_molecule(
     if isinstance(rows, dict):
         return rows  # {"error": ...}
     parsed_results = [
-        {"chembl_id": r.get("chembl_id"), "name": r.get("name"), "score": None}
+        {"chembl_id": r.get("chembl_id"), "name": r.get("name")}
         for r in rows
     ]
     return {"total_count": len(parsed_results), "results": parsed_results}

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1154,6 +1154,10 @@
           <div class="tool-item-desc">Search ChEMBL protein targets and drug targets.</div>
         </div>
         <div class="tool-item">
+          <div class="tool-item-name">search_chembl_id_lookup</div>
+          <div class="tool-item-desc">Resolve a name to ChEMBL IDs across compounds, targets, cell lines, and tissues (plus keyword search of assay descriptions).</div>
+        </div>
+        <div class="tool-item">
           <div class="tool-item-name">search_pdb_entity</div>
           <div class="tool-item-desc">Search PDBj structures, ligands, and peptides — filter by method, resolution, organism, or chemical structure.</div>
         </div>

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -21,6 +21,9 @@ schema_info:
     - atc
     - clinical trial
     - smiles
+    - inchikey
+    - cell line
+    - tissue
     - binding affinity
     - uniprot
   categories:
@@ -34,7 +37,7 @@ schema_info:
     - search_chembl_molecule
     - search_chembl_target
   version:
-    mie_version: "3.2"
+    mie_version: "3.3"
     mie_created: "2025-02-10"
     mie_updated: "2026-07-14"
     data_version: ChEMBL 34.0
@@ -76,11 +79,37 @@ critical_warnings: |
     else HTTP 400). Target symbols sit on the component: ?t cco:hasTargetComponent ?c . ?c
     skos:altLabel ?alt . ?alt bif:contains "EGFR" . Add cco:targetType "SINGLE PROTEIN" +
     cco:organismName "Homo sapiens" to collapse orthologs/complexes to the one intended target.
+    CellLine and Tissue names, by contrast, DO live on rdfs:label (e.g. "Liver", "CCRF S-180");
+    those classes are small (294 / 2,215) so a plain FILTER(LCASE(STR(?label))=...) is fine.
+  - STRUCTURE / PHYSCHEM ARE NOT DIRECT PREDICATES (SIO value nodes): SMILES, InChI, InChIKey,
+    molecular weight, logP, PSA, etc. are NOT properties directly on the molecule. They hang off
+    qualified-value nodes: ?m sio:SIO_000008 ?node . ?node a <CHEMINF_type> ; sio:SIO_000300 ?v .
+    A query like ?m cco:smiles ?s (or any direct predicate) returns 0 rows silently. CHEMINF type
+    → property: CHEMINF_000018 canonical_smiles, CHEMINF_000059 standard_inchi_key,
+    CHEMINF_000113 standard_inchi, CHEMINF_000042 full_molformula, CHEMINF_000216 full_mwt,
+    CHEMINF_000251 alogp, CHEMINF_000307 psa (full map in <MoleculePropertyShape>). For an exact
+    structure-identifier lookup, prefilter with bif:contains on the longest token, then FILTER on
+    the exact CASE-SENSITIVE value (InChIKeys are canonical uppercase):
+      ?node a sio:CHEMINF_000059 ; sio:SIO_000300 ?v . ?v bif:contains "KTUFNOKKBVMGRW" .
+      FILTER(STR(?v) = "KTUFNOKKBVMGRW-UHFFFAOYSA-N") . ?m sio:SIO_000008 ?node .
+  - ASSAY DESCRIPTION IS dcterms:description, NOT cco:description: an Assay's rdfs:label is just
+    its ChEMBL ID (not descriptive), and cco:description does NOT exist (returns 0). The searchable
+    free-text is dcterms:description (~100% of the 1.89M assays). Keyword-search it with bif:contains
+    (no exact FILTER — descriptions are free text): ?a a cco:Assay ; dcterms:description ?d . ?d
+    bif:contains "acetylcholinesterase" . Tissues use dcterms:title for the same role; CellLines use
+    dcterms:description.
+  - XSD:STRING TYPING (exact match): rdfs:label, skos:prefLabel, skos:altLabel, dcterms:description
+    and the identifier sio:SIO_000300 values are stored as typed xsd:string. A plain-literal exact
+    match — FILTER(?label = "Liver") or VALUES ?label { "Liver" } — joins to NOTHING. Use STR()-based
+    comparison (FILTER(STR(?label) = "Liver")) or append ^^xsd:string. Numeric sio:SIO_000300 values
+    (full_mwt, alogp, psa, ...) are xsd:double, not string — cast accordingly.
 
 shape_expressions: |
   PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
   PREFIX bibo: <http://purl.org/ontology/bibo/>
+  PREFIX sio: <http://semanticscience.org/resource/>
+  PREFIX dcterms: <http://purl.org/dc/terms/>
 
   <MoleculeShape> {
     a [ cco:SmallMolecule ] ;
@@ -94,7 +123,12 @@ shape_expressions: |
     cco:hasActivity @<ActivityShape> * ;
     cco:hasDrugIndication @<DrugIndicationShape> * ;
     cco:hasMechanism @<DrugMechanismShape> * ;
+    sio:SIO_000008 @<MoleculePropertyShape> * ;
     cco:moleculeXref IRI *
+  # NOTE: SMILES / InChI / InChIKey / MW / logP / PSA / molecular formula are NOT direct
+  #       predicates on the molecule — they hang off sio:SIO_000008 value nodes. See
+  #       <MoleculePropertyShape> and the STRUCTURE-PROPERTY critical_warning for the access
+  #       pattern. ~1,915,414 SmallMolecule (99.7%) carry a standard_inchi_key (verified 2026-07-14).
   # NOTE: skos:altLabel holds synonyms — generic + brand/trade names (e.g. "Gleevec",
   #       "Glivec"), research codes (NSC-/SID-), and IUPAC names. It is the predicate for
   #       name/brand → molecule ID resolution. See critical_warnings for the fast idiom.
@@ -118,11 +152,70 @@ shape_expressions: |
 
   <AssayShape> {
     a [ cco:Assay ] ;
+    rdfs:label xsd:string ;
+    dcterms:description xsd:string ? ;
     cco:chemblId xsd:string ;
     cco:assayType xsd:string ;
     cco:organismName xsd:string * ;
-    cco:hasTarget @<TargetShape>
+    cco:hasTarget @<TargetShape> ;
+    cco:hasDocument IRI ?
+  # NOTE: rdfs:label on an Assay is just its ChEMBL ID (e.g. "CHEMBL615156"), NOT descriptive.
+  #       The searchable free text is dcterms:description (e.g. "Inhibitory constant against
+  #       human placenta 17-beta-hydroxysteroid dehydrogenase"), present on 1,890,708/1,890,749
+  #       (~100%). It is dcterms:description — cco:description does NOT exist (returns 0 rows).
   # COUNTS: 1,890,749 Assay instances; assayType values: "Binding", "Functional", "ADME"
+  }
+
+  <MoleculePropertyShape> {
+    a [ sio:CHEMINF_000018 sio:CHEMINF_000059 sio:CHEMINF_000113 sio:CHEMINF_000042
+        sio:CHEMINF_000216 sio:CHEMINF_000350 sio:CHEMINF_000251 sio:CHEMINF_000307
+        sio:CHEMINF_000245 sio:CHEMINF_000244 sio:CHEMINF_000254 sio:CHEMINF_000300
+        sio:CHEMINF_000381 sio:CHEMINF_000312 sio:CHEMINF_000315 sio:CHEMINF_000431 ] ;
+    sio:SIO_000300 xsd:string ;
+    rdfs:label xsd:string ?
+  # A molecule's structure identifiers and physicochemical properties live on these
+  # SIO qualified-value nodes, reached as:
+  #   ?m sio:SIO_000008 ?node . ?node a <CHEMINF_type> ; sio:SIO_000300 ?value .
+  # The value-node's rdf:type (CHEMINF_*) selects WHICH property:
+  #   CHEMINF_000018 canonical_smiles     CHEMINF_000059 standard_inchi_key
+  #   CHEMINF_000113 standard_inchi        CHEMINF_000042 full_molformula
+  #   CHEMINF_000216 full_mwt              CHEMINF_000350 mw_freebase
+  #   CHEMINF_000251 alogp   CHEMINF_000307 psa   CHEMINF_000245 hba   CHEMINF_000244 hbd
+  #   CHEMINF_000254 rtb     CHEMINF_000300 heavy_atoms   CHEMINF_000381 aromatic_rings
+  #   CHEMINF_000312 num_ro5_violations   CHEMINF_000315 ro3_pass   CHEMINF_000431 qed_weighted
+  # DATATYPE TRAP: sio:SIO_000300 is xsd:string for the text identifiers (smiles/inchi/
+  #   inchi_key/molformula) but xsd:double for numeric properties (full_mwt, alogp, psa, ...).
+  #   InChIKey/InChI are canonical → exact match; SMILES is toolkit-specific → not portable.
+  }
+
+  <CellLineShape> {
+    a [ cco:CellLine ] ;
+    rdfs:label xsd:string ;
+    cco:chemblId xsd:string ;
+    dcterms:description xsd:string ;
+    cco:organismName xsd:string ? ;
+    cco:cellosaurusId xsd:string ? ;
+    cco:hasCLO IRI ? ;
+    cco:hasEFO IRI ? ;
+    cco:taxonomy IRI * ;
+    cco:cellXref IRI *
+  # rdfs:label is the descriptive cell-line name (e.g. "CCRF S-180", "143B", "A10") — use it for
+  # cell-line name → ID (exact, case-insensitive via STR()). dcterms:description mirrors the name.
+  # COUNTS: 2,215 CellLine instances (all carry rdfs:label + chemblId + dcterms:description)
+  }
+
+  <TissueShape> {
+    a [ cco:Tissue ] ;
+    rdfs:label xsd:string ;
+    cco:chemblId xsd:string ;
+    cco:targetType xsd:string ;
+    dcterms:title xsd:string ;
+    cco:organismName xsd:string ? ;
+    cco:taxonomy IRI *
+  # Tissues are modelled as targets (cco:targetType is always "TISSUE"). rdfs:label is the tissue
+  # name (e.g. "Liver", "Femur", "Blood") — use it for tissue → ID. NOTE the human-readable text
+  # is rdfs:label AND dcterms:title (NOT dcterms:description, unlike CellLine/Assay).
+  # COUNTS: 294 Tissue instances
   }
 
   <TargetShape> {
@@ -289,6 +382,28 @@ sparql_query_examples:
       # Molecule brand/synonym → ID (same idiom, altLabel on the molecule itself):
       #   ?m a cco:SmallMolecule ; skos:altLabel ?alt . ?alt bif:contains "Gleevec" .
       #   FILTER(LCASE(STR(?alt)) = "gleevec")   → CHEMBL941 (IMATINIB) + CHEMBL1642 (mesylate)
+
+  - title: Retrieve a Molecule's Structure Identifiers and Physicochemical Properties
+    description: "SMILES / InChIKey / molecular formula / MW / logP etc. are NOT direct predicates — each hangs off a sio:SIO_000008 qualified-value node whose rdf:type (a CHEMINF_* class) selects the property, with the value on sio:SIO_000300. Retrieves four properties for imatinib at once."
+    question: What are the SMILES, InChIKey, molecular formula and molecular weight of imatinib (CHEMBL941)?
+    complexity: intermediate
+    sparql: |
+      PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+      PREFIX sio: <http://semanticscience.org/resource/>
+
+      # Each property is a value node: ?m sio:SIO_000008 ?node . ?node a <CHEMINF_type> ;
+      #   sio:SIO_000300 ?value . The CHEMINF class picks the property (full map in
+      #   <MoleculePropertyShape>). Values are xsd:string for identifiers, xsd:double for numerics.
+      SELECT ?smiles ?inchiKey ?formula ?mwt
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        VALUES ?m { <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL941> }
+        ?m sio:SIO_000008 ?sn . ?sn a sio:CHEMINF_000018 ; sio:SIO_000300 ?smiles .   # canonical_smiles
+        ?m sio:SIO_000008 ?kn . ?kn a sio:CHEMINF_000059 ; sio:SIO_000300 ?inchiKey .  # standard_inchi_key
+        ?m sio:SIO_000008 ?fn . ?fn a sio:CHEMINF_000042 ; sio:SIO_000300 ?formula .   # full_molformula
+        ?m sio:SIO_000008 ?mn . ?mn a sio:CHEMINF_000216 ; sio:SIO_000300 ?mwt .       # full_mwt
+      }
+      # → CHEMBL941: SMILES Cc1ccc(...)n1, InChIKey KTUFNOKKBVMGRW-UHFFFAOYSA-N, C29H31N7O, 493.62
 
   - title: Get IC50 Measurements for Specific Targets Using VALUES with IRIs
     description: "Retrieves IC50 data for EGFR and VEGFR2 using specific target IRIs (from search_chembl_target) and typed predicate cco:standardType."
@@ -686,7 +801,7 @@ architectural_notes:
     - "Number of the 7 example queries using text search: 1 (Query 6)"
     - "Query 6 uses FILTER(CONTAINS(?mechanismType, \"INHIBITOR\")) on cco:mechanismActionType — a controlled-vocabulary string literal. A VALUES block would require listing all inhibitor subtypes (COMPETITIVE INHIBITOR, IRREVERSIBLE INHIBITOR, etc.); CONTAINS is the pragmatic alternative. All other mechanism/activity lookups use exact typed predicates."
     - "All other entity classes have structured predicates: organism (cco:organismName), disease (cco:hasMesh IRI), protein family (cco:hasProteinClassification IRI), activity type (cco:standardType), assay type (cco:assayType)"
-    - "bif:contains appropriate only for cco:description / rdfs:comment free-text fields (not needed in any of the 7 examples beyond Q6)"
+    - "bif:contains appropriate for genuine free-text fields — dcterms:description on Assay/CellLine (NOT cco:description, which does not exist) and dcterms:title on Tissue — e.g. keyword-searching assay descriptions. Not needed in any of the structured example queries."
 
 data_statistics:
   total_molecules: 1920603
@@ -697,6 +812,10 @@ data_statistics:
   total_documents: 99141
   total_mechanisms: 7568
   total_indications: 59954
+  total_cell_lines: 2215            # cco:CellLine; rdfs:label is descriptive (verified 2026-07-14)
+  total_tissues: 294               # cco:Tissue; cco:targetType "TISSUE" (verified 2026-07-14)
+  molecules_with_inchikey: 1915414  # ~99.7% of molecules carry a standard_inchi_key value node (2026-07-14)
+  assays_with_description: 1890708  # ~100% of assays carry dcterms:description (2026-07-14)
   human_protein_kinases: 423
   alzheimers_drugs: 305
   verified_date: "2026-07-07"
@@ -735,6 +854,26 @@ anti_patterns:
                 cco:hasProteinClassification <http://rdf.ebi.ac.uk/resource/chembl/protclass/CHEMBL_PC_1100> .
       }
     explanation: MIE schema shows cco:hasProteinClassification. Inspect examples to extract the IRI. Use it for comprehensive, precise, fast results.
+
+  - title: Structure/Physchem Queried as a Direct Predicate
+    problem: Treating SMILES / InChIKey / molecular weight as direct predicates on the molecule. They are NOT — they hang off sio:SIO_000008 qualified-value nodes typed by a CHEMINF class. The direct-predicate form returns 0 rows silently (there is no cco:smiles / cco:inchiKey).
+    wrong_sparql: |
+      # WRONG: invented direct predicate — returns nothing, no error
+      SELECT ?m ?inchiKey
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        ?m a cco:SmallMolecule ; cco:standardInchiKey ?inchiKey .
+      } LIMIT 10
+    correct_sparql: |
+      # CORRECT: traverse the SIO value node; the CHEMINF class selects which property
+      PREFIX sio: <http://semanticscience.org/resource/>
+      SELECT ?m ?inchiKey
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        ?m a cco:SmallMolecule ; sio:SIO_000008 ?node .
+        ?node a sio:CHEMINF_000059 ; sio:SIO_000300 ?inchiKey .   # CHEMINF_000059 = standard_inchi_key
+      } LIMIT 10
+    explanation: Structure identifiers and physicochemical properties use the SIO qualified-value pattern. See <MoleculePropertyShape> for the full CHEMINF-class → property map. For an exact identifier lookup, prefilter with bif:contains on the value's longest token, then FILTER on the exact value (case-sensitive for InChIKey/InChI).
 
   - title: Circular Reasoning with Search Results
     problem: Using molecule or target IRIs sampled from an exploratory query as the scope of a comprehensive count or activity aggregate.

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -6,6 +6,8 @@ import os
 import re
 import secrets
 import time
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
@@ -283,8 +285,16 @@ async def execute_sparql(
     return response.text
 
 
-# The Primary MCP server
-mcp = FastMCP("TogoMCP: RDF Portal MCP Server")
+# The Primary MCP server.
+# Pass TogoMCP's OWN version explicitly — otherwise FastMCP defaults serverInfo.version
+# to its own package version, so `initialize` would advertise FastMCP's version under
+# TogoMCP's name (misleading: it moves on a FastMCP upgrade, not on a TogoMCP release).
+try:
+    _TOGOMCP_VERSION = _pkg_version("togo-mcp")
+except PackageNotFoundError:  # not installed as a distribution (source-tree run)
+    _TOGOMCP_VERSION = "0+unknown"
+
+mcp = FastMCP("TogoMCP: RDF Portal MCP Server", version=_TOGOMCP_VERSION)
 
 
 from fastmcp.server.middleware import Middleware as _Middleware


### PR DESCRIPTION
Sync of `dev` → `main`. 5 commits, 6 files, +526/−121. All verified live against the test server after deploy (`initialize` reports `1.1.0`).

## ChEMBL search tools

- **`92a14d4`** — broaden `search_chembl_id_lookup` beyond COMPOUND/TARGET to **CELL_LINE, TISSUE** (exact-name on `rdfs:label`) and **ASSAY** (keyword-in-`dcterms:description`, opt-in so it doesn't swamp name lookups). Adds the missing `search_chembl_id_lookup` entry to the intro page's Keyword Search card.
- **`182b256`** — add `organism` to every `id_lookup` result (closes the mouse-vs-human ambiguity: CHEMBL3608 *Mus musculus* vs CHEMBL203 *Homo sapiens* were byte-identical); validate `target_type` against the live 25-value vocabulary (a typo now raises instead of silently returning 0 rows); drop the always-null `score` field.
- **`85a581d`** — round-2 audit fixes:
  - **Correctness:** FastMCP truncates a tool's exposed description at the docstring's `Args:` section, so the `Returns:` block — including “check for `error` before reading `results`” — never reached callers. Moved the return shape + non-raising error contract into the prose **before** `Args:` on all three tools.
  - ASSAY rows stop overloading a sentence onto `name` — they carry a real `description` (name=null) plus a relevance `score` (from `bif:contains option(score …)`, ranked).
  - Add `has_more` to every response (over-fetch `limit+1`) so a caller can tell "N of N" from "N of many" — the case that matters for ASSAY's high-hit keyword search.

## MIE

- **`137790c`** — ChEMBL MIE **v3.2 → v3.3**: document `<CellLineShape>`, `<TissueShape>`, the `<MoleculePropertyShape>` SIO/CHEMINF structure-identifier value nodes, and the Assay `dcterms:description` predicate (the searchable text; `cco:description` does not exist). 4 new critical_warnings, one example + one anti-pattern, refreshed statistics. All queries verified against the live endpoint.

## Server

- **`9c0e63b`** — `initialize` now reports TogoMCP's own version (`1.1.0`) instead of FastMCP's default (`3.4.3`), sourced from package metadata. Gives a real deploy fingerprint — it already caught a stale-process non-deploy during testing.

## Verification

Full suite 171 passing. Post-deploy live checks over raw JSON-RPC: version `1.1.0`; `tools/list` exposes `has_more` + the error contract; ASSAY returns `description`+`score`, ranked, with `has_more`; EGFR targets distinguishable by `organism`; invalid `target_type` → `isError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)