### PR TITLE
Sync dev → main: shared REST retry plumbing + Reactome filter fix + MIE v6.4

### DIFF
--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -810,6 +810,87 @@ class TestSearchReactomeEntity:
         with pytest.raises(ValueError, match="Missing search string"):
             await search_reactome_entity("   ")
 
+    @staticmethod
+    def _entry(stid: str, name: str, typ: str, species: list[str], summ: str = "") -> dict:
+        return {
+            "stId": stid, "id": stid, "name": name, "type": typ,
+            "exactType": typ, "species": species, "summation": summ,
+        }
+
+    def _payload(self, *entries: dict) -> dict:
+        return {"results": [{"entries": list(entries)}]}
+
+    @pytest.mark.asyncio
+    async def test_enriched_fields_and_highlight_stripped(self) -> None:
+        """A hit surfaces stId/type/exactType/species/summation with the search
+        highlighting <span> markup stripped from name and summation."""
+        entry = self._entry(
+            "R-HSA-109581",
+            'The <span class="highlighting" >Apoptosis</span> pathway',
+            "Pathway",
+            ["Homo sapiens"],
+            '<span class="highlighting" >Apoptosis</span> is cell death.',
+        )
+        with respx.mock(using="httpx") as router:
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json=self._payload(entry))
+            )
+            result = json.loads(await search_reactome_entity("apoptosis"))
+        assert result == [{
+            "id": "R-HSA-109581",
+            "name": "The Apoptosis pathway",
+            "type": "Pathway",
+            "exactType": "Pathway",
+            "species": ["Homo sapiens"],
+            "summation": "Apoptosis is cell death.",
+        }]
+
+    @pytest.mark.asyncio
+    async def test_species_filter_applied_client_side(self) -> None:
+        """When the server relaxes a species filter and returns cross-species
+        rows, the tool re-applies the filter and keeps only matching species."""
+        human = self._entry("R-HSA-1", "Apoptosis", "Pathway", ["Homo sapiens"])
+        mouse = self._entry("R-MMU-1", "Apoptosis", "Pathway", ["Mus musculus"])
+        with respx.mock(using="httpx") as router:
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json=self._payload(human, mouse))
+            )
+            result = json.loads(
+                await search_reactome_entity("apoptosis", species="Homo sapiens")
+            )
+        assert [r["id"] for r in result] == ["R-HSA-1"]
+
+    @pytest.mark.asyncio
+    async def test_bogus_species_returns_empty_not_relaxed(self) -> None:
+        """The confirmed silent-relaxation bug: a nonexistent species must yield
+        [] even though the server returns unfiltered rows for it."""
+        rows = [
+            self._entry("R-HSA-1", "Apoptosis", "Pathway", ["Homo sapiens"]),
+            self._entry("R-MMU-1", "Apoptosis", "Pathway", ["Mus musculus"]),
+        ]
+        with respx.mock(using="httpx") as router:
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json=self._payload(*rows))
+            )
+            result = json.loads(
+                await search_reactome_entity("apoptosis", species="Nonexistus fakeus")
+            )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_type_filter_applied_client_side(self) -> None:
+        """A relaxed `types` filter is likewise re-applied client-side."""
+        pathway = self._entry("R-HSA-1", "Apoptosis", "Pathway", ["Homo sapiens"])
+        reaction = self._entry("R-HSA-2", "Cleavage", "Reaction", ["Homo sapiens"])
+        with respx.mock(using="httpx") as router:
+            router.get(self._REACTOME_URL).mock(
+                return_value=httpx.Response(200, json=self._payload(pathway, reaction))
+            )
+            result = json.loads(
+                await search_reactome_entity("apoptosis", types="Pathway")
+            )
+        assert [r["type"] for r in result] == ["Pathway"]
+
 
 # ---------------------------------------------------------------------------
 # Rhea

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -42,9 +42,9 @@ def _sent_query(route) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _no_chembl_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Zero the ChEMBL retry backoff so the retry-then-error tests don't sleep."""
-    monkeypatch.setattr(api_tools, "_CHEMBL_BACKOFF_BASE", 0.0)
+def _no_rest_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero the REST retry backoff so the retry-then-error tests don't sleep."""
+    monkeypatch.setattr(api_tools, "_REST_BACKOFF_BASE", 0.0)
 
 
 class TestResolveQueryAlias:
@@ -107,6 +107,34 @@ class TestSearchUniprotEntity:
             result = await search_uniprot_entity("TP53")
         assert isinstance(result, str)
         assert "UniProt REST API request failed" in result
