### PR TITLE
Release v1.4.0 — TogoVar search_* fixes + MIE corrections

### DIFF
--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -13,7 +13,12 @@ This skill lives in a Claude Code environment with filesystem access and SPARQL 
 
 **1. No blind SPARQL retry loops.** Schema discovery legitimately requires many queries, but if a query fails twice in a row, stop and diagnose — wrong predicate, wrong graph, wrong IRI pattern — before retrying. More retries without diagnosis do not fix a structurally wrong query.
 
-**2. Nothing in the MIE file is invented.** Every RDF triple in `sample_rdf_entries` must be retrievable from the endpoint. Every SPARQL query in `sparql_query_examples` and `cross_database_queries` must execute successfully against the real endpoint before the file is written. Fake examples are worse than missing examples because they train the downstream LLM to write queries that look right but fail silently.
+**2. Nothing in the MIE file is invented — and "it ran" is not "it's right."** Every RDF triple in `sample_rdf_entries` must be retrievable, and every *executable claim* in the file must be executed against the real endpoint before the file is written **and its result confirmed correct**, not merely error-free:
+
+- **SPARQL** (`sparql_query_examples`, `cross_database_queries`, `anti_patterns.correct_sparql`, embedded `cross_references`): must run AND return the right thing. A query that succeeds but returns a union-inflated COUNT is a *failed* test, not a passing one — scope the graph and verify the figure (Phase 2g / 5i).
+- **Search-wrapper claims**: any assertion the file makes about a `search_*` / `ncbi_esearch` / `OLS4:searchClasses` tool's behavior (e.g. `architectural_notes.query_strategy`'s "use `search_chembl_target` for targets, EGFR → CHEMBL203") must be run through the actual tool and the claimed hit confirmed to appear at a *usable* rank/limit — not buried at rank 5 behind unrelated hits, and present at the limit the claim implies (Phase 5j).
+
+Fake or unverified examples are worse than missing ones: they train the downstream LLM to write queries *and tool-calls* that look right but fail silently.
 
 ## File locations in this environment
 
@@ -429,6 +434,20 @@ graph in the stored query. A `co_hosted_graphs` entry whose multiplier no longer
 against the current snapshot is stale — fix or remove it. Absence of a probe on a co-hosted
 endpoint is itself a failure: 2g is mandatory whenever get_sparql_endpoints() shows >1 DB.
 
+**5j. Verify every search-wrapper claim.** Rule 2 covers tool-behavior claims, not just
+SPARQL. For each assertion the file makes about a `search_*` / `ncbi_esearch` /
+`OLS4:searchClasses` tool — most live in `architectural_notes.query_strategy`, but scan the
+whole file — call the tool exactly as the claim implies and confirm the result. "Tool X maps
+term T to ID I" passes ONLY if the tool actually returns I *usably*: at the top, or within a
+limit a caller would plausibly use — not at rank 5 behind unrelated hits, and present at the
+limit the claim states. Rank matters: an ID the tool technically returns but ranks below a
+PPI complex, a mouse ortholog, or other noise is not a claim a downstream LLM can rely on. If
+the tool doesn't satisfy the claim, either rewrite it to what the tool actually does
+(including the rank/limit caveat and the disambiguation the caller needs), or drop it. A false
+tool-behavior claim is exactly the "fake example" Rule 2 forbids, aimed at a wrapper instead
+of SPARQL. (Real regression: the ChEMBL MIE claimed `search_chembl_target("EGFR") → CHEMBL203`;
+the tool returned CHEMBL203 at rank 5, and not at all at `limit=3`.)
+
 ### Phase 6 — Final declaration
 
 Only after Phases 1–5 are complete, report to the user:
@@ -450,6 +469,8 @@ Only after Phases 1–5 are complete, report to the user:
   - anti_patterns.correct_sparql tested: all correct_sparql blocks executed successfully
   - cross-graph inflation checked: co-hosted endpoint probed (2g), multipliers + safe pattern
     validated and recorded in co_hosted_graphs/critical_warnings — or "single-DB endpoint, N/A"
