### PR TITLE
Release v1.3.1 — Rhea projection bug fix + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ Two intentional, *different* error conventions coexist — preserve each module'
 
 List-style result tools return a **JSON string of a bare array** (not a Python `list`): empty and non-empty then share one wire shape. Returning a bare `list` makes FastMCP double-represent it (text array + wrapped `{"result": ...}`), so empty vs non-empty diverge for clients. `dict` returns (ChEMBL, `search_reactome_entity`, `get_sparql_endpoints`) and NCBI `list[TextContent]` returns are exempt — they aren't wrapped. `search_reactome_entity` uses the ChEMBL envelope `{total_count, has_more, results}` on success and `{"error": ...}` on failure (it validates+normalizes `species`/`types` case-insensitively against vendored vocabularies and raises on an unknown value — the server-side filter is case-sensitive and silently ignores a mis-cased value; `limit` is a true overall cap, not per-type; `summation` is opt-in).
 
+## Versioning
+
+The version in `pyproject.toml` is read at runtime via `importlib.metadata` and reported in `serverInfo.version` (the deployment tell — a stale build shows the old number). Bump it on every `dev → main` release, and sync `uv.lock` in the same commit.
+
+The "public contract" of this server is the **tool surface** as a client sees it — tool names, parameters, and return shapes — NOT any importable Python API. Apply semver against that surface, using the **agent-pragmatic** policy (our dominant client is an LLM that re-reads the tool schema every session and adapts, so a return-shape change is less catastrophic than for a compiled client):
+
+- **MAJOR** (`x.0.0`) — a change an agent genuinely can't recover from: **remove or rename a tool**, remove a parameter, or make an optional parameter required.
+- **MINOR** (`1.x.0`) — new capability, old calls still work: add a tool/database/optional parameter, add a field to a return object, widen accepted input (new alias, case-insensitivity). **Return-shape changes ride here too** (e.g. bare-list → `{total_count, has_more, results}`) — that's why the Reactome (1.1→1.2) and Rhea (1.2→1.3) overhauls were minor despite reshaping returns. Strict semver would call those MAJOR; we don't, deliberately, because agents adapt. (Caveat: a purely programmatic client hitting the endpoint *can* break on a reshape — weigh that if such consumers appear.)
+- **PATCH** (`1.3.x`) — behavior fixed, contract unchanged: a bug fix that makes a tool return what it already promised (the `chebi:CHEBI:` 500, the empty-query guard), docstring/description fixes, a silently-relaxed filter now honored, internal refactors/tests.
+
 ## Testing
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "1.3.0"
+version = "1.3.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -692,6 +692,75 @@ class TestSearchRheaEntity:
         assert result["results"][0] == {"rhea_id": "RHEA:10000"}
 
     @pytest.mark.asyncio