+
+    @pytest.mark.asyncio
+    async def test_retries_5xx_then_succeeds(self) -> None:
+        """The shared `_rest_get` plumbing now retries transient 5xx for the
+        non-ChEMBL REST wrappers too (they previously did a single try)."""
+        tsv_body = "Entry\tProtein names\tOrganism\nP04637\tp53\tHomo sapiens\n"
+        with respx.mock(using="httpx") as router:
+            route = router.get("https://rest.uniprot.org/uniprotkb/search").mock(
+                side_effect=[
+                    httpx.Response(503, text="<html>busy</html>"),
+                    httpx.Response(200, text=tsv_body),
+                ]
+            )
+            result = await search_uniprot_entity("TP53")
+        assert route.call_count == 2
+        assert "P04637" in result
+
+    @pytest.mark.asyncio
+    async def test_4xx_not_retried(self) -> None:
+        """4xx is a terminal client error — no retry, degrades to a message."""
+        with respx.mock(using="httpx") as router:
+            route = router.get("https://rest.uniprot.org/uniprotkb/search").mock(
+                return_value=httpx.Response(400, text="<html>bad</html>")
+            )
+            result = await search_uniprot_entity("TP53")
+        assert route.call_count == 1
+        assert "UniProt REST API request failed" in result
+        assert "<" not in result and ">" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -56,6 +56,112 @@ def _resolve_query_alias(
     return next(iter(provided.values()), "")
 
 
+# ---------------------------------------------------------------------------
+# Shared REST plumbing
+#
+# Every REST-wrapper tool below fronts a flaky third-party HTTP API (EBI is
+# ~1/3 flaky; the others have occasional 5xx/timeout blips). They share one
+# resilience story: retry transient 5xx/read-timeout failures with a short
+# linear backoff, treat 4xx as terminal, collapse HTML error pages to a short
+# snippet, and NEVER raise for an HTTP/transport error — degrade to an
+# `error`-carrying payload with a "fall back to SPARQL" hint (the module's
+# REST-wrapper contract). `_rest_get` centralizes that; each tool keeps its
+# own success-body handling (`.text` vs `.json()`) and error-envelope shape
+# (plain "Error:" string / `{"error"}` dict / bare `[{"error"}]` array).
+# ---------------------------------------------------------------------------
+
+_REST_MAX_ATTEMPTS = 3  # 1 initial try + 2 retries
+_REST_BACKOFF_BASE = 1.0  # seconds; nth retry waits base*n (patched to 0 in tests)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text: str, max_len: int = 200) -> str:
+    """Collapse an HTML error page into a short plain-text snippet.
+
+    Upstream APIs return full HTML documents (doctype, <script>/<style> blocks,
+    favicon links) on failure — hundreds of tokens of noise with no diagnostic
+    value. Drop scripts/styles wholesale, strip remaining tags, collapse
+    whitespace, and truncate.
+    """
+    text = re.sub(
+        r"<(script|style)\b[^>]*>.*?</\1>", " ", text, flags=re.IGNORECASE | re.DOTALL
+    )
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > max_len:
+        text = text[:max_len].rstrip() + "…"
+    return text
+
+
+class _RestError:
+    """Terminal outcome of `_rest_get`, carrying a clean, short message.
+
+    Distinguishable from a successful ``httpx.Response`` via ``isinstance`` so
+    callers branch on the outcome without an exception crossing the
+    REST-wrapper boundary.
+    """
+
+    __slots__ = ("message",)
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
+async def _rest_get(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    params: dict | None = None,
+    headers: dict | None = None,
+    context: str,
+) -> "httpx.Response | _RestError":
+    """GET ``path``, retrying transient 5xx/timeout failures with linear backoff.
+
+    Returns the successful ``httpx.Response`` (2xx). On terminal failure returns
+    ``_RestError(<clean short message>)`` — it never raises for HTTP/transport
+    errors. 4xx client errors are terminal (no retry); 5xx and read timeouts are
+    retried up to ``_REST_MAX_ATTEMPTS`` times. HTML error bodies are stripped to
+    a short snippet.
+    """
+    last_error = "unknown error"
+    for attempt in range(_REST_MAX_ATTEMPTS):
+        last = attempt == _REST_MAX_ATTEMPTS - 1
+        try:
+            response = await client.get(path, params=params, headers=headers)
+        except httpx.HTTPError as e:  # includes TimeoutException
+            last_error = f"{type(e).__name__}: {e}"
+            logger.warning(f"{context} attempt {attempt + 1} failed: {last_error}")
+            if last:
+                break
+            await asyncio.sleep(_REST_BACKOFF_BASE * (attempt + 1))
+            continue
+        if response.is_success:
+            return response
+        if 500 <= response.status_code < 600 and not last:
+            last_error = f"HTTP {response.status_code}"
+            logger.warning(f"{context} attempt {attempt + 1}: {last_error}, retrying")
+            await asyncio.sleep(_REST_BACKOFF_BASE * (attempt + 1))
+            continue
+        # Terminal: a 4xx, or a 5xx after retries are exhausted.
+        last_error = f"HTTP {response.status_code}: {_strip_html(response.text)}"
+        logger.warning(f"{context} failed (terminal): {last_error}")
+        break
+    return _RestError(last_error)
+
+
+def _rest_fail_msg(subject: str, detail: str, database: str) -> str:
+    """Shared "REST API failed → retry already done → fall back to SPARQL" hint.
+
+    ``subject`` names the failed operation (e.g. "UniProt REST API request");
+    ``database`` is the RDF-Portal key for the SPARQL fallback suggestion.
+    """
+    return (
+        f"{subject} failed ({detail}). Transient errors were already retried "
+        "automatically. If it keeps failing, fall back to SPARQL: "
+        f"run_sparql(database='{database}', sparql_query=...)."
+    )
+
+
 ######################################
 #####　Database-specific tools ########
 ######################################
@@ -186,19 +292,15 @@ async def search_uniprot_entity(
         "format": "tsv",
         "size": limit,
     }
-    try:
-        response = await _uniprot_client.get("/uniprotkb/search", params=params)
-        raise_for_status_with_body(response, context="UniProt search")
-        data = response.text
-        return data
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(f"UniProt search failed: {type(e).__name__}: {e}")
-        return (
-            f"Error: UniProt REST API request failed ({type(e).__name__}: {e}). "
-            "Usually transient — retry once after a brief delay. If it keeps "
-            "failing, fall back to SPARQL: "
-            "run_sparql(database='uniprot', sparql_query=...)."
+    resp = await _rest_get(
+        _uniprot_client, "/uniprotkb/search", params=params, context="UniProt search"
+    )
+    if isinstance(resp, _RestError):
+        logger.warning(f"UniProt search failed: {resp.message}")
+        return "Error: " + _rest_fail_msg(
+            "UniProt REST API request", resp.message, "uniprot"
         )
+    return resp.text
 
 
 # DB: ChEMBL
@@ -214,79 +316,29 @@ async def search_uniprot_entity(
 # they too resolve by exact SPARQL match. REST is retained ONLY for SMILES
 # (flexmatch) — a SMILES is written differently by each toolkit, so it needs the
 # chemistry engine's structural normalization, not an exact string match — and
-# would be needed for similarity/substructure search. Those REST helpers keep the
-# retry/HTML-strip plumbing below; EBI REST is flaky (~1/3 of calls 500 or time
-# out).
-_CHEMBL_MAX_ATTEMPTS = 3  # 1 initial try + 2 retries
-_CHEMBL_BACKOFF_BASE = 1.0  # seconds; nth retry waits base*n (patched to 0 in tests)
-_HTML_TAG_RE = re.compile(r"<[^>]+>")
-
-
-def _strip_html(text: str, max_len: int = 200) -> str:
-    """Collapse an HTML error page into a short plain-text snippet.
-
-    EBI returns full HTML documents (doctype, <script>/<style> blocks, favicon
-    links) on failure — hundreds of tokens of noise with no diagnostic value.
-    Drop scripts/styles wholesale, strip remaining tags, collapse whitespace,
-    and truncate.
-    """
-    text = re.sub(
-        r"<(script|style)\b[^>]*>.*?</\1>", " ", text, flags=re.IGNORECASE | re.DOTALL
-    )
-    text = _HTML_TAG_RE.sub(" ", text)
-    text = re.sub(r"\s+", " ", text).strip()
-    if len(text) > max_len:
-        text = text[:max_len].rstrip() + "…"
-    return text
+# would be needed for similarity/substructure search. Those REST helpers ride on
+# the shared `_rest_get` retry/HTML-strip plumbing near the top of this module;
+# EBI REST is flaky (~1/3 of calls 500 or time out).
 
 
 async def _chembl_get_json(path: str, params: dict, *, context: str) -> dict:
-    """GET a ChEMBL JSON endpoint, retrying transient 5xx/timeout failures.
+    """GET a ChEMBL JSON endpoint, retrying transient failures via `_rest_get`.
 
-    Returns the parsed JSON on success. On terminal failure returns
-    ``{"error": <clean message>}`` — it never raises for HTTP/transport
-    errors (the module's REST-wrapper contract). 4xx client errors are
-    terminal (no retry); 5xx and read timeouts are retried up to
-    ``_CHEMBL_MAX_ATTEMPTS`` times with a short linear backoff. HTML error
-    bodies are stripped to a short snippet.
+    Returns the parsed JSON on success. On terminal failure — including a 200
+    with a non-JSON body — returns ``{"error": <clean message>}``; it never
+    raises for HTTP/transport errors (the module's REST-wrapper contract).
     """
-    last_error = "unknown error"
-    for attempt in range(_CHEMBL_MAX_ATTEMPTS):
-        last = attempt == _CHEMBL_MAX_ATTEMPTS - 1
-        try:
-            response = await _chembl_client.get(path, params=params)
-        except httpx.HTTPError as e:  # includes TimeoutException
-            last_error = f"{type(e).__name__}: {e}"
-            logger.warning(f"{context} attempt {attempt + 1} failed: {last_error}")
-            if last:
-                break
-            await asyncio.sleep(_CHEMBL_BACKOFF_BASE * (attempt + 1))
-            continue
-        if response.is_success:
-            try:
-                return response.json()
-            except (json.JSONDecodeError, ValueError):
-                # 200 with a non-JSON body — an upstream anomaly. Degrade
-                # gracefully rather than raising (REST-wrapper contract).
-                last_error = f"malformed JSON body: {_strip_html(response.text)}"
-                logger.warning(f"{context} failed (terminal): {last_error}")
-                break
-        if 500 <= response.status_code < 600 and not last:
-            last_error = f"HTTP {response.status_code}"
-            logger.warning(f"{context} attempt {attempt + 1}: {last_error}, retrying")
-            await asyncio.sleep(_CHEMBL_BACKOFF_BASE * (attempt + 1))
-            continue
-        # Terminal: a 4xx, or a 5xx after retries are exhausted.
-        last_error = f"HTTP {response.status_code}: {_strip_html(response.text)}"
-        logger.warning(f"{context} failed (terminal): {last_error}")
-        break
-    return {
-        "error": (
-            f"ChEMBL REST API request failed ({last_error}). Transient errors "
-            "were already retried automatically. If it keeps failing, fall back "
-            "to SPARQL: run_sparql(database='chembl', sparql_query=...)."
-        )
-    }
+    resp = await _rest_get(_chembl_client, path, params=params, context=context)
+    if isinstance(resp, _RestError):
+        return {"error": _rest_fail_msg("ChEMBL REST API request", resp.message, "chembl")}
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError):
+        # 200 with a non-JSON body — an upstream anomaly. Degrade gracefully
+        # rather than raising (REST-wrapper contract).
+        detail = f"malformed JSON body: {_strip_html(resp.text)}"
+        logger.warning(f"{context} failed (terminal): {detail}")
+        return {"error": _rest_fail_msg("ChEMBL REST API request", detail, "chembl")}
 
 
 # --- name/symbol → ID resolution over the RDF graph (skos:altLabel) ---
@@ -986,21 +1038,13 @@ async def get_pubchem_compound_id(compound_name: str) -> str:
         "Error:" (not JSON). Check for that prefix before parsing.
     """
     url = f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound_name}/cids/JSON"
-    try:
-        response = await _pubchem_client.get(url)
-        raise_for_status_with_body(response, context="PubChem CID lookup")
-        return response.text
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(
-            f"PubChem CID lookup failed for {compound_name!r}: "
-            f"{type(e).__name__}: {e}"
+    resp = await _rest_get(_pubchem_client, url, context="PubChem CID lookup")
+    if isinstance(resp, _RestError):
+        logger.warning(f"PubChem CID lookup failed for {compound_name!r}: {resp.message}")
+        return "Error: " + _rest_fail_msg(
+            f"PubChem CID lookup for {compound_name!r}", resp.message, "pubchem"
         )
-        return (
-            f"Error: PubChem CID lookup failed for {compound_name!r} "
-            f"({type(e).__name__}: {e}). Usually transient — retry once after "
-            "a brief delay. If it keeps failing, fall back to SPARQL: "
-            "run_sparql(database='pubchem', sparql_query=...)."
-        )
+    return resp.text
 
 
 @mcp.tool()
@@ -1017,22 +1061,20 @@ async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
     """
     url = "https://togodx.dbcls.jp/human/sparqlist/api/metastanza_pubchem_compound"
     params = {"id": pubchem_compound_id}
-    try:
-        response = await _pubchem_client.get(url, params=params)
-        raise_for_status_with_body(response, context="PubChem compound attributes")
-        return response.text
-    except (httpx.HTTPError, ValueError) as e:
+    resp = await _rest_get(
+        _pubchem_client, url, params=params, context="PubChem compound attributes"
+    )
+    if isinstance(resp, _RestError):
         logger.warning(
             f"PubChem compound-attributes fetch failed for "
-            f"{pubchem_compound_id!r}: {type(e).__name__}: {e}"
+            f"{pubchem_compound_id!r}: {resp.message}"
         )
-        return (
-            f"Error: PubChem compound-attributes fetch failed for "
-            f"{pubchem_compound_id!r} ({type(e).__name__}: {e}). Usually "
-            "transient — retry once after a brief delay. If it keeps failing, "
-            "fall back to SPARQL: run_sparql(database='pubchem', "
-            "sparql_query=...)."
+        return "Error: " + _rest_fail_msg(
+            f"PubChem compound-attributes fetch for {pubchem_compound_id!r}",
+            resp.message,
+            "pubchem",
         )
+    return resp.text
 
 
 # DB: PDB
@@ -1262,41 +1304,35 @@ async def search_pdb_entity(
         )
 
     project = _PDB_ROW_PROJECTORS[db]
+    resp = await _rest_get(
+        _pdbj_client, f"/rest/newweb/search/{db}", params=params, context="PDBj search"
+    )
+    if isinstance(resp, _RestError):
+        logger.warning(f"PDBj search failed for db={db!r} query={query!r}: {resp.message}")
+        return json.dumps(
+            {"error": _rest_fail_msg("PDBj REST API request", resp.message, "pdb")}
+        )
     try:
-        response = await _pdbj_client.get(
-            f"/rest/newweb/search/{db}", params=params
+        payload = resp.json()
+    except ValueError as e:
+        detail = f"malformed JSON body: {_strip_html(resp.text)}"
+        logger.warning(f"PDBj search returned non-JSON for db={db!r}: {e}")
+        return json.dumps(
+            {"error": _rest_fail_msg("PDBj REST API request", detail, "pdb")}
         )
-        raise_for_status_with_body(response, context="PDBj search")
-        payload = response.json()
-        raw_total = payload.get("total", 0)
-        try:
-            total_results = int(raw_total)
-        except (TypeError, ValueError):
-            total_results = 0
-        # PDBj returns -1 ("not computed") for structured-filter searches, even
-        # alongside real rows. Surface that as null rather than a nonsensical
-        # negative count.
-        if total_results < 0:
-            total_results = None
-        # `limit`/`offset` are honored server-side; the slice is a safety belt.
-        result_list = [
-            project(entry) for entry in payload.get("results", [])[:limit]
-        ]
-        response_dict = {"total": total_results, "results": result_list}
-        return json.dumps(response_dict)
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(
-            f"PDBj search failed for db={db!r} query={query!r}: "
-            f"{type(e).__name__}: {e}"
-        )
-        return json.dumps({
-            "error": (
-                f"PDBj REST API request failed ({type(e).__name__}: {e}). "
-                "Usually transient — retry once after a brief delay. If it "
-                "keeps failing, fall back to SPARQL: "
-                "run_sparql(database='pdb', sparql_query=...)."
-            )
-        })
+    raw_total = payload.get("total", 0)
+    try:
+        total_results = int(raw_total)
+    except (TypeError, ValueError):
+        total_results = 0
+    # PDBj returns -1 ("not computed") for structured-filter searches, even
+    # alongside real rows. Surface that as null rather than a nonsensical
+    # negative count.
+    if total_results < 0:
+        total_results = None
+    # `limit`/`offset` are honored server-side; the slice is a safety belt.
+    result_list = [project(entry) for entry in payload.get("results", [])[:limit]]
+    return json.dumps({"total": total_results, "results": result_list})
 
 
 # DB: MeSH
@@ -1340,21 +1376,16 @@ async def search_mesh_descriptor(
             "search, term, keyword, keywords, search_term, name."
         )
     params = {"label": query, "match": "contains", "limit": limit}
-    try:
-        response = await _mesh_client.get("/mesh/lookup/descriptor", params=params)
-        raise_for_status_with_body(response, context="MeSH descriptor lookup")
-        return response.text
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(
-            f"MeSH descriptor lookup failed for {query!r}: "
-            f"{type(e).__name__}: {e}"
+    resp = await _rest_get(
+        _mesh_client, "/mesh/lookup/descriptor", params=params,
+        context="MeSH descriptor lookup",
+    )
+    if isinstance(resp, _RestError):
+        logger.warning(f"MeSH descriptor lookup failed for {query!r}: {resp.message}")
+        return "Error: " + _rest_fail_msg(
+            "MeSH descriptor lookup", resp.message, "mesh"
         )
-        return (
-            f"Error: MeSH descriptor lookup failed ({type(e).__name__}: {e}). "
-            "Usually transient — retry once after a brief delay. If it keeps "
-            "failing, fall back to SPARQL: "
-            "run_sparql(database='mesh', sparql_query=...)."
-        )
+    return resp.text
 
 
 # DB: Reactome
@@ -1464,25 +1495,23 @@ async def search_reactome_entity(
         params["types"] = ",".join(normalized)
 
     # Make API call
+    resp = await _rest_get(
+        _reactome_client, "/ContentService/search/query", params=params,
+        headers={"Accept": "application/json"}, context="Reactome search",
+    )
+    if isinstance(resp, _RestError):
+        logger.warning(f"Reactome search failed: {resp.message}")
+        return json.dumps([
+            {"error": _rest_fail_msg("Reactome REST API request", resp.message, "reactome")}
+        ])
     try:
-        response = await _reactome_client.get(
-            "/ContentService/search/query",
-            params=params,
-            headers={"Accept": "application/json"},
-        )
-        raise_for_status_with_body(response, context="Reactome search")
-        data = response.json()
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(f"Reactome search failed: {type(e).__name__}: {e}")
-        return json.dumps([{
-            "error": (
-                f"Reactome REST API request failed ({type(e).__name__}: "
-                f"{e}). Reactome's search endpoint can be slow or briefly "
-                "unavailable. Retry once after a brief delay. If it keeps "
-                "failing, fall back to SPARQL: "
-                "run_sparql(database='reactome', sparql_query=...)."
-            )
-        }])
+        data = resp.json()
+    except ValueError as e:
+        detail = f"malformed JSON body: {_strip_html(resp.text)}"
+        logger.warning(f"Reactome search returned non-JSON: {e}")
+        return json.dumps([
+            {"error": _rest_fail_msg("Reactome REST API request", detail, "reactome")}
+        ])
 
     # Extract and return results
     results = []
@@ -1565,33 +1594,24 @@ async def search_rhea_entity(
         "limit": limit,
     }
 
-    try:
-        response = await _rhea_client.get("/rhea", params=params)
-        raise_for_status_with_body(response, context="Rhea search")
+    resp = await _rest_get(_rhea_client, "/rhea", params=params, context="Rhea search")
+    if isinstance(resp, _RestError):
+        logger.warning(f"Rhea search failed: {resp.message}")
+        return json.dumps([
+            {"error": _rest_fail_msg("Rhea REST API request", resp.message, "rhea")}
+        ])
 
-        # Parse TSV response
-        lines = response.text.strip().split("\n")
+    # Parse TSV response
+    lines = resp.text.strip().split("\n")
+    if len(lines) < 2:
+        return json.dumps([])
 
-        if len(lines) < 2:
-            return json.dumps([])
+    # First line is header, skip it
+    results = []
+    for line in lines[1:]:
+        if line.strip():
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                results.append({"rhea_id": parts[0], "equation": parts[1]})
 
-        # First line is header, skip it
-        results = []
-        for line in lines[1:]:
-            if line.strip():
-                parts = line.split("\t")
-                if len(parts) >= 2:
-                    results.append({"rhea_id": parts[0], "equation": parts[1]})
-
-        return json.dumps(results)
-
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(f"Rhea search failed: {type(e).__name__}: {e}")
-        return json.dumps([{
-            "error": (
-                f"Rhea REST API request failed ({type(e).__name__}: {e}). "
-                "Usually transient — retry once after a brief delay. If it "
-                "keeps failing, fall back to SPARQL: "
-                "run_sparql(database='rhea', sparql_query=...)."
-            )
-        }])
+    return json.dumps(results)

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -1390,8 +1390,17 @@ async def search_mesh_descriptor(
 
 # DB: Reactome
 #
-# Canonical Reactome search `types` facet values (the API is case-sensitive and
-# silently ignores unknown/mis-cased values, returning UNFILTERED results).
+# The ContentService Solr search silently RELAXES filters that would yield zero
+# results and returns UNFILTERED rows instead (its "helpful" default; the server
+# `Force filters` param that disables it has a space in its name that breaks over
+# HTTP). Confirmed live 2026-07-14: query="apoptosis" + a nonexistent species
+# returned 1058 cross-species matches. So this wrapper does NOT trust the server
+# to honor `species`/`types` — it re-applies both filters CLIENT-SIDE against the
+# fields every result already carries (`species` array, `type` == the facet
+# value), which guarantees the contract regardless of server relaxation. `types`
+# is still validated up front (a mis-cased value would also silently relax).
+#
+# Canonical Reactome search `types` facet values (case-sensitive on the server).
 # Verified against /ContentService/search/facet on 2026-06-24. Keyed by
 # lowercase for case-insensitive validation -> canonical form.
 _REACTOME_TYPES = {
@@ -1402,6 +1411,15 @@ _REACTOME_TYPES = {
         "Polymer", "Drug", "RNA Sequence", "OtherEntity", "Cell",
     )
 }
+
+# Reactome wraps matched substrings in <span class="highlighting">…</span> in
+# `name` and `summation`; strip the markup (both open and close tags).
+_REACTOME_HL_RE = re.compile(r"</?span[^>]*>")
+
+
+def _reactome_clean(text: str) -> str:
+    """Strip Reactome's search-highlighting <span> markup and trim."""
+    return _REACTOME_HL_RE.sub("", text or "").strip()
 
 
 @mcp.tool()
@@ -1443,11 +1461,23 @@ async def search_reactome_entity(
             hits *per type*, not 30 hits total. To bound the total,
             constrain `types` to a single value.
 
+    Note on filtering: the Reactome server silently ignores a `species`/`types`
+    filter that would yield zero results and returns UNFILTERED rows instead.
+    This tool defends against that by re-applying both filters CLIENT-SIDE, so a
+    species/type filter is always honored — a filter with no genuine matches
+    returns `[]`, never unrelated rows. `species` filtering keeps only entries
+    whose species list contains the requested name(s), so it drops
+    species-agnostic entities (e.g. chemical compounds); omit `species` to keep
+    them.
+
     Returns:
-        JSON string: a bare array of results, each with 'id', 'name', and
-        'type' fields. Empty and non-empty results share the same shape.
-        Example: '[{"id": "R-HSA-109581", "name": "Apoptosis",
-        "type": "Pathway"}]'
+        JSON string: a bare array of results, each with 'id' (stable Reactome
+        stId), 'name', 'type' (facet type), 'exactType' (specific class),
+        'species' (list), and 'summation' (short description, may be ''). Empty
+        and non-empty results share the same shape. Example:
+        '[{"id": "R-HSA-109581", "name": "Apoptosis", "type": "Pathway",
+        "exactType": "Pathway", "species": ["Homo sapiens"],
+        "summation": "Apoptosis is a distinct form of cell death…"}]'
 
     Raises:
         ValueError: If `query` is blank or `types`/`species` are invalid.
@@ -1469,6 +1499,11 @@ async def search_reactome_entity(
     # Build API request
     params = {"query": query, "cluster": "true", "start": 0, "rows": rows}
 
+    # `want_*` are the lowercased filter sets re-applied client-side after the
+    # response comes back (the server silently relaxes zero-yield filters).
+    want_species: set[str] | None = None
+    want_types: set[str] | None = None
+
     if species:
         species_list = [species] if isinstance(species, str) else list(species)
         bad = [s for s in species_list if s.strip().isdigit()]
@@ -1479,6 +1514,7 @@ async def search_reactome_entity(
                 "silently ignores numeric IDs and can also drop other filters."
             )
         params["species"] = ",".join(species_list)
+        want_species = {s.strip().lower() for s in species_list}
     if types:
         types_list = [types] if isinstance(types, str) else list(types)
         normalized, unknown = [], []
@@ -1493,6 +1529,7 @@ async def search_reactome_entity(
                 f"{sorted(set(_REACTOME_TYPES.values()))}."
             )
         params["types"] = ",".join(normalized)
+        want_types = {t.lower() for t in normalized}
 
     # Make API call
     resp = await _rest_get(
@@ -1513,20 +1550,30 @@ async def search_reactome_entity(
             {"error": _rest_fail_msg("Reactome REST API request", detail, "reactome")}
         ])
 
-    # Extract and return results
+    # Extract results, re-applying species/type filters client-side (the server
+    # silently relaxes zero-yield filters — see the module comment above).
     results = []
     for result_group in data.get("results", []):
         for entry in result_group.get("entries", []):
-            # Clean HTML highlighting tags from name
-            name = entry.get("name", "N/A")
-            name = re.sub(r'<span class="highlighting"\s*>', "", name)
-            name = re.sub(r"</span>", "", name)
+            entry_type = entry.get("type", "Unknown")
+            if want_types is not None and entry_type.lower() not in want_types:
+                continue
+            entry_species = entry.get("species") or []
+            if isinstance(entry_species, str):
+                entry_species = [entry_species]
+            if want_species is not None and not (
+                want_species & {s.lower() for s in entry_species}
+            ):
+                continue
 
             results.append(
                 {
                     "id": entry.get("stId", entry.get("id", "N/A")),
-                    "name": name.strip(),
-                    "type": entry.get("type", "Unknown"),
+                    "name": _reactome_clean(entry.get("name", "N/A")),
+                    "type": entry_type,
+                    "exactType": entry.get("exactType", entry_type),
+                    "species": entry_species,
+                    "summation": _strip_html(entry.get("summation", ""), max_len=240),
                 }
             )
 

--- a/togo_mcp/data/mie/reactome.yaml
+++ b/togo_mcp/data/mie/reactome.yaml
@@ -29,9 +29,9 @@ schema_info:
   kw_search_tools:
     - search_reactome_entity
   version:
-    mie_version: "6.3"
+    mie_version: "6.4"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-07"
+    mie_updated: "2026-07-14"
     data_version: "Release 95"
     update_frequency: "Quarterly"
   access:
@@ -98,6 +98,18 @@ critical_warnings: |
     (apoptosis) — which is why ROCK1 looks "easier to find". This is faithful biology
     (ROCK1/ROCK2 are interchangeable in RHO signaling), not a Reactome bug — do not conclude
     ROCK2 is under-annotated.
+  - SEARCH-TOOL stId IS NOT A SPARQL IRI: search_reactome_entity() returns a Reactome stable ID
+    in its `id` field (e.g. "R-HSA-109581"), alongside `species`, `exactType`, and `summation`.
+    That stId is NOT the BioPAX subject IRI. BioPAX subjects look like
+    <http://www.reactome.org/biopax/95/48887#Pathway2221> — a per-export counter that is
+    UNGUESSABLE from the stId. Pasting the stId (or a hand-built reactome.org URL) as a SPARQL
+    subject returns 0 rows silently. BRIDGE via the Reactome xref instead (verified 2026-07-14:
+    R-HSA-109581 -> Pathway2221 "Apoptosis"):
+        ?entity bp:xref [ bp:db "Reactome"^^xsd:string ; bp:id "R-HSA-109581"^^xsd:string ] .
+    The ^^xsd:string is mandatory (see warning (a)). Bonus: the stId is species-specific
+    (R-HSA = human, R-MMU = mouse, …), so bridging on it targets exactly ONE organism's entity —
+    cleaner than matching bp:displayName, which hits the same-named pathway in every species.
+    Use the search result's `species` field to confirm the intended organism before bridging.
 
 shape_expressions: |
   PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
@@ -730,12 +742,12 @@ architectural_notes:
   query_strategy:
     - "ALWAYS read get_MIE_file('reactome') and scan critical_warnings before writing queries"
     - "PRE-FLIGHT LITERAL SWEEP (do this before submitting EVERY query): scan every quoted literal in VALUES, FILTER =, and triple-pattern objects. If it binds to bp:db / bp:id / bp:name / bp:eCNumber / bp:controlType, it MUST carry ^^xsd:string — plain strings silently return 0 rows. VALUES is the highest-miss spot because the typing requirement isn't visually cued there."
-    - "Exploratory: use search_reactome_entity() to find example entities and extract typed values"
+    - "Exploratory: use search_reactome_entity() to find entities — it returns a Reactome stId (id field), species, exactType, and summation. The stId is NOT a BioPAX IRI; bridge it via bp:xref (bp:db 'Reactome'^^xsd:string, bp:id '<stId>'^^xsd:string) to reach the SPARQL entity. See critical_warnings."
     - "Exact matching: always use ^^xsd:string for bp:db, bp:id, bp:name, bp:eCNumber, bp:controlType"
     - "GO terms: query RelationshipXref (68K) — NOT UnificationXref (1.5K misses 98% of GO data)"
     - "Modifications: use VALUES with MOD IDs to avoid text search (MOD:00046/47/48/00696 for phospho)"
     - "Cellular locations: use exact term strings ('plasma membrane'^^xsd:string) — no text search"
-    - "Pathway hierarchy: anchor to specific IRI via search_reactome_entity(); use bp:pathwayComponent+"
+    - "Pathway hierarchy: resolve a name to a Reactome stId via search_reactome_entity(), bridge the stId to the BioPAX entity via bp:xref (bp:db 'Reactome'^^xsd:string), then traverse with bp:pathwayComponent+"
     - "ENTITYSET MEMBERS: a protein participating in a reaction only as a member of a functional group (EntitySet; bp:comment 'Converted from EntitySet in Reactome') is INVISIBLE to bp:left|bp:right direct search (45,785 groups, 221,164 member links). Always UNION three branches: (1) direct reaction participant, (2) complex component (bp:component+), (3) EntitySet member (bp:memberPhysicalEntity+, transitive — sets nest). Catalysis controllers have the same issue (10,579 cases) — UNION bp:controller too. Detect groups by the COMMENT, not rdf:type (most are typed bp:Protein). Run the 'Detect EntitySet Membership' diagnostic first. Verified: ROCK2 (O75116) reachable only via branch (3); ROCK1 (Q13464) needs (3) for RHO pathways and (1) for Apoptosis."
     - "Text search: bif:contains for bp:displayName pathway discovery only (Virtuoso indexed)"
     - "Priority: Specific IRIs/VALUES > Typed predicates > Graph navigation > bif:contains"


### PR DESCRIPTION
Syncs three related commits from dev to main.

## Commits

- **0adf2dd** `refactor(api_tools)` — hoist ChEMBL's retry/backoff/HTML-strip logic into a shared `_rest_get` primitive; retrofit UniProt, PubChem (×2), PDB, MeSH, Reactome, Rhea onto it. Those five wrappers now retry transient 5xx/timeouts (previously single-attempt). No wire-contract changes. Adds UniProt retry/4xx tests.

- **9c63291** `fix(reactome)` — `search_reactome_entity` now re-applies `species`/`types` filters **client-side**, closing a confirmed silent-relaxation bug (a bogus species returned 1058 cross-species rows; now returns `[]`). Also surfaces fields the response already carried: `stId` (as id), `exactType`, `species`, `summation`. Verified live.

- **c6b20fd** `docs(reactome-mie)` — Reactome MIE **v6.4**: documents the `search_reactome_entity` stId → BioPAX-IRI `bp:xref` bridge (the enriched tool made this integration path relevant; without it an LLM pastes an `R-HSA-…` stId as a SPARQL subject and silently gets 0 rows). Verified live.

## Verification
- 177 tests pass locally
- Reactome fix verified end-to-end against live RDF Portal (bogus species → 0; Mus musculus → mouse-only)
- MIE bridge verified live: `R-HSA-109581 → Pathway2221 → 142 reactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)