+  - search-wrapper claims verified: every search_*/ncbi/OLS4 tool-behavior claim run through
+    the tool and confirmed to return the stated result usably (5j) — or "no tool-behavior claims"
   - Lines: [count]
 ```
 
@@ -466,6 +487,7 @@ A complete MIE file satisfies:
 - 7 SPARQL queries (2/3/2), 6–7 prioritising structured lookups, ≤ 1 using text search — **all tested**
 - `bif:contains` preferred over `FILTER(CONTAINS())` on Virtuoso (check `access.backend`); property paths split before `bif:contains`
 - No circular reasoning (never `VALUES ?x { <results-of-search-api> }` inside a COUNT)
+- Every search-wrapper behavior claim (e.g. in `architectural_notes.query_strategy`) run through the tool and confirmed to return the stated result at a usable rank/limit — **not just that the tool ran** (5j)
 - Cross-DB: 1–2 examples if shared endpoint, otherwise `examples: []` + explanatory notes
 - `data_statistics` contains only verified counts/coverage — no `verification_queries`, `cardinality`, or `performance_characteristics` subfields
 - Valid YAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "1.3.1"
+version = "1.4.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_togovar.py
+++ b/tests/test_togovar.py
@@ -488,7 +488,12 @@ async def test_search_variant_statistics_caveats():
     )
     out = json.loads(await search_variant(gene_hgnc_id=404, stat=True))
     caveats = out["statistics_caveats"]
-    assert "consequence" in caveats and "NOT scoped" in caveats["consequence"]
+    # consequence is scoped but per variant-transcript — the caveat warns against
+    # summing it against `filtered`, not that it is "unscoped".
+    assert "consequence" in caveats
+    assert "PER VARIANT-TRANSCRIPT" in caveats["consequence"]
+    assert "do NOT compare the sum" in caveats["consequence"].lower() or \
+        "not compare the sum" in caveats["consequence"].lower()
     assert "type" in caveats
     # facets absent from the response are not annotated
     assert "dataset" not in caveats

--- a/tests/test_togovar.py
+++ b/tests/test_togovar.py
@@ -14,8 +14,12 @@ import respx
 from togo_mcp.togovar import (
     _as_list,
     _build_variant_query,
+    _compact_allele,
+    _match_type,
     _project_variant,
     _range_from_bounds,
+    _summarize_allele,
+    _variant_iri,
     search_disease,
     search_gene,
     search_variant,
@@ -182,6 +186,104 @@ def test_project_variant():
 
 
 # --------------------------------------------------------------------------- #
+# T5/T6 — label maps, tgv_id, variant IRI in the projection
+# --------------------------------------------------------------------------- #
+def test_project_variant_labels_and_roundtrip_keys():
+    row = {
+        "id": "tgv47264307",
+        "type": "SO_0001483",
+        "chromosome": "12",
+        "position": 111803962,
+        "reference": "G",
+        "alternate": "A",
+        "most_severe_consequence": "SO_0001583",
+        "significance": [{"source": "clinvar", "interpretations": ["P", "DR"]}],
+    }
+    p = _project_variant(row)
+    # T6: stable SPARQL round-trip keys
+    assert p["tgv_id"] == "tgv47264307"
+    assert p["variant_iri"] == "http://identifiers.org/hco/12/GRCh38#111803962-G-A"
+    # T5: opaque codes get human-readable companions
+    assert p["type_label"] == "SNV"
+    assert p["most_severe_consequence_label"] == "missense_variant"
+    assert p["significance"][0]["interpretation_labels"] == [
+        "Pathogenic",
+        "Drug response",
+    ]
+    # raw codes preserved for backward compatibility
+    assert p["significance"][0]["interpretations"] == ["P", "DR"]
+
+
+def test_project_variant_unknown_code_falls_through():
+    row = {"type": "SO_9999999", "most_severe_consequence": None,
+           "significance": [{"interpretations": ["ZZ"]}]}
+    p = _project_variant(row)
+    assert p["type_label"] is None  # unknown SO -> no label
+    assert p["most_severe_consequence_label"] is None
+    # unknown significance code passes through unchanged, never dropped
+    assert p["significance"][0]["interpretation_labels"] == ["ZZ"]
+
+
+# --------------------------------------------------------------------------- #
+# T1 — large-allele summarization / bounded variant label
+# --------------------------------------------------------------------------- #
+def test_summarize_allele_bounds_large_sequences():
+    long_seq = "A" * 4000
+    assert _summarize_allele("ACGT", False) == "ACGT"  # short: verbatim
+    summ = _summarize_allele(long_seq, False)
+    assert summ.endswith("(4000 bp)") and len(summ) < 40
+    assert _summarize_allele(long_seq, True) == long_seq  # include_full
+    assert _summarize_allele(None, False) is None
+
+
+def test_compact_allele_and_variant_label_bounded():
+    assert _compact_allele("A") == "A"
+    assert _compact_allele("A" * 3000) == "A" * 8 + "…3000bp"
+
+
+def test_project_variant_large_sv_bounded():
+    row = {
+        "chromosome": "17",
+        "position": 43045008,
+        "reference": "T" * 8080,
+        "alternate": "T",
+        "type": "SO_0000159",
+    }
+    p = _project_variant(row)
+    # T1: variant label is length-bounded (was ~16.5k chars before the fix)
+    assert len(p["variant"]) <= 64
+    # true lengths still reported
+    assert p["ref_length"] == 8080
+    assert p["alt_length"] == 1
+    # reference summarized, not the full 8kb sequence
+    assert len(p["reference"]) < 64 and p["reference"].endswith("(8080 bp)")
+    # IRI omitted for the multi-kb allele (would reintroduce the bloat)
+    assert p["variant_iri"] is None
+    # full sequence available on request
+    full = _project_variant(row, include_full_alleles=True)
+    assert full["reference"] == "T" * 8080
+
+
+def test_variant_iri_none_for_incomplete_or_long():
+    assert _variant_iri("12", 100, "G", "A").endswith("#100-G-A")
+    assert _variant_iri("12", None, "G", "A") is None
+    assert _variant_iri("12", 100, "A" * 100, "A") is None  # allele too long
+
+
+# --------------------------------------------------------------------------- #
+# T3/T4 — match_type classification
+# --------------------------------------------------------------------------- #
+def test_match_type_ranks():
+    assert _match_type("ALDH2", "aldh2") == ("exact", 0)
+    assert _match_type("ALDH2A1", "ALDH2") == ("prefix", 1)
+    assert _match_type("Cystic fibrosis", "fibrosis") == ("word", 2)
+    assert _match_type("Hepatic fibrosis-renal cysts", "cystic fibrosis") == (
+        "fuzzy",
+        3,
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Tool coroutines — respx-mocked HTTP
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
@@ -194,7 +296,12 @@ async def test_search_gene_projects_hgnc_id():
     )
     out = json.loads(await search_gene(query="ALDH2"))
     assert out == [
-        {"hgnc_id": 404, "symbol": "ALDH2", "name": "aldehyde dehydrogenase 2"}
+        {
+            "hgnc_id": 404,
+            "symbol": "ALDH2",
+            "name": "aldehyde dehydrogenase 2",
+            "match_type": "exact",
+        }
     ]
 
 
@@ -282,3 +389,132 @@ async def test_search_variant_http_error_raises():
     )
     with pytest.raises(ValueError, match="TogoVar variant search"):
         await search_variant(gene_hgnc_id=404)
+
+
+# --------------------------------------------------------------------------- #
+# T3 — gene re-ranking: exact first; non-existent symbol has no exact hit
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_gene_exact_ranked_first():
+    # API returns a loose set in arbitrary order; exact must float to the top.
+    respx.get(f"{BASE}/search/gene").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": 407, "symbol": "ALDHX", "name": "aldehyde dehydrogenase 1B1"},
+                {"id": 15471, "symbol": "ALDH12", "name": "aldehyde dehydrogenase 8"},
+                {"id": 404, "symbol": "ALDH2", "name": "aldehyde dehydrogenase 2"},
+            ],
+        )
+    )
+    out = json.loads(await search_gene(query="ALDH2"))
+    assert out[0]["symbol"] == "ALDH2"
+    assert out[0]["hgnc_id"] == 404
+    assert out[0]["match_type"] == "exact"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_gene_nonexistent_has_no_exact():
+    # "ALDH2A1" does not exist; the endpoint still returns ALDH2-ish rows, but
+    # none should be classified `exact`.
+    respx.get(f"{BASE}/search/gene").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": 404, "symbol": "ALDH2", "name": "aldehyde dehydrogenase 2"},
+                {"id": 15471, "symbol": "ALDH12", "name": "aldehyde dehydrogenase 8"},
+            ],
+        )
+    )
+    out = json.loads(await search_gene(query="ALDH2A1"))
+    assert all(r["match_type"] != "exact" for r in out)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_gene_limit_applied():
+    respx.get(f"{BASE}/search/gene").mock(
+        return_value=httpx.Response(
+            200,
+            json=[{"id": i, "symbol": f"G{i}", "name": "x"} for i in range(50)],
+        )
+    )
+    out = json.loads(await search_gene(query="G", limit=5))
+    assert len(out) == 5
+
+
+# --------------------------------------------------------------------------- #
+# T4 — disease re-ranking demotes loose token matches
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_disease_exact_first_fuzzy_last():
+    respx.get(f"{BASE}/search/disease").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": "MONDO_0008941", "cui": None,
+                 "label": "Hepatic fibrosis-renal cysts-intellectual disability"},
+                {"id": "MONDO_0009061", "cui": "C0010674", "label": "Cystic fibrosis"},
+            ],
+        )
+    )
+    out = json.loads(await search_disease(query="cystic fibrosis"))
+    assert out[0]["mondo_id"] == "MONDO_0009061"
+    assert out[0]["match_type"] == "exact"
+    assert out[-1]["match_type"] == "fuzzy"
+
+
+# --------------------------------------------------------------------------- #
+# T2 — statistics_caveats attached, only for facets present
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variant_statistics_caveats():
+    respx.post(f"{BASE}/search/variant").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "statistics": {
+                    "total": 100, "filtered": 10,
+                    "type": {"SO_0001483": 10},
+                    "consequence": {"SO_0001583": 999999},
+                },
+                "data": [],
+            },
+        )
+    )
+    out = json.loads(await search_variant(gene_hgnc_id=404, stat=True))
+    caveats = out["statistics_caveats"]
+    assert "consequence" in caveats and "NOT scoped" in caveats["consequence"]
+    assert "type" in caveats
+    # facets absent from the response are not annotated
+    assert "dataset" not in caveats
+    assert "significance" not in caveats
+
+
+# --------------------------------------------------------------------------- #
+# T1 — response size safety valve trims rows on overflow
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variant_size_valve_trims():
+    # Each row carries a multi-kb allele; with include_full_alleles the payload
+    # blows past the cap and rows must be trimmed with a `truncated` flag.
+    big = "A" * 5000
+    rows = [
+        {"chromosome": "1", "position": i, "reference": big, "alternate": "A",
+         "id": f"tgv{i}"}
+        for i in range(50)
+    ]
+    respx.post(f"{BASE}/search/variant").mock(
+        return_value=httpx.Response(200, json={"data": rows})
+    )
+    out = json.loads(
+        await search_variant(gene_hgnc_id=404, include_full_alleles=True)
+    )
+    assert "truncated" in out
+    assert len(out["data"]) < 50
+    assert out["truncated"]["returned_rows"] == len(out["data"])

--- a/togo_mcp/data/mie/togovar.yaml
+++ b/togo_mcp/data/mie/togovar.yaml
@@ -61,7 +61,7 @@ schema_info:
     - "http://togovar.org/clinvar — full embedded ClinVar RDF. Its nodes re-use dcterms:identifier and med2rdf:gene, but dcterms:identifier here is the ClinVar *AlleleID*, NOT the VariationID (see critical_warnings ALLELEID/VARIATIONID trap). Join the variant layer into this graph ONLY via clinvar:variation_id (xsd:integer); never via dcterms:identifier."
   kw_search_tools: []
   version:
-    mie_version: "1.1"
+    mie_version: "1.2"
     mie_created: "2026-07-12"
     mie_updated: "2026-07-14"
     data_version: "GRCh38 endpoint (grch38.togovar.org), snapshot 2026-07"
@@ -148,14 +148,21 @@ critical_warnings: |
     IDs (http://rdf.ebi.ac.uk/resource/ensembl/217) — both minted under the SAME
     ensembl namespace. The sibling tgvo:gene_symbol_source ("HGNC" vs "EntrezGene")
     distinguishes them. Filter to the ENSG form if you mean Ensembl genes.
-  - REST togovar_search_variant CAVEATS. (1) For genes with large structural
-    variants (BRCA1, DMD, ...), the `variant` id embeds the full multi-kb REF/ALT
-    sequence, so responses can exceed client/token limits — use a small `limit` and
-    avoid `stat=True` together with row bodies. (2) In `stat=True` output the `type`
-    and `dataset` facets ARE scoped to the filtered set, but the `consequence` and
-    `significance` facets are NOT (verified: for disease_id MONDO_0007254 filtered =
-    24,550 yet consequence missense SO_0001583 = 334,380 and significance US = 26,894).
-    Do NOT read the consequence/significance breakdowns as counts of the query result.
+  - REST togovar_search_variant NOTES. (1) Each result row carries `tgv_id` and a
+    reconstructed `variant_iri` — either resolves in this SPARQL endpoint, so the
+    REST->SPARQL handoff is direct (fetch frequencies/significance via REST, then
+    deep-dive VEP/cross-refs here). Large structural-variant alleles are summarized
+    in the row (with `ref_length`/`alt_length`); pass `include_full_alleles=True`
+    only when the full sequence is needed. (2) In `stat=True` output ALL facets are
+    scoped to the filtered set, but they count at different granularities: `type`
+    and `dataset` count PER VARIANT (type sums to `filtered`), while `consequence`
+    counts PER VARIANT-TRANSCRIPT (the same VEP fan-out documented below — sum =
+    `filtered` x mean transcripts/variant, ~5-6 for a typical gene but 400+ in
+    transcript-dense loci like BRCA1) and `significance` counts PER
+    VARIANT-CONDITION classification record. So consequence/significance sums
+    legitimately exceed `filtered` and must NOT be read as variant counts of the
+    query result — they are annotation-record counts (use COUNT(DISTINCT) semantics
+    when reasoning about variants).
 
 shape_expressions: |
   PREFIX gvo:   <http://genome-variation.org/resource#>
@@ -511,29 +518,32 @@ controlled_vocabularies:
       togovar_search_variant returns clinical significance as short codes in the
       `significance[].interpretations` array and in the stat `significance` facet.
       These are TogoVar's own abbreviations of ClinVar/MGeND germline classifications.
-      Verified codes observed live for rs671 include P, DR, RF, PR; the codes below
-      are the standard ClinVar mappings. A few codes (LPLP, NC, AN, CS) were observed
-      in stat facets but are not confidently expandable here — confirm against
-      TogoVar's official legend before quoting them to a user.
+      The full legend below is the authoritative TogoVar mapping (from the TogoVar UI
+      advanced_search_conditions.json, clinvar bucket — a superset of the mgend bucket);
+      all codes are confirmed. Note PLP/LPLP are LOW-PENETRANCE variants, NOT the
+      "Pathogenic/Likely pathogenic" combined class.
     legend:
+      NC: Not in ClinVar
       P: Pathogenic
       LP: Likely pathogenic
-      PLP: Pathogenic/Likely pathogenic
-      B: Benign
-      LB: Likely benign
-      US: Uncertain significance
-      CI: Conflicting interpretations of pathogenicity
-      RF: Risk factor
-      DR: Drug response
-      PR: Protective
-      A: Association
-      AF: Affects
-      O: Other
-      NP: Not provided
+      PLP: Pathogenic, low penetrance
+      LPLP: Likely pathogenic, low penetrance
       ERA: Established risk allele
       LRA: Likely risk allele
       URA: Uncertain risk allele
-    unconfirmed_codes: ["LPLP", "NC", "AN", "CS"]   # observed in stat facets; verify against TogoVar docs
+      US: Uncertain significance
+      LB: Likely benign
+      B: Benign
+      CI: Conflicting interpretations of pathogenicity
+      DR: Drug response
+      CS: Confers sensitivity
+      RF: Risk factor
+      A: Association
+      PR: Protective
+      AF: Affects
+      O: Other
+      NP: Not provided
+      AN: Association not found
   - name: Sequence Ontology consequence terms
     description: |
       Functional consequences (tgvo:most_severe_consequence and the rdf:type of each

--- a/togo_mcp/data/mie/togovar.yaml
+++ b/togo_mcp/data/mie/togovar.yaml
@@ -9,8 +9,14 @@ schema_info:
     supporting reference datasets (ClinVar, Ensembl gene models, HGNC, MedGen,
     MONDO, Sequence Ontology, GWAS Catalog, PubMed/PubTator, MeSH, EFO, GO).
     Primary use: variant-to-gene-to-consequence lookup and clinical-significance
-    triage for human variants. NOTE: per-population allele frequencies are NOT in
-    this endpoint (REST API only) — see critical_warnings.
+    triage for human variants.
+    TWO IMPORTANT SCOPE NOTES (see critical_warnings): (1) this SPARQL endpoint is
+    an ANNOTATED SUBSET of TogoVar — it holds 390,725,782 variants, while the
+    TogoVar REST API (togovar_search_variant) reports 1,097,708,150 (~2.8x more);
+    do not treat the SPARQL total as "the size of TogoVar". (2) per-population
+    ALLELE FREQUENCIES are NOT in this endpoint at all — they are REST-only.
+    Clinical significance IS reachable in SPARQL (via a deep embedded-ClinVar
+    blank-node path, verified in example #7) but REST is the robust fallback.
   keywords:
     - variant
     - variation
@@ -42,7 +48,7 @@ schema_info:
     - http://togovar.org/hgnc                           # HGNC gene records (med2rdf:Gene)
     - http://togovar.org/medgen                         # MedGen (MGREL relations)
     - http://togovar.org/mondo                          # MONDO disease ontology
-    - http://togovar.org/so                             # Sequence Ontology (owl:Class)
+    - http://togovar.org/so                             # Sequence Ontology (rdfs:label per SO term)
     - http://togovar.org/go                             # Gene Ontology
     - http://togovar.org/mesh                           # MeSH
     - http://togovar.org/efo                            # Experimental Factor Ontology
@@ -52,11 +58,12 @@ schema_info:
     - http://togovar.org/hco                            # Human Chromosome Ontology (reference IRIs)
   co_hosted_graphs:
     - "http://togovar.org/variant/annotation/clinvar — RE-TYPES the SAME variant IRI as `a gvo:SNV`/Deletion/etc. that http://togovar.org/variant already types (2,944,525 variants). An unscoped `?s a gvo:SNV` COUNT double-counts these. Multiplier = x2 for ClinVar-annotated variants. Safe pattern: pin GRAPH <http://togovar.org/variant> or use COUNT(DISTINCT ?variant)."
-    - "http://togovar.org/clinvar — full embedded ClinVar RDF; its own med2rdf:Variation / clinvar:VariationArchiveType nodes re-use dcterms:identifier and med2rdf:gene on shared IRIs. Join to the variant layer only via the ClinVar VariationID string; do not COUNT variant classes across this graph."
+    - "http://togovar.org/clinvar — full embedded ClinVar RDF. Its nodes re-use dcterms:identifier and med2rdf:gene, but dcterms:identifier here is the ClinVar *AlleleID*, NOT the VariationID (see critical_warnings ALLELEID/VARIATIONID trap). Join the variant layer into this graph ONLY via clinvar:variation_id (xsd:integer); never via dcterms:identifier."
   kw_search_tools: []
   version:
-    mie_version: "1.0"
+    mie_version: "1.1"
     mie_created: "2026-07-12"
+    mie_updated: "2026-07-14"
     data_version: "GRCh38 endpoint (grch38.togovar.org), snapshot 2026-07"
     update_frequency: "Periodic (aligned with TogoVar releases)"
   license:
@@ -65,13 +72,48 @@ schema_info:
     backend: "Virtuoso"
 
 critical_warnings: |
+  - ALLELEID vs VARIATIONID JOIN-KEY COLLISION (silent WRONG-GENE trap). In the
+    embedded ClinVar graph <http://togovar.org/clinvar>, dcterms:identifier is the
+    ClinVar *AlleleID* (xsd:string), NOT the VariationID. The annotation graph
+    <http://togovar.org/variant/annotation/clinvar> stores dcterms:identifier =
+    *VariationID* (xsd:string). Joining these two on dcterms:identifier is WRONG:
+    the numeric spaces overlap, so it silently binds an unrelated record. Verified:
+    for rs671/ALDH2 (VariationID 18390) the string-on-string join returns AlleleID
+    18390 = a SRD5A2 record on chr2 (variation_id 3351), i.e. the WRONG gene
+    (ncbigene:6716 instead of ncbigene:217). CORRECT join: cast the annotation-layer
+    VariationID string with xsd:integer() and BIND it, then match the embedded graph
+    on clinvar:variation_id (xsd:integer). Use a BIND-as-object join, NOT a FILTER:
+    `FILTER(?vid = xsd:integer(?variationId))` across two GRAPH blocks with no shared
+    variable returns 0 rows in Virtuoso; `BIND(xsd:integer(?variationId) AS ?vid)`
+    then `?cv clinvar:variation_id ?vid` works (see example #7). NB: within the
+    embedded graph, clinvar:variation_id sits on BOTH an allele-level blank node
+    (which carries med2rdf:gene + clinvar:name) AND the variation IRI
+    <http://ncbi.nlm.nih.gov/clinvar/variation/{id}> (which carries the
+    classified_record / significance chain) — join both by variation_id.
+  - SPARQL IS A SUBSET OF TOGOVAR; COUNTS DIFFER FROM THE REST API. This SPARQL
+    endpoint holds 390,725,782 variants, but the TogoVar REST API
+    (togovar_search_variant) reports total = 1,097,708,150 (~2.8x larger). Do NOT
+    reconcile counts across the two backends or quote the SPARQL total as "the size
+    of TogoVar". Treat SPARQL as the annotated subset; use REST for whole-database
+    totals and for allele frequencies.
   - NO ALLELE FREQUENCY IN THIS ENDPOINT. TogoVar's headline per-population
     frequencies (ToMMo/54KJPN, gnomAD genomes/exomes, JGA, GEM-J WGA, NCBN, BBJ)
     are NOT stored in this SPARQL endpoint — they are served only via the TogoVar
     REST API (togovar.py sub-server). Verified: even rs671 (extremely common) has
-    only the 9 core predicates and no frequency predicate in ANY graph. There is no
-    `frequency`/`info` bnode chain in the variant graph. Do not attempt to query
-    frequencies here; you will get 0 rows, not an error.
+    only the core predicates and no frequency predicate in ANY graph. Do not query
+    frequencies here; you will get 0 rows, not an error. (Frequencies DO come back
+    in the REST togovar_search_variant row payload.)
+  - CLINICAL SIGNIFICANCE IS DEEP BUT REACHABLE IN SPARQL; REST IS THE ROBUST PATH.
+    Pathogenic/benign/drug-response interpretations live behind an asymmetric
+    blank-node chain in the embedded ClinVar graph:
+    <variation IRI> clinvar:classified_record -> clinvar:classifications ->
+    clinvar:germline_classification -> clinvar:description (the significance literal,
+    e.g. "drug response") + clinvar:review_status. Verified for rs671 (example #7).
+    CAVEAT: the attachment path is not uniform across records — some nodes carry
+    clinvar:classifications directly (no classified_record hop) — so a single fixed
+    property path can miss records. For reliable significance/conditions across
+    arbitrary variants, prefer the REST API (togovar_search_variant returns a clean
+    `significance` array with interpretation codes + conditions).
   - CROSS-GRAPH RE-TYPING / UNION INFLATION. The same variant IRI is typed
     `a <http://genome-variation.org/resource#SNV>` (or Deletion/Insertion/...) in
     BOTH <http://togovar.org/variant> AND <http://togovar.org/variant/annotation/clinvar>