+    async def test_projection_does_not_change_row_set(self) -> None:
+        """`columns` is a projection over FIELDS, never ROWS: total_count and
+        has_more must be invariant under `columns`, even when the projected
+        column is empty on every row. Regression for the sparse-column row-drop
+        that silently collapsed total_count/has_more to 0/false."""
+        _KEY = {
+            "rhea-id": "rhea_id", "equation": "equation", "chebi": "chebi",
+            "chebi-id": "chebi_id", "ec": "ec", "uniprot": "uniprot",
+            "go": "go", "pubmed": "pubmed",
+            "reaction-xref(EcoCyc)": "xref_ecocyc",
+            "reaction-xref(KEGG)": "xref_kegg",
+            "reaction-xref(MetaCyc)": "xref_metacyc",
+            "reaction-xref(Reactome)": "xref_reactome",
+            "reaction-xref(M-CSA)": "xref_mcsa",
+        }
+
+        def _mock(request: httpx.Request) -> httpx.Response:
+            # Worst case: rhea-id anchor populated, every OTHER column blank.
+            fetched = request.url.params.get("columns").split(",")
+            header = "\t".join(f"h_{c}" for c in fetched)
+            body = "\n".join(
+                "\t".join(rid if c == "rhea-id" else "" for c in fetched)
+                for rid in ("RHEA:1", "RHEA:2", "RHEA:3")
+            )
+            return httpx.Response(200, text=f"{header}\n{body}\n")
+
+        with respx.mock(using="httpx") as router:
+            router.get("https://www.rhea-db.org/rhea").mock(side_effect=_mock)
+            for col in _KEY:
+                r = await search_rhea_entity("glucose", limit=10, columns=col)
+                assert r["total_count"] == 3, col
+                assert r["has_more"] is False, col
+                assert len(r["results"]) == 3, col
+                # every requested column present as a key on every row, blank ok
+                assert all(_KEY[col] in row for row in r["results"]), col
+
+    @pytest.mark.asyncio
+    async def test_sparse_column_still_returns_rows(self) -> None:
+        """The pathological case: projecting onto only a sparse xref column must
+        still return the matched rows (with the xref blank), not an empty
+        envelope. rhea-id is fetched as an anchor to keep rows countable."""
+        captured = {}
+
+        def _mock(request: httpx.Request) -> httpx.Response:
+            captured["columns"] = request.url.params.get("columns")
+            # Rhea emits an all-blank data line per row for a sole sparse column;
+            # the anchor makes the tool fetch rhea-id too, so each line has content.
+            return httpx.Response(
+                200,
+                text=(
+                    "Reaction identifier\tCross-reference (Reactome)\n"
+                    "RHEA:14293\t\nRHEA:14405\t\nRHEA:22152\t\n"
+                ),
+            )
+
+        with respx.mock(using="httpx") as router:
+            router.get("https://www.rhea-db.org/rhea").mock(side_effect=_mock)
+            r = await search_rhea_entity(
+                "glucose", limit=2, columns="reaction-xref(Reactome)"
+            )
+        # anchor prepended to the outgoing request
+        assert captured["columns"] == "rhea-id,reaction-xref(Reactome)"
+        assert r["total_count"] == 2
+        assert r["has_more"] is True  # 3 matched > limit 2
+        assert all("xref_reactome" in row for row in r["results"])
+        # projected down to ONLY the requested column (anchor dropped from output)
+        assert r["results"][0] == {"xref_reactome": ""}
+
+    @pytest.mark.asyncio
     async def test_chebi_double_prefix_collapsed(self) -> None:
         """A canonically-prefixed ChEBI id in a chebi:-scoped term (chebi:CHEBI:
         17234) is collapsed to the bare form the API accepts, avoiding an opaque

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -1065,6 +1065,10 @@ async def search_rhea_entity(
     'chebi-id' → 'chebi_id'). On upstream failure returns {'error': ...} instead
     — CHECK FOR 'error' BEFORE READING 'results'.
 
+    Valid `columns` (default rhea-id,equation): rhea-id, equation, chebi,
+    chebi-id, ec, uniprot, go, pubmed, reaction-xref(EcoCyc|KEGG|MetaCyc|
+    Reactome|M-CSA).
+
     Args:
         query: Search string, e.g. "ATP", "glucose", "ec:1.1.1.1",
             "chebi:17234", "uniprot:*". REQUIRED — a blank query raises

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -1164,10 +1164,21 @@ async def search_rhea_entity(
     if not col_ids:
         raise ValueError("columns must name at least one valid Rhea column.")
 
+    # Always fetch `rhea-id` as a stable anchor even if the caller didn't ask
+    # for it. `columns` is a PROJECTION over fields — it must never change which
+    # ROWS come back. But a projection onto only sparse column(s) (e.g. a row
+    # with no reaction-xref(Reactome)) makes Rhea emit an all-blank TSV data
+    # line; blank lines are indistinguishable from the trailing newline and get
+    # dropped during parsing, silently shrinking the row set and corrupting
+    # total_count/has_more. rhea-id is non-empty on every row, so anchoring on
+    # it keeps every matched row countable; we project back to the requested
+    # columns for output below.
+    fetch_ids = col_ids if "rhea-id" in col_ids else ["rhea-id", *col_ids]
+
     # Over-fetch by one so has_more can be detected after truncating to `limit`.
     params = {
         "query": query,
-        "columns": ",".join(col_ids),
+        "columns": ",".join(fetch_ids),
         "format": "tsv",
         "limit": limit + 1,
     }
@@ -1178,23 +1189,26 @@ async def search_rhea_entity(
         return {"error": _rest_fail_msg("Rhea REST API request", resp.message, "rhea")}
 
     # Parse TSV. The header row carries display LABELS ("Reaction identifier"),
-    # not column IDs, so we map by POSITION against the requested `col_ids`.
-    # Values never contain tabs (multi-valued cells are ';'-joined), so a plain
-    # tab split is safe; a trailing empty cell may be dropped, hence the guard.
-    lines = resp.text.strip().split("\n")
-    if len(lines) < 2:
-        return {"total_count": 0, "has_more": False, "results": []}
-
-    keys = [_RHEA_COLUMNS[c] for c in col_ids]
-    results = []
-    for line in lines[1:]:  # first line is the header
-        if not line.strip():
-            continue
+    # not column IDs, so we map by POSITION against `fetch_ids`. Values never
+    # contain tabs (multi-valued cells are ';'-joined), so a plain tab split is
+    # safe. A row is real iff its rhea-id anchor is populated — that is the ONLY
+    # blank-line filter, so a row with every OTHER column empty still survives.
+    fetch_keys = [_RHEA_COLUMNS[c] for c in fetch_ids]
+    anchor = fetch_ids.index("rhea-id")
+    rows = []
+    for line in resp.text.split("\n")[1:]:  # first line is the header
         parts = line.split("\t")
-        results.append(
-            {key: (parts[i] if i < len(parts) else "") for i, key in enumerate(keys)}
+        if anchor >= len(parts) or not parts[anchor].strip():
+            continue  # header-only / trailing blank line, not a data row
+        rows.append(
+            {k: (parts[i] if i < len(parts) else "") for i, k in enumerate(fetch_keys)}
         )
 
-    has_more = len(results) > limit
-    results = results[:limit]
+    # has_more from the RAW row count (before truncation), so the projection
+    # can't influence it. Then project onto the requested columns only — every
+    # requested column is present as a key on every row, blank ("") included.
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    out_keys = [_RHEA_COLUMNS[c] for c in col_ids]
+    results = [{k: row[k] for k in out_keys} for row in rows]
     return {"total_count": len(results), "has_more": has_more, "results": results}

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## v1.3.1 (patch)

### Fix — `search_rhea_entity` projection corrupted the result envelope (HIGH, silent-wrong-answer)
`columns` is a projection over fields, but a projection onto only sparse column(s) made Rhea emit all-blank TSV data lines that the parser dropped — silently shrinking the row set and corrupting `total_count`/`has_more`. `columns="reaction-xref(Reactome)"` on a query with hundreds of hits returned `{total_count: 0, has_more: false, results: []}`.

Fix: fetch `rhea-id` as a stable non-empty anchor even when unrequested, filter blank lines by the anchor only, compute `has_more` from the raw row count, then project onto the requested columns (every requested column present as a key, blank `""` included). Invariant: for fixed query+limit, `total_count`/`has_more` are independent of `columns`. Regression tests assert the invariance property across all 13 columns + the pathological case.

### Docs
- Enumerate the 13 `columns` IDs in the main tool description (was only in the param schema).
- Document the versioning policy (agent-pragmatic semver) in CLAUDE.md.

202 tests pass. Fix verified live on test-togomcp.rdfportal.org (v1.3.0 build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)