@@ -86,6 +128,12 @@ critical_warnings: |
     (dcterms:identifier = ClinVar VariationID, gvo:info = ALLELEID) lives in
     <http://togovar.org/variant/annotation/clinvar>. Querying the wrong graph returns
     0 rows silently — always pin the correct GRAPH.
+  - PER-TRANSCRIPT FAN-OUT. tgvo:hasConsequence is a blank node PER TRANSCRIPT
+    overlap, so projecting tgvo:hgvsp / tgvo:transcript / tgvo:gene multiplies rows
+    per variant. Verified: the single variant 111781979-C-T (ALDH2 p.Pro59Leu)
+    returns 5 consequence bnodes (4 distinct HGVSp: ENSP00000261733 / ENSP00000403349
+    / NP_000681 / NP_001191818). COUNT variants with COUNT(DISTINCT ?variant) and use
+    SELECT DISTINCT for listings, or you will over-count.
   - NORMALIZED vs VCF ALLELES. gvo:ref/gvo:alt are VOA-normalized (trimmed) alleles
     and are the EMPTY STRING "" for pure deletions (alt) / insertions (ref).
     gvo:ref_vcf/gvo:alt_vcf carry the VCF anchor base (never empty). gvo:pos differs
@@ -94,11 +142,20 @@ critical_warnings: |
   - gvo:pos and faldo:position are xsd:integer. Match with an integer literal
     (e.g. `gvo:pos 111803962`), NOT a string ("111803962") — a string joins to nothing.
     gvo:ref/gvo:alt and dcterms:identifier are xsd:string (plain literal matches fine).
+    clinvar:variation_id and clinvar:allele_id are xsd:integer (match with integers).
   - tgvo:gene IS POLYMORPHIC UNDER ONE NAMESPACE. Objects of tgvo:gene are BOTH
     Ensembl gene IRIs (http://rdf.ebi.ac.uk/resource/ensembl/ENSG...) AND NCBI Gene
     IDs (http://rdf.ebi.ac.uk/resource/ensembl/217) — both minted under the SAME
     ensembl namespace. The sibling tgvo:gene_symbol_source ("HGNC" vs "EntrezGene")
     distinguishes them. Filter to the ENSG form if you mean Ensembl genes.
+  - REST togovar_search_variant CAVEATS. (1) For genes with large structural
+    variants (BRCA1, DMD, ...), the `variant` id embeds the full multi-kb REF/ALT
+    sequence, so responses can exceed client/token limits — use a small `limit` and
+    avoid `stat=True` together with row bodies. (2) In `stat=True` output the `type`
+    and `dataset` facets ARE scoped to the filtered set, but the `consequence` and
+    `significance` facets are NOT (verified: for disease_id MONDO_0007254 filtered =
+    24,550 yet consequence missense SO_0001583 = 334,380 and significance US = 26,894).
+    Do NOT read the consequence/significance breakdowns as counts of the query result.
 
 shape_expressions: |
   PREFIX gvo:   <http://genome-variation.org/resource#>
@@ -108,6 +165,8 @@ shape_expressions: |
   PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   PREFIX obo:   <http://purl.obolibrary.org/obo/>
+  PREFIX cvo:   <http://purl.jp/bio/10/clinvar/>
+  PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
 
   # ---- CORE VARIANT (graph: http://togovar.org/variant) ----
   # Total 390,725,782 variants: SNV 339,076,968 | Deletion 29,307,469 |
@@ -115,8 +174,8 @@ shape_expressions: |
   # http://identifiers.org/hco/{chr}/GRCh38#{pos}-{ref}-{alt}
   <VariantShape> {
     a [ gvo:SNV gvo:Deletion gvo:Insertion gvo:MNV gvo:Indel ] ;  # exactly one type
-    dcterms:identifier xsd:string ;        # tgv ID, e.g. "tgv239865485" — exactly 1
-    gvo:pos      xsd:integer ;             # normalized 1-based position (=1)
+    dcterms:identifier xsd:string ;        # tgv ID, e.g. "tgv47264307" — exactly 1
+    gvo:pos      xsd:integer ;             # normalized 1-based position
     gvo:pos_vcf  xsd:integer ;             # VCF position (indels differ from pos by 1)
     gvo:ref      xsd:string ;             # normalized REF ("" for pure insertions)
     gvo:alt      xsd:string ;             # normalized ALT ("" for pure deletions)
@@ -150,10 +209,10 @@ shape_expressions: |
   # Same variant IRI as subject; ~100% of variants annotated (sampling N=2000 SNV).
   <VepAnnotationShape> {
     rdfs:seeAlso IRI * ;                        # dbSNP: http://identifiers.org/dbsnp/rs... (~99% of SNVs; 0..n)
-    tgvo:most_severe_consequence IRI ;          # SO term obo:SO_XXXXXXX (exactly 1)
-    tgvo:hasConsequence @<ConsequenceShape> +   # one per transcript overlap
+    tgvo:most_severe_consequence IRI ;          # SO term obo:SO_XXXXXXX (exactly 1); label in the `so` graph
+    tgvo:hasConsequence @<ConsequenceShape> +   # one per transcript overlap (PER-TRANSCRIPT FAN-OUT)
   }
-  # Consequence blank node — typed with its SO consequence term(s).
+  # Consequence blank node — typed with its SO consequence term(s). One PER TRANSCRIPT.
   <ConsequenceShape> {
     a [ obo:SO_0001583 ] * ;                    # rdf:type = SO consequence term(s), e.g. missense_variant
     tgvo:transcript IRI ? ;                     # http://rdf.ebi.ac.uk/resource/ensembl.transcript/{ENST|NM_...}
@@ -175,24 +234,56 @@ shape_expressions: |
 
   # ---- CLINVAR ANNOTATION (graph: http://togovar.org/variant/annotation/clinvar) ----
   # RE-DECLARES the variant IRI (same subject) — see critical_warnings union inflation.
-  # 2,944,525 variants carry this annotation.
+  # 2,944,525 variants carry this annotation. dcterms:identifier here = ClinVar VariationID.
   <ClinvarAnnotationShape> {
     a [ gvo:SNV gvo:Deletion gvo:Insertion ] ;  # re-typed here (double-count trap)
-    dcterms:identifier xsd:string ;             # ClinVar VariationID, e.g. "18390"
+    dcterms:identifier xsd:string ;             # ClinVar VariationID, e.g. "18390" (NOT the AlleleID)
     gvo:ref xsd:string ; gvo:alt xsd:string ;
     gvo:pos xsd:integer ;
     faldo:location @<LocationShape> ;
     gvo:info @<ClinvarInfoShape> +              # key/value INFO bnode
   }
-  # INFO key/value bnode; observed key so far: ALLELEID (rdfs:label) + rdf:value.
+  # INFO key/value bnode; observed key: ALLELEID (rdfs:label) + rdf:value (the AlleleID integer).
   <ClinvarInfoShape> {
     rdfs:label xsd:string ;                     # e.g. "ALLELEID"
     rdf:value xsd:integer                       # e.g. 33429 (the ClinVar Allele ID) — xsd:integer
   }
-  # For full clinical significance / conditions, join the ClinVar VariationID into the
-  # embedded ClinVar dataset graph <http://togovar.org/clinvar> (DBCLS ClinVar RDF;
-  # med2rdf:Variation nodes keyed by dcterms:identifier; med2rdf:gene -> NCBI gene).
-  # That graph mirrors the standalone `clinvar` database — see clinvar.yaml.
+
+  # ---- EMBEDDED CLINVAR DATASET (graph: http://togovar.org/clinvar) ----
+  # DBCLS ClinVar RDF (mirrors the standalone `clinvar` database, see clinvar.yaml).
+  # clinvar:variation_id (xsd:integer) is the CORRECT join key from the annotation layer
+  # (dcterms:identifier there = VariationID string -> xsd:integer -> clinvar:variation_id).
+  # A given VariationID resolves to TWO node kinds, both carrying clinvar:variation_id:
+  #  (1) an ALLELE-LEVEL blank node — carries med2rdf:gene (-> ncbigene IRI) and clinvar:name;
+  #  (2) the VARIATION IRI <http://ncbi.nlm.nih.gov/clinvar/variation/{id}> — carries rdfs:label,
+  #      clinvar:accession (VCV...), and the significance chain via clinvar:classified_record.
+  <ClinvarAlleleShape> {                        # node kind (1) — reached by clinvar:variation_id
+    a [ med2rdf:Variation cvo:TypeAllele ] ;
+    cvo:variation_id xsd:integer ;              # e.g. 18390
+    cvo:allele_id    xsd:integer ;              # e.g. 33429 (this is dcterms:identifier in this graph)
+    dcterms:identifier xsd:string ;             # AlleleID as string (NOT the VariationID — collision trap)
+    med2rdf:gene IRI ? ;                         # http://ncbi.nlm.nih.gov/gene/{n} (NCBI gene)
+    cvo:name xsd:string * ;                     # e.g. "NM_000690.4(ALDH2):c.1510G>A (p.Glu504Lys)"
+    cvo:canonical_spdi xsd:string ?             # e.g. "NC_000012.12:111803961:G:A"
+  }
+  <ClinvarVariationShape> {                     # node kind (2) — the significance carrier
+    a [ cvo:VariationArchiveType ] ;
+    cvo:variation_id xsd:integer ;
+    cvo:accession xsd:string ? ;                # VCV000018390
+    rdfs:label xsd:string ? ;
+    cvo:classified_record @<ClinvarClassifiedRecordShape> ?
+  }
+  # Significance chain (verified for rs671; attachment path can vary across records).
+  <ClinvarClassifiedRecordShape> {
+    cvo:classifications @<ClinvarClassificationsShape> ?
+  }
+  <ClinvarClassificationsShape> {
+    cvo:germline_classification @<GermlineClassificationShape> ?
+  }
+  <GermlineClassificationShape> {
+    cvo:description  xsd:string ;               # THE significance literal, e.g. "drug response", "Pathogenic"
+    cvo:review_status xsd:string ?              # e.g. "reviewed by expert panel"
+  }
 
 sample_rdf_entries:
   rdf_prefixes: |
@@ -202,6 +293,8 @@ sample_rdf_entries:
     @prefix dcterms: <http://purl.org/dc/terms/> .
     @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix cvo:     <http://purl.jp/bio/10/clinvar/> .
+    @prefix med2rdf: <http://med2rdf.org/ontology/med2rdf#> .
     @prefix hco:     <http://identifiers.org/hco/12/GRCh38#> .
   entries:
     - title: "Core SNV record — rs671 / ALDH2 (graph: variant)"
@@ -230,13 +323,22 @@ sample_rdf_entries:
                 tgvo:transcript <http://rdf.ebi.ac.uk/resource/ensembl.transcript/ENST00000261733> ;
                 tgvo:hgvsp "ENSP00000261733.2:p.Glu504Lys" ;
                 tgvo:impact "MODERATE" ] .
-    - title: "ClinVar annotation — re-typed variant IRI (graph: variant/annotation/clinvar)"
-      description: The SAME variant IRI re-declared with the ClinVar VariationID and an ALLELEID INFO bnode (illustrates the union-inflation trap).
+    - title: "Embedded ClinVar allele + significance — rs671 (graph: clinvar)"
+      description: The embedded-ClinVar allele node (gene, name, keyed by clinvar:variation_id) and the variation-IRI significance chain reached via classified_record. Shows the CORRECT join key (variation_id, integer) — dcterms:identifier here is the AlleleID.
       rdf: |
-        # GRAPH <http://togovar.org/variant/annotation/clinvar>
-        hco:111803962-G-A a gvo:SNV ;                 # re-typed here AND in the variant graph
-            dcterms:identifier "18390" ;              # ClinVar VariationID
-            gvo:info [ rdfs:label "ALLELEID" ; rdf:value 33429 ] .
+        # GRAPH <http://togovar.org/clinvar>
+        _:allele a med2rdf:Variation, cvo:TypeAllele ;
+            cvo:variation_id 18390 ;                # correct join key (integer VariationID)
+            cvo:allele_id 33429 ;
+            dcterms:identifier "33429" ;            # AlleleID as string (NOT the VariationID)
+            med2rdf:gene <http://ncbi.nlm.nih.gov/gene/217> ;   # ALDH2 (NOT SRD5A2/6716)
+            cvo:name "NM_000690.4(ALDH2):c.1510G>A (p.Glu504Lys)" .
+        <http://ncbi.nlm.nih.gov/clinvar/variation/18390>
+            cvo:variation_id 18390 ; cvo:accession "VCV000018390" ;
+            cvo:classified_record [ cvo:classifications [
+                cvo:germline_classification [
+                    cvo:description "drug response" ;
+                    cvo:review_status "reviewed by expert panel" ] ] ] .
 
 sparql_query_examples:
   - title: "Variant core record by TogoVar variant IRI"
@@ -257,25 +359,28 @@ sparql_query_examples:
       }
       LIMIT 20
 
-  - title: "Resolve a dbSNP rsID to variant + most-severe consequence"
-    description: dbSNP rsIDs are stored as IRIs (rdfs:seeAlso) in the ensembl annotation graph — use the IRI, not a text match.
-    question: "Which TogoVar variant is dbSNP rs671, and what is its most severe consequence?"
+  - title: "Resolve a dbSNP rsID to variant + most-severe consequence (with SO label)"
+    description: dbSNP rsIDs are stored as IRIs (rdfs:seeAlso) in the ensembl annotation graph — use the IRI, not a text match. The SO consequence IRI is opaque; join the embedded `so` graph to get its human-readable label.
+    question: "Which TogoVar variant is dbSNP rs671, and what is its most severe consequence (with a readable label)?"
     complexity: basic
     sparql: |
       PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT ?variant ?soConsequence
+      SELECT ?variant ?soConsequence ?soLabel
       WHERE {
         GRAPH <http://togovar.org/variant/annotation/ensembl> {
           ?variant rdfs:seeAlso <http://identifiers.org/dbsnp/rs671> ;
                    tgvo:most_severe_consequence ?soConsequence .
         }
+        GRAPH <http://togovar.org/so> {                 # SO term labels live here
+          ?soConsequence rdfs:label ?soLabel .          # SO_0001583 -> "missense_variant"
+        }
       }
       LIMIT 20
 
   - title: "All variants in a gene by Ensembl gene IRI, with consequence"
-    description: Filter the consequence bnode by the Ensembl gene IRI (typed predicate lookup) — no gene-name text search.
+    description: Filter the consequence bnode by the Ensembl gene IRI (typed predicate lookup) — no gene-name text search. DISTINCT collapses the per-transcript fan-out.
     question: "List variants affecting ALDH2 (ENSG00000111275) with their most severe consequence."
     complexity: intermediate
     sparql: |
@@ -292,7 +397,7 @@ sparql_query_examples:
       LIMIT 20
 
   - title: "SAFE variant-class count (avoid cross-graph re-typing inflation)"
-    description: Demonstrates the graph-pinned COUNT that returns the true class size; the unscoped form double-counts ClinVar-annotated variants.
+    description: Demonstrates the graph-pinned COUNT that returns the true class size; the unscoped form double-counts ClinVar-annotated variants. (A `GROUP BY ?type` over this graph also works, but returns FALDO position types alongside the 5 variant classes.)
     question: "How many Insertion variants are in TogoVar?"
     complexity: intermediate
     sparql: |
@@ -307,7 +412,7 @@ sparql_query_examples:
       LIMIT 1
 
   - title: "Predicted-deleterious missense variants in a gene (SIFT)"
-    description: Uses the controlled SIFT prediction literal and the Ensembl gene IRI on the same consequence bnode; STRSTARTS covers the *_low_confidence variants.
+    description: Uses the controlled SIFT prediction literal and the Ensembl gene IRI on the same consequence bnode; STRSTARTS covers the *_low_confidence variants. DISTINCT collapses per-transcript fan-out.
     question: "Which ALDH2 variants are predicted deleterious by SIFT, and what is the protein change?"
     complexity: intermediate
     sparql: |
@@ -326,7 +431,7 @@ sparql_query_examples:
       LIMIT 20
 
   - title: "Full variant report joining core + VEP annotation graphs"
-    description: Cross-GRAPH join within the endpoint — core coordinates from the variant graph, dbSNP + gene + protein change from the ensembl annotation graph, anchored on a gene to stay bounded.
+    description: Cross-GRAPH join within the endpoint — core coordinates from the variant graph, dbSNP + gene + protein change from the ensembl annotation graph, anchored on a gene to stay bounded. DISTINCT collapses per-transcript fan-out.
     question: "For ALDH2 variants, give position, ref/alt, dbSNP rsID and protein consequence."
     complexity: advanced
     sparql: |
@@ -348,22 +453,36 @@ sparql_query_examples:
       }
       LIMIT 20
 
-  - title: "Variant to ClinVar VariationID to embedded ClinVar dataset gene"
-    description: Bridge the variant layer to the embedded DBCLS ClinVar RDF via the ClinVar VariationID string join; the ClinVar variation node carries the NCBI gene link.
-    question: "For the variant chr12:111803962 G>A, what ClinVar VariationID and gene does the ClinVar dataset record?"
+  - title: "Variant to ClinVar gene + germline significance (CORRECT variation_id join)"
+    description: >
+      Clinical-triage flagship. Bridges the variant layer to the embedded ClinVar RDF via the
+      ClinVar VariationID cast to INTEGER and joined on clinvar:variation_id — the CORRECT key.
+      Joining on dcterms:identifier instead (the AlleleID in the embedded graph) silently returns
+      the WRONG gene (rs671 -> SRD5A2 instead of ALDH2). The join is a BIND-as-object, not a FILTER
+      cast (a cross-GRAPH FILTER on variation_id returns 0 rows in Virtuoso). Gene + name come from
+      the allele-level node; significance from the variation-IRI classified_record chain.
+    question: "For chr12:111803962 G>A (rs671), what gene, variant name and ClinVar germline significance does the embedded ClinVar dataset record?"
     complexity: advanced
     sparql: |
       PREFIX dcterms: <http://purl.org/dc/terms/>
       PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX cvo:     <http://purl.jp/bio/10/clinvar/>
+      PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
 
-      SELECT DISTINCT ?variationId ?gene
+      SELECT DISTINCT ?variationId ?gene ?name ?significance ?reviewStatus
       WHERE {
         GRAPH <http://togovar.org/variant/annotation/clinvar> {
-          <http://identifiers.org/hco/12/GRCh38#111803962-G-A> dcterms:identifier ?variationId .
+          <http://identifiers.org/hco/12/GRCh38#111803962-G-A> dcterms:identifier ?variationId .  # VariationID (string)
         }
-        GRAPH <http://togovar.org/clinvar> {           # embedded ClinVar RDF (see clinvar.yaml)
-          ?cv dcterms:identifier ?variationId ;
-              med2rdf:gene ?gene .
+        BIND(xsd:integer(?variationId) AS ?vid)      # cast + BIND, then join as a triple object
+        GRAPH <http://togovar.org/clinvar> {
+          ?alleleNode cvo:variation_id ?vid ;        # INTEGER VariationID — the correct join key
+                      med2rdf:gene ?gene .            # -> ncbigene:217 (ALDH2); NOT 6716 (SRD5A2)
+          OPTIONAL { ?alleleNode cvo:name ?name FILTER(isLiteral(?name)) }
+          ?varNode cvo:variation_id ?vid ;
+                   cvo:classified_record/cvo:classifications/cvo:germline_classification ?gc .
+          ?gc cvo:description ?significance .          # e.g. "drug response"
+          OPTIONAL { ?gc cvo:review_status ?reviewStatus }
         }
       }
       LIMIT 20
@@ -379,11 +498,51 @@ cross_database_queries:
     reference datasets AS INTERNAL GRAPHS (clinvar, ensembl gene models, hgnc, medgen,
     mondo, so, gwas-catalog, mesh, efo, go, pubmed, pubtator), so the important joins are
     CROSS-GRAPH within this endpoint — demonstrated in sparql_query_examples #6 (core+VEP)
-    and #7 (variant -> ClinVar VariationID -> embedded ClinVar dataset).
+    and #7 (variant -> ClinVar variation_id -> embedded ClinVar gene + significance).
     Manual bridging to RDF Portal: use the stable external IRIs TogoVar exposes as join keys
     — dbSNP rsID (http://identifiers.org/dbsnp/rs...), Ensembl gene (ENSG...), Ensembl
-    transcript, HGNC (http://identifiers.org/hgnc/...), SO terms (obo:SO_...), and ClinVar
-    VariationID — via TogoID conversion or a separate query against the RDF Portal endpoint.
+    transcript, HGNC (http://identifiers.org/hgnc/...), SO terms (obo:SO_...), NCBI gene
+    (from the embedded ClinVar med2rdf:gene), and ClinVar VariationID — via TogoID conversion
+    or a separate query against the RDF Portal endpoint.
+
+controlled_vocabularies:
+  - name: TogoVar REST clinical-significance abbreviation codes
+    description: |
+      togovar_search_variant returns clinical significance as short codes in the
+      `significance[].interpretations` array and in the stat `significance` facet.
+      These are TogoVar's own abbreviations of ClinVar/MGeND germline classifications.
+      Verified codes observed live for rs671 include P, DR, RF, PR; the codes below
+      are the standard ClinVar mappings. A few codes (LPLP, NC, AN, CS) were observed
+      in stat facets but are not confidently expandable here — confirm against
+      TogoVar's official legend before quoting them to a user.
+    legend:
+      P: Pathogenic
+      LP: Likely pathogenic
+      PLP: Pathogenic/Likely pathogenic
+      B: Benign
+      LB: Likely benign
+      US: Uncertain significance
+      CI: Conflicting interpretations of pathogenicity
+      RF: Risk factor
+      DR: Drug response
+      PR: Protective
+      A: Association
+      AF: Affects
+      O: Other
+      NP: Not provided
+      ERA: Established risk allele
+      LRA: Likely risk allele
+      URA: Uncertain risk allele
+    unconfirmed_codes: ["LPLP", "NC", "AN", "CS"]   # observed in stat facets; verify against TogoVar docs
+  - name: Sequence Ontology consequence terms
+    description: |
+      Functional consequences (tgvo:most_severe_consequence and the rdf:type of each
+      hasConsequence bnode) are Sequence Ontology IRIs (http://purl.obolibrary.org/obo/SO_XXXXXXX).
+      Their human-readable labels are in the embedded <http://togovar.org/so> graph via
+      rdfs:label (verified: SO_0001583 -> "missense_variant"). Join there for labels;
+      do NOT hardcode SO numbers. Common ones: SO_0001583 missense_variant,
+      SO_0001627 intron_variant, SO_0001819 synonymous_variant, SO_0001589 frameshift_variant,
+      SO_0001587 stop_gained.
 
 cross_references:
   - pattern: rdfs:seeAlso (dbSNP)
@@ -406,64 +565,78 @@ cross_references:
     description: |
       Functional consequences are Sequence Ontology term IRIs
       (http://purl.obolibrary.org/obo/SO_XXXXXXX), both as most_severe_consequence and
-      as the rdf:type of each hasConsequence bnode. The SO terms themselves are in the
-      embedded <http://togovar.org/so> graph.
+      as the rdf:type of each hasConsequence bnode. Labels are in the embedded
+      <http://togovar.org/so> graph (rdfs:label; see example #2 and controlled_vocabularies).
     databases:
       variant:
         - "TogoVar: most_severe_consequence on ~100% of variants (sampling N=2000)"
-  - pattern: dcterms:identifier (ClinVar VariationID) -> embedded ClinVar
+  - pattern: ClinVar VariationID -> embedded ClinVar (clinvar:variation_id, INTEGER)
     description: |
       The clinvar annotation graph stores the ClinVar VariationID as dcterms:identifier
-      (xsd:string). Join it into <http://togovar.org/clinvar> (DBCLS ClinVar RDF) for
-      significance, conditions (MONDO/MedGen), and gene links.
+      (xsd:string). To reach the embedded ClinVar dataset <http://togovar.org/clinvar>,
+      CAST it to xsd:integer and join on clinvar:variation_id — NOT on dcterms:identifier,
+      which in the embedded graph is the ClinVar AlleleID (numeric-space collision returns
+      the wrong record; see critical_warnings). From there: med2rdf:gene (-> NCBI gene) and
+      clinvar:name on the allele-level node; germline significance via
+      clinvar:classified_record/classifications/germline_classification/description on the
+      variation IRI. Also links out via rdfs:seeAlso to
+      http://ncbi.nlm.nih.gov/clinvar/variation/{id} and clinvar:accession (VCV...).
     databases:
       variant:
         - "TogoVar: 2,944,525 variants carry a ClinVar annotation (~0.75% of 390.7M)"
 
 architectural_notes:
   query_strategy:
-    - "FIRST: read this MIE; note which GRAPH each predicate lives in (core vs ensembl-anno vs clinvar-anno)."
-    - "KEYWORD ENTRY (REST->SPARQL handoff): resolve names with the TogoVar REST tools, then anchor SPARQL on the returned ID. togovar_search_gene('ALDH2')->hgnc_id 404 anchors directly via `?c tgvo:hgnc <http://identifiers.org/hgnc/404>` (no Ensembl-ENSG conversion needed; verified 6,490 ALDH2 variants). togovar_search_disease(name)->MONDO id feeds the <http://togovar.org/mondo> graph / ClinVar join. rsIDs need no search — they are rdfs:seeAlso IRIs."
-    - "Anchor on a specific IRI: variant IRI (hco/{chr}/GRCh38#{pos}-{ref}-{alt}), dbSNP rsID, Ensembl gene ENSG, or HGNC IRI."
+    - "FIRST: read this MIE; note which GRAPH each predicate lives in (core vs ensembl-anno vs clinvar-anno vs embedded-clinvar)."
+    - "KEYWORD ENTRY (REST->SPARQL handoff): resolve names with the TogoVar REST tools, then anchor SPARQL on the returned ID. togovar_search_gene('ALDH2')->hgnc_id 404 anchors directly via `?c tgvo:hgnc <http://identifiers.org/hgnc/404>` (no Ensembl-ENSG conversion needed). togovar_search_disease(name)->MONDO id feeds the <http://togovar.org/mondo> graph / ClinVar join. rsIDs need no search — they are rdfs:seeAlso IRIs."
+    - "REST RESOLVER CAVEATS before anchoring SPARQL: (a) togovar_search_gene does LOOSE PREFIX matching and returns ~40 rows for any 'ALD*' query — a NON-EXISTENT symbol like 'ALDH2A1' returns the SAME ~40 rows as 'ALDH2' (trailing chars ignored), and it mixes approved symbols with aliases under one hgnc_id (e.g. ALDHX and ALDH1B1 both hgnc_id 407). VERIFY the returned symbol EXACTLY equals the intended gene before using its hgnc_id; the correct hit is first, but do not trust rank blindly. (b) togovar_search_disease may OMIT the canonical MONDO term: 'breast cancer' returns only subtypes and NOT MONDO_0007254, which is nonetheless a valid disease_id (togovar_search_variant filtered=24,550). When you intend a superclass, pass the broad/ancestor MONDO term explicitly."
+    - "Anchor on a specific IRI: variant IRI (hco/{chr}/GRCh38#{pos}-{ref}-{alt}), dbSNP rsID, Ensembl gene ENSG, HGNC IRI, or ClinVar variation IRI."
     - "Always pin GRAPH — predicates are graph-scoped and the variant IRI is re-typed across graphs."
     - "For counts of variant classes, pin GRAPH <http://togovar.org/variant> (or COUNT(DISTINCT)) to avoid the x2 ClinVar re-typing inflation."
+    - "To bridge into the embedded ClinVar dataset, CAST the VariationID to xsd:integer and join on clinvar:variation_id (never dcterms:identifier); use BIND-as-object, not a cross-GRAPH FILTER."
     - "Priority: Specific IRIs > typed predicates (SO/impact/prediction literals) > cross-graph joins. Text search is not needed."
   schema_design:
-    - "Central entity: Variant (390.7M) with 9 core predicates in the variant graph; type is one of SNV/Deletion/Insertion/MNV/Indel."
+    - "Central entity: Variant (390.7M in SPARQL; REST reports 1.1B total) with core predicates in the variant graph; type is one of SNV/Deletion/Insertion/MNV/Indel."
     - "Coordinates via FALDO: SNV->ExactPosition, Insertion->InBetweenPosition, Deletion/multi-base->Region(begin/end InBetweenPosition). Normalized (gvo:*) vs VCF (gvo:*_vcf) allele/pos pairs."
     - "Annotation is layered in separate graphs keyed by the SAME variant IRI: ensembl (VEP consequences, dbSNP), clinvar (VariationID, ALLELEID)."
-    - "hasConsequence bnodes are per-transcript, typed with SO consequence term(s), carrying gene/transcript/HGVS/impact/SIFT/PolyPhen/AlphaMissense."
+    - "hasConsequence bnodes are PER-TRANSCRIPT, typed with SO consequence term(s), carrying gene/transcript/HGVS/impact/SIFT/PolyPhen/AlphaMissense — they fan out (use DISTINCT / COUNT DISTINCT)."
+    - "Embedded ClinVar: a VariationID maps to an allele-level bnode (med2rdf:gene, clinvar:name) AND a variation IRI (classified_record -> classifications -> germline_classification -> description = significance). Both carry clinvar:variation_id."
     - "Reference ontologies/datasets embedded as graphs: clinvar (DBCLS ClinVar RDF), ensembl gene models, hgnc, medgen, mondo, so, go, mesh, efo, gwas-catalog, pubmed, pubtator, hco."
   performance:
-    - "COUNT/DISTINCT over the full annotation graphs (390M+ subjects) times out (~90s) — anchor on a gene/variant IRI, or use the indexed class-count on the variant graph."
-    - "Class-partitioned COUNTs on the variant graph (?s a gvo:SNV) ARE fast (Virtuoso type index)."
+    - "Per-class COUNT with the class PINNED is fast (Virtuoso type index): SELECT (COUNT(?v) AS ?n) WHERE { GRAPH <http://togovar.org/variant> { ?v a gvo:SNV } } returns 339,076,968 quickly."
+    - "GROUP BY ?type over GRAPH <http://togovar.org/variant> also completes (returns in seconds on the current snapshot) but includes the FALDO position types (ExactPosition/InBetweenPosition/Region) alongside the 5 variant classes — filter to gvo:* types or read data_statistics.by_class."
+    - "COUNT(DISTINCT ?s) over an entire 390M-subject ANNOTATION graph (ensembl/clinvar) is heavy — anchor on a gene/variant IRI instead of scanning."
     - "Bound every consequence/gene query with a specific gene or variant IRI plus LIMIT."
     - "bif:contains is available (Virtuoso) but unnecessary here; if ever used, split property paths before it."
   data_integration:
-    - "Join keys: variant IRI (internal cross-graph), dbSNP rsID, Ensembl gene/transcript IRI, HGNC IRI, SO term IRI, ClinVar VariationID."
-    - "ClinVar clinical detail lives in the embedded <http://togovar.org/clinvar> graph — reuse the clinvar.yaml MIE for its deep schema."
+    - "Join keys: variant IRI (internal cross-graph), dbSNP rsID, Ensembl gene/transcript IRI, HGNC IRI, SO term IRI, and — into embedded ClinVar — clinvar:variation_id (xsd:integer), NOT dcterms:identifier."
+    - "ClinVar clinical detail (significance, conditions) lives in the embedded <http://togovar.org/clinvar> graph — reuse the clinvar.yaml MIE for its deep schema. REST is the robust fallback for significance."
     - "Allele frequencies are external to this endpoint (TogoVar REST API only)."
   data_quality:
     - "The same variant IRI is re-typed in the clinvar annotation graph (union inflation trap)."
+    - "Embedded-ClinVar dcterms:identifier is the AlleleID, whose numeric space overlaps VariationIDs — join on clinvar:variation_id or bind the wrong gene."
     - "tgvo:gene mixes Ensembl gene IRIs and NCBI Gene IDs under one namespace (disambiguate via gene_symbol_source)."
     - "gvo:ref/gvo:alt are empty strings for pure indels; use gvo:ref_vcf/gvo:alt_vcf for anchor-base VCF form."
     - "tgvo:sift and tgvo:polyphen have MIXED xsd:decimal/xsd:integer datatypes (numeric comparison works; exact equality does not)."
+    - "hasConsequence fans out per transcript; count with COUNT(DISTINCT ?variant)."
   text_search_justification:
     - "Number of the 7 example queries that use text search: 0."
-    - "Every filter concept here is IRI- or controlled-literal-backed: genes (ENSG/HGNC IRIs), variants (dbSNP/variant IRIs), consequences (SO IRIs), impact/SIFT/PolyPhen (controlled literals)."
+    - "Every filter concept here is IRI- or controlled-literal-backed: genes (ENSG/HGNC IRIs), variants (dbSNP/variant IRIs), consequences (SO IRIs), impact/SIFT/PolyPhen (controlled literals), significance (clinvar:description literal)."
     - "No free-text predicate exists on variants, so no bif:contains is warranted."
 
 data_statistics:
   total_entities: 390725782
-  verified_date: "2026-07-12"
-  verification_method: "Direct GROUP BY type COUNT on GRAPH <http://togovar.org/variant> (indexed)"
+  rest_api_total_variants: 1097708150
+  sparql_is_subset: true
+  verified_date: "2026-07-14"
+  verification_method: "GROUP BY type COUNT on GRAPH <http://togovar.org/variant> (indexed); REST total from togovar_search_variant stat"
   by_class:
     SNV: 339076968
     Deletion: 29307469
     Insertion: 22340786
     MNV: 492
     Indel: 67
-    verified_date: "2026-07-12"
+    verified_date: "2026-07-14"
   coverage:
     vep_consequence: "~100% of variants (most_severe_consequence present)"
     vep_calculation: "sampling N=2000 SNV: all sampled had a most_severe_consequence"
@@ -489,6 +662,28 @@ anti_patterns:
       } LIMIT 20
     explanation: "Genes are identified by Ensembl (ENSG) and HGNC IRIs; use the IRI, which is canonical and indexed."
 
+  - title: "AlleleID/VariationID join-key collision (wrong ClinVar gene)"
+    problem: "Joining the annotation-layer VariationID to the embedded ClinVar graph on dcterms:identifier. In the embedded graph dcterms:identifier is the AlleleID; the numeric spaces overlap, so the join silently binds an unrelated record and returns the wrong gene."
+    wrong_sparql: |
+      # rs671 (VariationID 18390) -> AlleleID 18390 -> variation_id 3351 -> SRD5A2 (gene 6716). WRONG.
+      GRAPH <http://togovar.org/variant/annotation/clinvar> {
+        <...#111803962-G-A> dcterms:identifier ?vid . }
+      GRAPH <http://togovar.org/clinvar> {
+        ?cv dcterms:identifier ?vid ; med2rdf:gene ?gene . }   # string==string collision
+    correct_sparql: |
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT DISTINCT ?gene WHERE {
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          <http://identifiers.org/hco/12/GRCh38#111803962-G-A> dcterms:identifier ?variationId . }
+        BIND(xsd:integer(?variationId) AS ?vid)              # cast + BIND, not a FILTER
+        GRAPH <http://togovar.org/clinvar> {
+          ?cv cvo:variation_id ?vid ; med2rdf:gene ?gene . }  # -> ncbigene:217 (ALDH2). CORRECT.
+      } LIMIT 20
+    explanation: "clinvar:variation_id (xsd:integer) is the only correct join key from the annotation layer; dcterms:identifier in the embedded graph is the AlleleID. Bind the cast integer and use it as a triple object — a cross-GRAPH FILTER on variation_id returns 0 rows in Virtuoso."
+
   - title: "Unscoped Variant-Class COUNT (cross-graph re-typing inflation)"
     problem: "Counting a variant class without pinning the graph double-counts the 2.94M ClinVar-annotated variants re-typed in the clinvar annotation graph."
     wrong_sparql: |
@@ -501,57 +696,41 @@ anti_patterns:
       }
     explanation: "The same variant IRI is typed gvo:SNV in both the variant and clinvar annotation graphs; pin the core graph (or COUNT DISTINCT) for the true class size."
 
-  - title: "Querying Allele Frequency from SPARQL"
-    problem: "Expecting per-population allele frequencies (ToMMo, gnomAD, JGA...) in this endpoint; they are not here."
+  - title: "Per-transcript fan-out inflates variant counts"
+    problem: "Projecting tgvo:hgvsp / tgvo:transcript / tgvo:gene multiplies rows per variant — one row per transcript overlap on the hasConsequence bnode."
     wrong_sparql: |
-      # Returns 0 rows — no such predicate anywhere in the endpoint
-      ?variant tgvo:frequency ?f .
-    correct_sparql: |
-      # Frequencies come from the TogoVar REST API, not SPARQL. From SPARQL you can only
-      # obtain identity/annotation; fetch the variant IRI or rsID here, then call the REST API:
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      SELECT ?variant WHERE {
+      # e.g. ALDH2 111781979-C-T (p.Pro59Leu) returns 5 rows (ENSP/ENSP/NP/NP + 1 no-HGVSp)
+      SELECT ?variant ?hgvsp WHERE {
         GRAPH <http://togovar.org/variant/annotation/ensembl> {
-          ?variant rdfs:seeAlso <http://identifiers.org/dbsnp/rs671> .
-        }
-      } LIMIT 1
-    explanation: "This SPARQL endpoint holds variant identity, coordinates, VEP consequences and ClinVar/annotation only. Allele frequencies are served by the TogoVar REST API."
-
-  - title: "Normalized vs VCF Allele/Position Confusion"
-    problem: "Matching a VCF-style REF/ALT (with anchor base) against gvo:ref/gvo:alt, which are normalized and empty for pure indels."
-    wrong_sparql: |
-      # A VCF deletion "TTCAGG.../T" will never match the normalized alleles
-      ?v gvo:ref "TTCAGGAAGTCAGATGGTTAAGCGACTG" ; gvo:alt "T" .
+          ?variant tgvo:hasConsequence ?c . ?c tgvo:hgvsp ?hgvsp } }
     correct_sparql: |
-      PREFIX gvo: <http://genome-variation.org/resource#>
-      SELECT ?v WHERE {
-        GRAPH <http://togovar.org/variant> {
-          ?v gvo:ref_vcf "TTCAGGAAGTCAGATGGTTAAGCGACTG" ; gvo:alt_vcf "T" .   # VCF pair
-        }
-      } LIMIT 5
-    explanation: "gvo:ref/gvo:alt are VOA-normalized (trimmed, empty for pure indels); use the gvo:*_vcf pair to match VCF input, and gvo:pos_vcf for the VCF position."
+      PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+      SELECT (COUNT(DISTINCT ?variant) AS ?n) WHERE {
+        GRAPH <http://togovar.org/variant/annotation/ensembl> {
+          ?variant tgvo:hasConsequence ?c .
+          ?c tgvo:hgnc <http://identifiers.org/hgnc/404> }
+      }
+    explanation: "hasConsequence is a per-transcript bnode; count DISTINCT variants and use SELECT DISTINCT for listings when fanning out over consequences."
 
 common_errors:
   - error: "Empty results despite a valid-looking query"
     causes:
-      - "Predicate queried in the wrong graph (core vs ensembl-anno vs clinvar-anno)"
+      - "Predicate queried in the wrong graph (core vs ensembl-anno vs clinvar-anno vs embedded-clinvar)"
       - "Looking for allele frequency (not present in this endpoint)"
       - "Matching gvo:pos with a string, or matching normalized alleles against VCF alleles"
+      - "Cross-GRAPH FILTER(?vid = xsd:integer(?variationId)) instead of BIND-as-object join (returns 0 rows)"
       - "SIFT/PolyPhen prediction filter using '=' when values include *_low_confidence suffixes"
     solutions:
       - "Pin the GRAPH that owns the predicate (see shape_expressions graph comments)"
       - "Fetch frequencies from the TogoVar REST API, not SPARQL"
       - "Use integer literals for gvo:pos/faldo:position; use gvo:*_vcf for VCF alleles"
+      - "BIND(xsd:integer(?variationId) AS ?vid) and join `?cv clinvar:variation_id ?vid`"
       - "Use STRSTARTS(?pred, 'deleterious') / VALUES for prediction categories"
-  - error: "Query timeout"
+  - error: "Wrong gene / wrong record from a ClinVar join"
     causes:
-      - "COUNT(DISTINCT ?s) over an entire 390M-subject annotation graph"
-      - "Unbounded consequence/gene traversal without a specific gene or variant IRI"
-      - "Enumerating all named graphs or all predicates over the full store"
+      - "Joined the embedded ClinVar graph on dcterms:identifier (= AlleleID), whose numbers collide with VariationIDs"
     solutions:
-      - "Anchor on a specific gene/variant/dbSNP IRI and add LIMIT"
-      - "For class totals use the indexed class-count on GRAPH <http://togovar.org/variant>"
-      - "Avoid SELECT DISTINCT ?g / DISTINCT ?p sweeps over the union graph"
+      - "Join on clinvar:variation_id (xsd:integer); dcterms:identifier in that graph is the AlleleID"
   - error: "Counts larger than expected"
     causes:
       - "Cross-graph re-typing: ClinVar-annotated variants counted in both variant and clinvar graphs"

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -178,31 +178,42 @@ _IRI_ALLELE_MAX = 50
 # `truncated` note is added so the payload stays inline-readable.
 _MAX_RESPONSE_CHARS = 90_000
 
-# Per-facet scope of the `stat=True` statistics block. The TogoVar API applies
-# the query filters INCONSISTENTLY across facets — verified live: `type`/
-# `dataset` are scoped to the filtered set, but `consequence` is returned
-# whole-database (its counts are orders of magnitude larger than `filtered` and
-# barely move when the filter changes), and `significance` is faceted (it
-# excludes its own significance filter and counts per variant-condition). This
-# is a backend behavior a REST proxy cannot re-scope, so we ship the caveats
-# alongside the raw numbers to stop callers from summing them against
-# `filtered`. Attached to the response as `statistics_caveats`.
+# Per-facet counting granularity of the `stat=True` statistics block. ALL four
+# facets ARE scoped to the filtered set (verified live: each responds to the
+# gene/disease/consequence/location filters), but they count at DIFFERENT
+# granularities, so only `type` sums to `filtered`:
+#   - `type`/`dataset` count per variant.
+#   - `consequence` counts per variant-TRANSCRIPT (VEP fan-out): its sum is
+#     `filtered` x mean transcripts/variant, a locus-dependent multiple — ~5-6
+#     for a typical gene (e.g. ALDH2) but 400+ in transcript-dense regions
+#     (e.g. the BRCA1 locus, where one variant has ~460 transcript annotations).
+#   - `significance` counts per variant-CONDITION classification record (a
+#     variant classified under several conditions counts once each).
+# So consequence/significance sums legitimately exceed `filtered` and must NOT
+# be compared to it — but they are not "unscoped" and not whole-database. We
+# ship these caveats alongside the raw numbers as `statistics_caveats`.
 _STATISTICS_CAVEATS = {
-    "type": "Scoped to the filtered set (per-value counts sum to `filtered`).",
+    "type": (
+        "Per-variant count, scoped to the filtered set (values sum to `filtered`)."
+    ),
     "dataset": (
-        "Scoped to the filtered set; a variant present in N datasets is counted "
-        "N times, so the sum may exceed `filtered` while each value is <= it."
+        "Per-variant count scoped to the filtered set; a variant present in N "
+        "cohorts is counted N times, so the sum may exceed `filtered` while each "
+        "value is <= it."
     ),
     "consequence": (
-        "NOT scoped — the TogoVar API returns the WHOLE-DATABASE consequence "
-        "distribution regardless of filters. Do NOT sum against `filtered` or "
-        "read these as counts for the filtered set."
+        "Scoped to the filtered set but counted PER VARIANT-TRANSCRIPT (VEP "
+        "consequence fan-out), so the sum = `filtered` x mean transcripts per "
+        "variant — a locus-dependent multiple (~5-6 for a typical gene, 400+ in "
+        "transcript-dense regions like BRCA1). Read each value as 'annotation "
+        "records with this consequence', NOT 'variants'; do NOT compare the sum "
+        "to `filtered`."
     ),
     "significance": (
-        "Faceted, NOT a filtered count: reflects the gene/disease-filtered set "
-        "MINUS the significance filter itself, counted per variant-condition (a "
-        "variant may recur under several conditions). May exceed `filtered`; do "
-        "NOT sum against it."
+        "Scoped to the filtered set but counted PER VARIANT-CONDITION "
+        "classification record (a variant classified under several conditions "
+        "counts once each), so the sum can exceed `filtered`. Do NOT compare the "
+        "sum to `filtered`."
     ),
 }
 
@@ -586,10 +597,12 @@ async def search_disease(
 
     COVERAGE LIMIT: TogoVar only indexes diseases that have ClinVar/MGeND
     variant associations, so some canonical/parent MONDO terms are simply absent
-    here (e.g. MONDO_0007254 "breast cancer" is a valid `disease_id` for
-    `search_variant`, returning ~24,550 variants, yet does NOT appear in these
-    results). If you already know the MONDO ID, pass it straight to
-    `search_variant`; do not assume this resolver is exhaustive.
+    here (e.g. MONDO_0007254 "breast cancer" does NOT appear in these results).
+    But a broad/parent MONDO ID still WORKS as a `disease_id` in `search_variant`
+    even when unlisted here — the variant search resolves it via MONDO descendant
+    expansion (MONDO_0007254 -> ~24,550 variants). So if you know or can resolve
+    the canonical MONDO ID (e.g. via OLS4 or the `mondo` RDF database), pass it
+    straight to `search_variant`; do not assume this resolver is exhaustive.
 
     Args:
         query (str): Disease name (e.g. "breast cancer", "Marfan syndrome").
@@ -662,11 +675,14 @@ async def search_variant(
     SPARQL side is the annotated subset), so REST counts will not match SPARQL
     `COUNT(*)` — they measure different sets.
 
-    STATISTICS SCOPE (stat=True): only the `type` and `dataset` facets are
-    scoped to the filtered set. `consequence` is returned whole-database by the
-    API (ignores your filters) and `significance` is a facet excluding its own
-    filter — do NOT sum either against `filtered`. See `statistics_caveats` in
-    the response for the per-facet rule.
+    STATISTICS SCOPE (stat=True): all facets are scoped to the filtered set, but
+    they count at different granularities. `type` counts per variant (sums to
+    `filtered`); `dataset` per variant-cohort; `consequence` per
+    variant-TRANSCRIPT (VEP fan-out, so its sum is `filtered` x transcripts per
+    variant — ~5-6 for a typical gene, 400+ in transcript-dense loci like
+    BRCA1); `significance` per variant-condition record. So consequence/
+    significance sums exceed `filtered` and must NOT be summed against it (they
+    are not per-variant counts). See `statistics_caveats` for the per-facet rule.
 
     ROUND-TRIP TO SPARQL: each row carries `tgv_id` and `variant_iri`; either
     resolves in the `togovar` SPARQL graph for VEP/cross-reference deep dives.

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -75,6 +75,200 @@ _FREQUENCY_DATASET_BASES = frozenset([
     "bbj_riken",
 ])
 
+# --------------------------------------------------------------------------- #
+# Code -> human-readable label maps (the API returns opaque codes; agents and
+# users need the labels). Both maps are the authoritative TogoVar vocabularies:
+#   - significance: TogoVar advanced_search_conditions.json (clinvar bucket, a
+#     superset of the mgend bucket).
+#   - SO terms (variant `type` and VEP `most_severe_consequence`): resolved
+#     against the Sequence Ontology (accession -> term name).
+# Codes not in a map fall through unchanged, so an unknown value is never lost.
+# --------------------------------------------------------------------------- #
+_SIGNIFICANCE_LABELS = {
+    "NC": "Not in ClinVar",
+    "P": "Pathogenic",
+    "LP": "Likely pathogenic",
+    "PLP": "Pathogenic, low penetrance",
+    "LPLP": "Likely pathogenic, low penetrance",
+    "ERA": "Established risk allele",
+    "LRA": "Likely risk allele",
+    "URA": "Uncertain risk allele",
+    "US": "Uncertain significance",
+    "LB": "Likely benign",
+    "B": "Benign",
+    "CI": "Conflicting interpretations of pathogenicity",
+    "DR": "Drug response",
+    "CS": "Confers sensitivity",
+    "RF": "Risk factor",
+    "A": "Association",
+    "PR": "Protective",
+    "AF": "Affects",
+    "O": "Other",
+    "NP": "Not provided",
+    "AN": "Association not found",
+}
+
+_SO_LABELS = {
+    # variant types (the `type` field)
+    "SO_0001483": "SNV",
+    "SO_0002007": "MNV",
+    "SO_0000159": "deletion",
+    "SO_0000667": "insertion",
+    "SO_1000002": "substitution",
+    "SO_1000032": "delins",
+    "SO_0002173": "indel",
+    "SO_0001019": "copy_number_variation",
+    "SO_0001060": "sequence_variant",
+    # VEP consequence terms (the `most_severe_consequence` field)
+    "SO_0001580": "coding_sequence_variant",
+    "SO_0001907": "feature_elongation",
+    "SO_0001906": "feature_truncation",
+    "SO_0001589": "frameshift_variant",
+    "SO_0001626": "incomplete_terminal_codon_variant",
+    "SO_0001822": "inframe_deletion",
+    "SO_0001821": "inframe_insertion",
+    "SO_0001583": "missense_variant",
+    "SO_0001621": "NMD_transcript_variant",
+    "SO_0001818": "protein_altering_variant",
+    "SO_0001819": "synonymous_variant",
+    "SO_0002012": "start_lost",
+    "SO_0001587": "stop_gained",
+    "SO_0001578": "stop_lost",
+    "SO_0002019": "start_retained_variant",
+    "SO_0001567": "stop_retained_variant",
+    "SO_0001624": "3_prime_UTR_variant",
+    "SO_0001623": "5_prime_UTR_variant",
+    "SO_0001627": "intron_variant",
+    "SO_0001792": "non_coding_transcript_exon_variant",
+    "SO_0001619": "non_coding_transcript_variant",
+    "SO_0001574": "splice_acceptor_variant",
+    "SO_0001575": "splice_donor_variant",
+    "SO_0001630": "splice_region_variant",
+    "SO_0001787": "splice_donor_5th_base_variant",
+    "SO_0002170": "splice_donor_region_variant",
+    "SO_0002169": "splice_polypyrimidine_tract_variant",
+    "SO_0001893": "transcript_ablation",
+    "SO_0001889": "transcript_amplification",
+    "SO_0001620": "mature_miRNA_variant",
+    "SO_0001894": "regulatory_region_ablation",
+    "SO_0001891": "regulatory_region_amplification",
+    "SO_0001566": "regulatory_region_variant",
+    "SO_0001782": "TF_binding_site_variant",
+    "SO_0001895": "TFBS_ablation",
+    "SO_0001892": "TFBS_amplification",
+    "SO_0001632": "downstream_gene_variant",
+    "SO_0001628": "intergenic_variant",
+    "SO_0001631": "upstream_gene_variant",
+}
+
+# Allele-rendering bounds (T1: large structural variants carry multi-kb REF/ALT
+# that otherwise blow past the client token budget).
+#   - Alleles longer than _ALLELE_INLINE_MAX are summarized in the `reference`/
+#     `alternate` fields (unless include_full_alleles=True); the true lengths
+#     are always reported as `ref_length`/`alt_length`.
+#   - The compact `variant` label truncates each allele past _ALLELE_HEAD so the
+#     locus string stays bounded (SNVs like "12:111766887:A>T" are unaffected).
+#   - The reconstructed variant IRI embeds the full allele, so it is omitted for
+#     alleles over _IRI_ALLELE_MAX (a multi-kb SV would reintroduce the bloat);
+#     `tgv_id` is always emitted as the compact SPARQL round-trip key instead.
+_ALLELE_INLINE_MAX = 50
+_ALLELE_HEAD = 20
+_IRI_ALLELE_MAX = 50
+# Soft cap on the serialized response; above it, data rows are trimmed and a
+# `truncated` note is added so the payload stays inline-readable.
+_MAX_RESPONSE_CHARS = 90_000
+
+# Per-facet scope of the `stat=True` statistics block. The TogoVar API applies
+# the query filters INCONSISTENTLY across facets — verified live: `type`/
+# `dataset` are scoped to the filtered set, but `consequence` is returned
+# whole-database (its counts are orders of magnitude larger than `filtered` and
+# barely move when the filter changes), and `significance` is faceted (it
+# excludes its own significance filter and counts per variant-condition). This
+# is a backend behavior a REST proxy cannot re-scope, so we ship the caveats
+# alongside the raw numbers to stop callers from summing them against
+# `filtered`. Attached to the response as `statistics_caveats`.
+_STATISTICS_CAVEATS = {
+    "type": "Scoped to the filtered set (per-value counts sum to `filtered`).",
+    "dataset": (
+        "Scoped to the filtered set; a variant present in N datasets is counted "
+        "N times, so the sum may exceed `filtered` while each value is <= it."
+    ),
+    "consequence": (
+        "NOT scoped — the TogoVar API returns the WHOLE-DATABASE consequence "
+        "distribution regardless of filters. Do NOT sum against `filtered` or "
+        "read these as counts for the filtered set."
+    ),
+    "significance": (
+        "Faceted, NOT a filtered count: reflects the gene/disease-filtered set "
+        "MINUS the significance filter itself, counted per variant-condition (a "
+        "variant may recur under several conditions). May exceed `filtered`; do "
+        "NOT sum against it."
+    ),
+}
+
+
+def _summarize_allele(seq: str | None, include_full: bool) -> str | None:
+    """Return an allele string bounded for display, or the full seq if asked.
+
+    Sequences over _ALLELE_INLINE_MAX collapse to "<head>…(<n> bp)" unless
+    include_full is True. None passes through.
+    """
+    if seq is None:
+        return None
+    if include_full or len(seq) <= _ALLELE_INLINE_MAX:
+        return seq
+    return f"{seq[:_ALLELE_HEAD]}…({len(seq)} bp)"
+
+
+def _compact_allele(seq: Any) -> str:
+    """Render one allele for the bounded `variant` locus label."""
+    if not seq:
+        return str(seq)
+    if len(seq) <= _ALLELE_HEAD:
+        return seq
+    return f"{seq[:8]}…{len(seq)}bp"
+
+
+def _variant_iri(
+    chromosome: Any, position: Any, reference: Any, alternate: Any
+) -> str | None:
+    """Reconstruct the TogoVar/HCO variant IRI for a SPARQL round-trip.
+
+    Returns None when coordinates are incomplete or when either allele exceeds
+    _IRI_ALLELE_MAX (embedding a multi-kb SV allele would reintroduce the bloat
+    T1 fixes — callers use `tgv_id` for those).
+    """
+    if not (chromosome and position and reference and alternate):
+        return None
+    if len(reference) > _IRI_ALLELE_MAX or len(alternate) > _IRI_ALLELE_MAX:
+        return None
+    return (
+        f"http://identifiers.org/hco/{chromosome}/GRCh38#"
+        f"{position}-{reference}-{alternate}"
+    )
+
+
+def _match_type(candidate: str | None, query: str) -> tuple[str, int]:
+    """Classify how `candidate` matches `query` and give a sort rank.
+
+    Returns ("exact"|"prefix"|"word"|"fuzzy", rank) — lower rank sorts first.
+    The TogoVar search endpoints do loose token matching with no relevance
+    order, so both resolver tools re-rank client-side: exact hits first, then
+    prefix, then whole-word, then everything else (demoting unrelated
+    token-only matches like "Hepatic fibrosis…" for "cystic fibrosis").
+    """
+    c = (candidate or "").strip().lower()
+    q = query.strip().lower()
+    if not c:
+        return "fuzzy", 3
+    if c == q:
+        return "exact", 0
+    if c.startswith(q):
+        return "prefix", 1
+    if q in c.split():
+        return "word", 2
+    return "fuzzy", 3
+
 
 def _as_list(value: str | list[str]) -> list[str]:
     """Coerce a str-or-list argument to a clean list[str]."""
@@ -241,13 +435,24 @@ def _build_variant_query(
     return {"and": clauses}
 
 
-def _project_variant(row: dict[str, Any]) -> dict[str, Any]:
+def _project_variant(
+    row: dict[str, Any], include_full_alleles: bool = False
+) -> dict[str, Any]:
     """Flatten a /search/variant data row into the fields agents actually use.
 
-    The list endpoint does not echo a tgv ID; cross-database identifiers live
-    under `external_link` (dbsnp -> rs, clinvar -> VCV), which we surface as
-    `rs`/`clinvar` for TogoID/ClinVar interoperability. Per-dataset frequencies
-    are reshaped into a `{source: {af, ac, an}}` map.
+    `tgv_id` (the row's `id`) and the reconstructed `variant_iri` are the two
+    stable keys for a SPARQL round-trip (frequency/significance via REST here ->
+    VEP/cross-references via SPARQL). Cross-database identifiers live under
+    `external_link` (dbsnp -> rs, clinvar -> VCV), surfaced as `rs`/`clinvar`.
+    Per-dataset frequencies are reshaped into a `{source: {af, ac, an}}` map.
+
+    Opaque codes are given human-readable companions: `type_label`,
+    `most_severe_consequence_label`, and `interpretation_labels` on each
+    significance entry (the raw codes are kept for backward compatibility).
+
+    Large structural variants carry multi-kb REF/ALT; the `variant` label is
+    length-bounded and `reference`/`alternate` are summarized (with true
+    `ref_length`/`alt_length`) unless include_full_alleles=True.
     """
     ext = row.get("external_link") or {}
 
@@ -262,29 +467,42 @@ def _project_variant(row: dict[str, Any]) -> dict[str, Any]:
         if src:
             freqs[src] = {"af": f.get("af"), "ac": f.get("ac"), "an": f.get("an")}
 
-    significance = [
-        {
+    significance = []
+    for s in row.get("significance") or []:
+        interps = s.get("interpretations") or []
+        significance.append({
             "source": s.get("source"),
-            "interpretations": s.get("interpretations"),
+            "interpretations": interps,
+            "interpretation_labels": [
+                _SIGNIFICANCE_LABELS.get(i, i) for i in interps
+            ],
             "conditions": [c.get("name") for c in s.get("conditions", [])],
-        }
-        for s in row.get("significance") or []
-    ]
+        })
+
+    chrom = row.get("chromosome")
+    pos = row.get("position")
+    ref = row.get("reference")
+    alt = row.get("alternate")
+    vtype = row.get("type")
+    msc = row.get("most_severe_consequence")
 
     return {
-        "variant": (
-            f"{row.get('chromosome')}:{row.get('position')}:"
-            f"{row.get('reference')}>{row.get('alternate')}"
-        ),
-        "type": row.get("type"),
-        "chromosome": row.get("chromosome"),
-        "position": row.get("position"),
-        "reference": row.get("reference"),
-        "alternate": row.get("alternate"),
+        "tgv_id": row.get("id"),
+        "variant": f"{chrom}:{pos}:{_compact_allele(ref)}>{_compact_allele(alt)}",
+        "variant_iri": _variant_iri(chrom, pos, ref, alt),
+        "type": vtype,
+        "type_label": _SO_LABELS.get(vtype) if vtype else None,
+        "chromosome": chrom,
+        "position": pos,
+        "reference": _summarize_allele(ref, include_full_alleles),
+        "alternate": _summarize_allele(alt, include_full_alleles),
+        "ref_length": len(ref) if isinstance(ref, str) else None,
+        "alt_length": len(alt) if isinstance(alt, str) else None,
         "genes": symbols,
         "rs": _titles("dbsnp"),
         "clinvar": _titles("clinvar"),
-        "most_severe_consequence": row.get("most_severe_consequence"),
+        "most_severe_consequence": msc,
+        "most_severe_consequence_label": _SO_LABELS.get(msc) if msc else None,
         "sift": row.get("sift"),
         "polyphen": row.get("polyphen"),
         "alphamissense": row.get("alphamissense"),
@@ -296,19 +514,32 @@ def _project_variant(row: dict[str, Any]) -> dict[str, Any]:
 @togovar_mcp.tool()
 async def search_gene(
     query: Annotated[str, Field(description="Gene symbol or alias, e.g. 'ALDH2'.")] = "",
+    limit: Annotated[int, Field(ge=1, le=100)] = 10,
 ) -> str:
     """Resolve a human gene symbol/alias to its HGNC ID for variant search.
 
     This is the FIRST step of the two-step variant workflow: the `hgnc_id`
     returned here is what `search_variant` takes as `gene_hgnc_id`.
 
+    The TogoVar endpoint does loose token matching with no relevance order (it
+    returns the same set for "ALDH2" and the non-existent "ALDH2A1"), so this
+    tool RE-RANKS client-side: exact symbol match first, then prefix, then other
+    matches. Each result carries `match_type` ("exact"|"prefix"|"word"|"fuzzy")
+    against your query — CHECK IT: if the top hit is not `exact`, the exact
+    symbol you asked for does not exist and the rows are loose false positives,
+    so do not blindly feed the first `hgnc_id` downstream. (The endpoint echoes
+    the matched token as `symbol` and the HGNC approved gene name as `name`; it
+    does not expose approved-vs-alias status, so use `name` to sanity-check.)
+
     Args:
         query (str): Gene symbol or alias (e.g. "ALDH2", "BRCA2").
+        limit (int): Max matches to return, in [1, 100]. Default 10.
 
     Returns:
         str: JSON array (bare list) of matches, each
-        `{"hgnc_id": int, "symbol": str, "name": str}`, best match first.
-        Empty and non-empty results share the same `[...]` shape.
+        `{"hgnc_id": int, "symbol": str, "name": str, "match_type": str}`,
+        best match first. Empty and non-empty results share the same `[...]`
+        shape.
 
     Raises:
         ValueError: If `query` is blank, or on any HTTP/upstream error.
@@ -318,10 +549,18 @@ async def search_gene(
     response = await _client.get("/search/gene", params={"term": query.strip()})
     raise_for_status_with_body(response, context="TogoVar gene search")
     hits = response.json()
-    results = [
-        {"hgnc_id": h.get("id"), "symbol": h.get("symbol"), "name": h.get("name")}
-        for h in hits
-    ]
+    ranked = []
+    for h in hits:
+        kind, rank = _match_type(h.get("symbol"), query)
+        ranked.append((rank, {
+            "hgnc_id": h.get("id"),
+            "symbol": h.get("symbol"),
+            "name": h.get("name"),
+            "match_type": kind,
+        }))
+    # Stable sort preserves the endpoint's within-rank order.
+    ranked.sort(key=lambda t: t[0])
+    results = [r for _, r in ranked[:limit]]
     return json.dumps(results)
 
 
@@ -330,6 +569,7 @@ async def search_disease(
     query: Annotated[
         str, Field(description="Disease term, e.g. 'breast cancer'.")
     ] = "",
+    limit: Annotated[int, Field(ge=1, le=100)] = 10,
 ) -> str:
     """Resolve a disease term to MONDO / MedGen IDs for variant search.
 
@@ -337,12 +577,28 @@ async def search_disease(
     `disease_id`. Both land directly on TogoMCP's existing mondo/medgen RDF
     databases and TogoID nodes.
 
+    The TogoVar endpoint does loose token matching with no relevance order (a
+    query like "cystic fibrosis" also returns unrelated "Hepatic fibrosis…"
+    rows), so this tool RE-RANKS client-side: exact label match first, then
+    prefix, then whole-word, then loose token matches last. Each result carries
+    `match_type` ("exact"|"prefix"|"word"|"fuzzy") — a top hit that is not
+    `exact` means no exact label matched.
+
+    COVERAGE LIMIT: TogoVar only indexes diseases that have ClinVar/MGeND
+    variant associations, so some canonical/parent MONDO terms are simply absent
+    here (e.g. MONDO_0007254 "breast cancer" is a valid `disease_id` for
+    `search_variant`, returning ~24,550 variants, yet does NOT appear in these
+    results). If you already know the MONDO ID, pass it straight to
+    `search_variant`; do not assume this resolver is exhaustive.
+
     Args:
         query (str): Disease name (e.g. "breast cancer", "Marfan syndrome").
+        limit (int): Max matches to return, in [1, 100]. Default 10.
 
     Returns:
-        str: JSON array (bare list) of matches, each
-        `{"mondo_id": str, "medgen_cui": str | None, "label": str}`.
+        str: JSON array (bare list) of matches, each `{"mondo_id": str,
+        "medgen_cui": str | None, "label": str, "match_type": str}`, best match
+        first.
 
     Raises:
         ValueError: If `query` is blank, or on any HTTP/upstream error.
@@ -354,10 +610,17 @@ async def search_disease(
     response = await _client.get("/search/disease", params={"term": query.strip()})
     raise_for_status_with_body(response, context="TogoVar disease search")
     hits = response.json()
-    results = [
-        {"mondo_id": h.get("id"), "medgen_cui": h.get("cui"), "label": h.get("label")}
-        for h in hits
-    ]
+    ranked = []
+    for h in hits:
+        kind, rank = _match_type(h.get("label"), query)
+        ranked.append((rank, {
+            "mondo_id": h.get("id"),
+            "medgen_cui": h.get("cui"),
+            "label": h.get("label"),
+            "match_type": kind,
+        }))
+    ranked.sort(key=lambda t: t[0])
+    results = [r for _, r in ranked[:limit]]
     return json.dumps(results)
 
 
@@ -381,6 +644,7 @@ async def search_variant(
     limit: Annotated[int, Field(ge=0, le=1000)] = 100,
     offset: Annotated[int, Field(ge=0)] = 0,
     stat: bool = False,
+    include_full_alleles: bool = False,
 ) -> str:
     """Search TogoVar for human genome variants with population frequencies.
 
@@ -391,6 +655,21 @@ async def search_variant(
 
     All filters are optional and combined with AND. Supply zero filters to
     browse; but scope tightly — the database holds ~1 billion variants.
+
+    COUNTS: `total` is the size of the whole REST backend (~1.1 billion) and is
+    constant across queries; `filtered` is the count matching your filters. Note
+    the REST backend is LARGER than TogoMCP's `togovar` SPARQL graph (~3.9x: the
+    SPARQL side is the annotated subset), so REST counts will not match SPARQL
+    `COUNT(*)` — they measure different sets.
+
+    STATISTICS SCOPE (stat=True): only the `type` and `dataset` facets are
+    scoped to the filtered set. `consequence` is returned whole-database by the
+    API (ignores your filters) and `significance` is a facet excluding its own
+    filter — do NOT sum either against `filtered`. See `statistics_caveats` in
+    the response for the per-facet rule.
+
+    ROUND-TRIP TO SPARQL: each row carries `tgv_id` and `variant_iri`; either
+    resolves in the `togovar` SPARQL graph for VEP/cross-reference deep dives.
 
     TWO-STEP WORKFLOW for gene/disease filters:
         1. `search_gene("ALDH2")` -> hgnc_id -> pass as `gene_hgnc_id`.
@@ -424,15 +703,36 @@ async def search_variant(
             significance). REQUIRED to get a count — e.g. "how many variants
             match". Left False by default because computing the aggregation is
             the slow part of the query; use stat=False when you only need rows.
+            See STATISTICS SCOPE above — the facets are not uniformly filtered.
+        include_full_alleles: If True, return full REF/ALT sequences even for
+            large structural variants. Default False summarizes alleles over
+            ~50 bp as "<head>…(<n> bp)" to keep the response inline-readable;
+            `ref_length`/`alt_length` always give the true lengths.
 
     Returns:
-        str: JSON string `{"data": [...], "total"?, "filtered"?, "statistics"?}`.
-        Each data row carries `variant` (chr:pos:ref>alt), coordinates, genes,
-        `rs` (dbSNP) and `clinvar` (VCV) cross-links, most-severe consequence,
-        SIFT/PolyPhen/AlphaMissense scores, clinical `significance`, and a
-        `frequencies` map keyed by dataset ({af, ac, an}). `total`/`filtered`/
-        `statistics` are present ONLY when `stat=True`. (The list endpoint does
-        not return a tgv ID; use `rs`/`clinvar` for cross-database linking.)
+        str: JSON string
+        `{"data": [...], "total"?, "filtered"?, "statistics"?,
+          "statistics_caveats"?, "truncated"?}`.
+        Each data row carries `tgv_id`, `variant` (a length-bounded
+        chr:pos:ref>alt locus label), `variant_iri` (for SPARQL round-trip;
+        null for very long alleles), coordinates, `reference`/`alternate`
+        (summarized unless include_full_alleles) with `ref_length`/`alt_length`,
+        `type`(+`type_label`), genes, `rs` (dbSNP) and `clinvar` (VCV)
+        cross-links, `most_severe_consequence`(+`_label`),
+        SIFT/PolyPhen/AlphaMissense scores, clinical `significance` (each with
+        `interpretations` codes + `interpretation_labels`), and a `frequencies`
+        map keyed by dataset ({af, ac, an}). `total`/`filtered`/`statistics`/
+        `statistics_caveats` are present ONLY when `stat=True`. `truncated` is
+        present (and data rows trimmed) only if the response would be oversized.
+
+        Clinical-significance codes (in `interpretations`): P=Pathogenic,
+        LP=Likely pathogenic, PLP=Pathogenic low-penetrance, LPLP=Likely
+        pathogenic low-penetrance, US=Uncertain significance, LB=Likely benign,
+        B=Benign, CI=Conflicting interpretations, DR=Drug response, RF=Risk
+        factor, PR=Protective, A=Association, AF=Affects, CS=Confers sensitivity,
+        ERA/LRA/URA=Established/Likely/Uncertain risk allele, O=Other, NP=Not
+        provided, AN=Association not found, NC=Not in ClinVar. `_label` fields
+        carry these spelled out.
 
     Raises:
         ValueError: On invalid enum/coordinate inputs, or any HTTP/upstream error.
@@ -467,7 +767,10 @@ async def search_variant(
     payload = response.json()
 
     result: dict[str, Any] = {
-        "data": [_project_variant(row) for row in payload.get("data", [])],
+        "data": [
+            _project_variant(row, include_full_alleles)
+            for row in payload.get("data", [])
+        ],
     }
     # Match counts and the category breakdown come from the statistics block,
     # which the API only computes (and it is the expensive part) when stat=1.
@@ -477,4 +780,25 @@ async def search_variant(
         result["total"] = stats.get("total")
         result["filtered"] = stats.get("filtered")
         result["statistics"] = stats
-    return json.dumps(result)
+        # The API filters facets inconsistently (consequence is whole-database,
+        # significance is a self-excluding facet); ship the scope rules so the
+        # numbers are not misread. Only annotate facets actually present.
+        result["statistics_caveats"] = {
+            k: v for k, v in _STATISTICS_CAVEATS.items() if k in stats
+        }
+
+    # Safety valve: even with alleles summarized, a wide + stat response can be
+    # large. If it overflows the soft cap, drop data rows (keeping any stats)
+    # until it fits, and flag the truncation rather than silently returning it.
+    out = json.dumps(result)
+    if len(out) > _MAX_RESPONSE_CHARS and result["data"]:
+        while result["data"] and len(out) > _MAX_RESPONSE_CHARS:
+            drop = max(1, len(result["data"]) // 4)
+            del result["data"][-drop:]
+            result["truncated"] = {
+                "reason": "response exceeded size cap; data rows trimmed",
+                "returned_rows": len(result["data"]),
+                "hint": "narrow filters or lower `limit` to see all rows.",
+            }
+            out = json.dumps(result)
+    return out

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release v1.4.0

### TogoVar REST tools (`togo_mcp/togovar.py`)
Fixes T1–T8 from the `togovar_search_*` task, all verified live:

- **T1** — bound large-SV output: `variant` label is length-capped, REF/ALT over ~50 bp summarized (`ref_length`/`alt_length` always given), new `include_full_alleles` opt-in, response-size safety valve. BRCA1-pathogenic repro drops 54,325 → ~5,600 chars.
- **T2** — `statistics_caveats` documenting per-facet counting. (Investigation showed the facets ARE scoped — consequence counts per variant-transcript, significance per variant-condition — so the earlier "whole-DB" framing was corrected, not a code bug.)
- **T3/T4/T8** — client-side exact-first re-ranking + `match_type` + `limit` on `search_gene`/`search_disease`.
- **T5** — human-readable labels (`type_label`, `most_severe_consequence_label`, `interpretation_labels`) from authoritative TogoVar/SO vocabularies.
- **T6** — `tgv_id` + reconstructed `variant_iri` per row for a direct REST→SPARQL handoff (both verified to resolve in the `togovar` graph).
- **T7** — docstring notes REST (~1.1B) vs SPARQL (~3.9× smaller subset) count divergence.

### MIE (`data/mie/togovar.yaml` → v1.2)
- Corrected the stat-facet scope note (was "NOT scoped"; now per-record counting, consistent with the file's own fan-out docs).
- REST note updated for tgv_id/variant_iri + allele summarization.
- Significance legend adopts TogoVar's authoritative mapping (fixes `PLP`, confirms `LPLP`/`NC`/`AN`/`CS`, drops `unconfirmed_codes`).

### Versioning
- **MINOR** 1.3.1 → 1.4.0: all tool changes are additive (new optional params + return fields); existing calls unaffected. `uv.lock` synced.

Full suite: 215 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)