### PR TITLE
v1.5.0 — TogoVar REST projection: per-transcript VEP, genotype/QC counts, variant_iri gating (+ MIE v1.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "1.4.0"
+version = "1.5.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_togovar.py
+++ b/tests/test_togovar.py
@@ -16,6 +16,7 @@ from togo_mcp.togovar import (
     _build_variant_query,
     _compact_allele,
     _match_type,
+    _label_facets,
     _project_variant,
     _range_from_bounds,
     _summarize_allele,
@@ -181,8 +182,20 @@ def test_project_variant():
     assert p["genes"] == ["ALDH2"]
     assert p["rs"] == ["rs671"]
     assert p["clinvar"] == ["VCV000018390"]
-    assert p["frequencies"]["tommo"] == {"af": 0.21, "ac": 52, "an": 250}
-    assert p["significance"][0]["conditions"] == ["Alcohol sensitivity"]
+    assert p["frequencies"]["tommo"] == {
+        "af": 0.21,
+        "ac": 52,
+        "an": 250,
+        "filter": None,  # C3: QC status is always surfaced; None = not reported
+    }
+    # C4: conditions keep the MedGen CUI, not just the display name
+    assert p["significance"][0]["conditions"] == [
+        {"name": "Alcohol sensitivity", "medgen": "C123"}
+    ]
+    # C5: no tgv_id on this row -> the variant is not in the SPARQL subset, so no
+    # IRI is emitted (it would resolve to nothing).
+    assert p["tgv_id"] is None
+    assert p["variant_iri"] is None
 
 
 # --------------------------------------------------------------------------- #
@@ -222,6 +235,135 @@ def test_project_variant_unknown_code_falls_through():
     assert p["most_severe_consequence_label"] is None
     # unknown significance code passes through unchanged, never dropped
     assert p["significance"][0]["interpretation_labels"] == ["ZZ"]
+
+
+# --------------------------------------------------------------------------- #
+# C2-C5, C7 — stop discarding data the REST backend already returns
+# --------------------------------------------------------------------------- #
+def test_variant_iri_gated_on_tgv_id():
+    """C5: variant_iri is a constructed coordinate IRI, so it must NOT be emitted
+    for a variant absent from the SPARQL subset (tgv_id is null there) — the IRI
+    would resolve to zero rows. Real case: ClinVar-Pathogenic CFTR 7:117480132-C-T.
+    """
+    absent = {"id": None, "chromosome": "7", "position": 117480132,
+              "reference": "C", "alternate": "T"}
+    present = {"id": "tgv207092446", "chromosome": "7", "position": 117480108,
+               "reference": "C", "alternate": "T"}
+
+    assert _project_variant(absent)["variant_iri"] is None
+    assert (
+        _project_variant(present)["variant_iri"]
+        == "http://identifiers.org/hco/7/GRCh38#117480108-C-T"
+    )
+
+
+def test_project_variant_transcripts_are_opt_in():
+    """C2: per-transcript VEP is carried by REST but kept out of the default
+    payload (a BRCA1-locus variant has 400+ transcript annotations).
+    """
+    row = {
+        "id": "tgv47264307",
+        "transcripts": [
+            {
+                "transcript_id": "ENST00000261733",
+                "gene_id": "ENSG00000111275",
+                "hgnc_id": 404,
+                "consequence": ["SO_0001583"],
+                "hgvs_c": "ENST00000261733.7:c.1510G>A",
+                "hgvs_p": "ENSP00000261733.2:p.Glu504Lys",
+                "hgvs_g": "NC_000012.12:g.111803962G>A",
+                "sift": 0.0,
+                "polyphen": 0.709,
+                "alphamissense": 0.8864,
+            }
+        ],
+    }
+    assert "transcripts" not in _project_variant(row)
+
+    t = _project_variant(row, include_transcripts=True)["transcripts"][0]
+    assert t["transcript_id"] == "ENST00000261733"
+    assert t["hgvs_p"] == "ENSP00000261733.2:p.Glu504Lys"
+    assert t["consequence_labels"] == ["missense_variant"]  # SO code gets a label
+    assert t["alphamissense"] == 0.8864  # per-transcript prediction, not the row's
+
+
+def test_frequencies_keep_qc_filter_and_genotype_counts():
+    """C3: genotype counts are PER-SOURCE, not universal — copy each key only when
+    the panel actually has it (verified live on rs671).
+    """
+    row = {
+        "id": "tgv47264307",
+        "frequencies": [
+            # full genotype set + quality
+            {"source": "jga_wgs", "af": 0.2, "ac": 4, "an": 20, "filter": ["PASS"],
+             "aac": 1, "arc": 2, "rrc": 7, "hac": 3, "hoc": 4},
+            # het/hom only, no hemizygous, no quality
+            {"source": "jga_snp", "af": 0.24, "ac": 9, "an": 40, "filter": ["PASS"],
+             "aac": 11778, "arc": 66470, "rrc": 104717},
+            # no genotype counts at all, but has quality
+            {"source": "tommo", "af": 0.192, "ac": 20904, "an": 108604,
+             "filter": ["PASS"], "quality": 8700090.0},
+        ],
+    }
+    f = _project_variant(row)["frequencies"]
+
+    assert f["jga_wgs"]["hac"] == 3 and f["jga_wgs"]["rrc"] == 7
+    assert f["jga_snp"]["arc"] == 66470
+    assert "hac" not in f["jga_snp"]  # absent key is not invented as None
+    assert f["tommo"]["quality"] == 8700090.0
+    assert not {"aac", "arc", "rrc"} & set(f["tommo"])  # panel has no genotypes
+    assert f["tommo"]["filter"] == ["PASS"]  # QC status preserved on every panel
+
+
+def test_significance_keeps_submission_count_and_medgen():
+    """C4: MedGen CUI is the join key to disease databases; submission_count is the
+    evidence weight behind an interpretation."""
+    row = {
+        "id": "tgv47264307",
+        "significance": [
+            {
+                "source": "clinvar",
+                "interpretations": ["P"],
+                "submission_count": 1,
+                "conditions": [
+                    {"name": "AMED syndrome, digenic", "medgen": "C5436906"}
+                ],
+            }
+        ],
+    }
+    s = _project_variant(row)["significance"][0]
+    assert s["submission_count"] == 1
+    assert s["conditions"] == [
+        {"name": "AMED syndrome, digenic", "medgen": "C5436906"}
+    ]
+
+
+def test_label_facets_adds_readable_companions():
+    """C7: stat facets are keyed by raw SO accessions / significance codes.
+
+    The API returns the FULL vocabulary in each facet, mostly zeros, so the
+    labelled companion must drop them or it doubles the response noise.
+    """
+    stats = {
+        "filtered": 1,
+        "type": {"SO_0001483": 1},
+        "consequence": {"SO_0001583": 4, "SO_0001624": 2, "SO_0001587": 0},
+        "significance": {"P": 1, "DR": 1, "B": 0, "NC": 0},
+        "dataset": {"tommo": 1},  # not code-keyed -> no labelled companion
+    }
+    labeled = _label_facets(stats)
+
+    assert labeled["type_labeled"] == {"SNV": 1}
+    assert labeled["consequence_labeled"] == {
+        "missense_variant": 4,
+        "3_prime_UTR_variant": 2,
+    }
+    assert labeled["significance_labeled"] == {"Pathogenic": 1, "Drug response": 1}
+    assert "stop_gained" not in labeled["consequence_labeled"]  # zeros dropped
+    assert "Benign" not in labeled["significance_labeled"]
+    assert "dataset_labeled" not in labeled
+    # raw facets are untouched (zeros included) — the labelled maps are additive
+    assert stats["consequence"]["SO_0001587"] == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/togo_mcp/data/mie/togovar.yaml
+++ b/togo_mcp/data/mie/togovar.yaml
@@ -61,9 +61,9 @@ schema_info:
     - "http://togovar.org/clinvar — full embedded ClinVar RDF. Its nodes re-use dcterms:identifier and med2rdf:gene, but dcterms:identifier here is the ClinVar *AlleleID*, NOT the VariationID (see critical_warnings ALLELEID/VARIATIONID trap). Join the variant layer into this graph ONLY via clinvar:variation_id (xsd:integer); never via dcterms:identifier."
   kw_search_tools: []
   version:
-    mie_version: "1.2"
+    mie_version: "1.3"
     mie_created: "2026-07-12"
-    mie_updated: "2026-07-14"
+    mie_updated: "2026-07-15"
     data_version: "GRCh38 endpoint (grch38.togovar.org), snapshot 2026-07"
     update_frequency: "Periodic (aligned with TogoVar releases)"
   license:
@@ -96,6 +96,13 @@ critical_warnings: |
     reconcile counts across the two backends or quote the SPARQL total as "the size
     of TogoVar". Treat SPARQL as the annotated subset; use REST for whole-database
     totals and for allele frequencies.
+    THE MISSING VARIANTS INCLUDE CLINICALLY IMPORTANT ONES — the gap is not confined to
+    rare/non-functional variants. Verified in CFTR: the ClinVar-PATHOGENIC 7:117480132-C-T
+    (VariationID 53845) and 7:117480138-T-C (VariationID 634833) have NO node in
+    GRAPH <http://togovar.org/variant> (and tgv_id = null in REST). So for comprehensive
+    clinical triage / pathogenic-variant ENUMERATION, use the REST API
+    (togovar_search_variant) as the PRIMARY path; treat SPARQL as the annotation
+    deep-dive layer for the variants it does carry.
   - NO ALLELE FREQUENCY IN THIS ENDPOINT. TogoVar's headline per-population
     frequencies (ToMMo/54KJPN, gnomAD genomes/exomes, JGA, GEM-J WGA, NCBN, BBJ)
     are NOT stored in this SPARQL endpoint — they are served only via the TogoVar
@@ -108,10 +115,11 @@ critical_warnings: |
     blank-node chain in the embedded ClinVar graph:
     <variation IRI> clinvar:classified_record -> clinvar:classifications ->
     clinvar:germline_classification -> clinvar:description (the significance literal,
-    e.g. "drug response") + clinvar:review_status. Verified for rs671 (example #7).
-    CAVEAT: the attachment path is not uniform across records — some nodes carry
-    clinvar:classifications directly (no classified_record hop) — so a single fixed
-    property path can miss records. For reliable significance/conditions across
+    e.g. "drug response") + clinvar:review_status. Verified for rs671 AND rs334
+    (example #7 — rs334/HBB returns "Pathogenic" over the identical path).
+    CAVEAT: two confirming cases do not prove uniformity. The attachment path is NOT
+    uniform across records — some nodes carry clinvar:classifications directly (no
+    classified_record hop) — so a single fixed property path can miss records. For reliable significance/conditions across
     arbitrary variants, prefer the REST API (togovar_search_variant returns a clean
     `significance` array with interpretation codes + conditions).
   - CROSS-GRAPH RE-TYPING / UNION INFLATION. The same variant IRI is typed
@@ -148,10 +156,20 @@ critical_warnings: |
     IDs (http://rdf.ebi.ac.uk/resource/ensembl/217) — both minted under the SAME
     ensembl namespace. The sibling tgvo:gene_symbol_source ("HGNC" vs "EntrezGene")
     distinguishes them. Filter to the ENSG form if you mean Ensembl genes.
-  - REST togovar_search_variant NOTES. (1) Each result row carries `tgv_id` and a
-    reconstructed `variant_iri` — either resolves in this SPARQL endpoint, so the
-    REST->SPARQL handoff is direct (fetch frequencies/significance via REST, then
-    deep-dive VEP/cross-refs here). Large structural-variant alleles are summarized
+  - REST togovar_search_variant NOTES. (1) `variant_iri` IS A CONSTRUCTED COORDINATE IRI
+    AND IS NOT PROOF OF SPARQL PRESENCE. It is built mechanically from chr/pos/ref/alt, so
+    it is emitted on EVERY row — including variants ABSENT from this SPARQL endpoint (which
+    holds only the ~2.8x smaller annotated subset). Only rows with a NON-NULL `tgv_id` have
+    a record in GRAPH <http://togovar.org/variant>. GATE any REST->SPARQL round-trip on
+    `tgv_id != null`; NEVER assume `variant_iri` resolves. Verified in CFTR: 7:117480108-C-T
+    (tgv_id = tgv207092446) resolves in the core variant graph, whereas the ClinVar-Pathogenic
+    7:117480132-C-T and 7:117480138-T-C have tgv_id = null and have NO node in
+    <http://togovar.org/variant> at all — a FALDO positional lookup over ALL alleles at those
+    chr7 positions returns nothing, so this is NOT a normalized-vs-VCF allele artifact (these
+    SNVs have pos = pos_vcf and ref/alt = ref_vcf/alt_vcf anyway). Such coordinates may still
+    appear as re-typed nodes in <http://togovar.org/variant/annotation/clinvar> (carrying only
+    the ClinVar VariationID), with NO tgv ID and NO VEP annotation — so a "hit" there is not a
+    core variant record. Large structural-variant alleles are summarized
     in the row (with `ref_length`/`alt_length`); pass `include_full_alleles=True`
     only when the full sequence is needed. (2) In `stat=True` output ALL facets are
     scoped to the filtered set, but they count at different granularities: `type`
@@ -162,7 +180,31 @@ critical_warnings: |
     VARIANT-CONDITION classification record. So consequence/significance sums
     legitimately exceed `filtered` and must NOT be read as variant counts of the
     query result — they are annotation-record counts (use COUNT(DISTINCT) semantics
-    when reasoning about variants).
+    when reasoning about variants). They are NOT unscoped and NOT whole-database:
+    verified live on rs671, filtered = 1 yields a consequence-facet sum of 8 (its 8
+    transcript annotations, spread over 36 listed SO terms) and a significance-facet
+    sum of 6 — whole-database facets would be in the millions/billions here. This
+    matches `_STATISTICS_CAVEATS` in togo_mcp/togovar.py; keep the two aligned.
+    (3) HARD PAGINATION CAP: `scroll.max_rows` = 10,000. The API accepts
+    `offset + limit <= 10,000` and returns HTTP 400 at 10,001 (verified: offset=9990
+    limit=10 -> 200 with 10 rows; offset=9991 limit=10 -> 400). A result set larger
+    than 10,000 therefore CANNOT be fully paged — e.g. gene ALDH2 (hgnc_id 404) has
+    filtered = 24,410, so ~14,410 of its variants are unreachable by paging. To
+    enumerate a large set, either narrow the filters until `filtered` <= 10,000
+    (split by consequence, significance, or genomic window), or enumerate in SPARQL
+    — remembering SPARQL is only the annotated subset (see the SUBSET warning), so
+    neither backend alone gives a complete large enumeration.
+    (4) REST rows are RICHER than the tool's projection suggests, but the extra
+    fields are NOT uniformly present. Each raw row carries per-transcript VEP
+    (`transcripts[]`: consequence SO IDs, hgvs_c/hgvs_p/hgvs_g, per-transcript
+    sift/polyphen/alphamissense, gene_id/hgnc_id/symbol) and per-population
+    `frequencies[]` (source, af/ac/an, filter e.g. PASS). So VEP and HGVS are NOT
+    SPARQL-only. CAVEAT: genotype/QC fields are PER-SOURCE, not universal — verified
+    on rs671, `jga_wgs` carries the full genotype set (aac/arc/rrc + hemizygous
+    hac/hoc + aoc/ooc/roc), `jga_snp` carries aac/arc/rrc only, `ncbn` only aac, and
+    `tommo`/`jga_wes`/`gem_j_wga` carry NONE (they do carry `quality`), while
+    `gnomad_exomes`/`gnomad_genomes` carry neither genotype counts nor `quality`.
+    Never assume a genotype count exists for a given panel — check the key first.
 
 shape_expressions: |
   PREFIX gvo:   <http://genome-variation.org/resource#>
@@ -269,7 +311,13 @@ shape_expressions: |
     cvo:variation_id xsd:integer ;              # e.g. 18390
     cvo:allele_id    xsd:integer ;              # e.g. 33429 (this is dcterms:identifier in this graph)
     dcterms:identifier xsd:string ;             # AlleleID as string (NOT the VariationID — collision trap)
-    med2rdf:gene IRI ? ;                         # http://ncbi.nlm.nih.gov/gene/{n} (NCBI gene)
+    med2rdf:gene IRI * ;                         # http://ncbi.nlm.nih.gov/gene/{n} (NCBI gene).
+                                                 # MULTI-VALUED: ClinVar may assign SEVERAL genes to one
+                                                 # allele, incl. overlapping LOC loci. rs334 (HBB sickle-cell,
+                                                 # VariationID 15333) -> 3 genes: 3043 (HBB) + 107133510 +
+                                                 # 106099062. ~10-14% of allele nodes carry >1 gene
+                                                 # (2 x 3,000-node samples), so the variation_id join FANS OUT
+                                                 # one row per gene — collapse it (see anti_patterns).
     cvo:name xsd:string * ;                     # e.g. "NM_000690.4(ALDH2):c.1510G>A (p.Glu504Lys)"
     cvo:canonical_spdi xsd:string ?             # e.g. "NC_000012.12:111803961:G:A"
   }
@@ -468,6 +516,14 @@ sparql_query_examples:
       the WRONG gene (rs671 -> SRD5A2 instead of ALDH2). The join is a BIND-as-object, not a FILTER
       cast (a cross-GRAPH FILTER on variation_id returns 0 rows in Virtuoso). Gene + name come from
       the allele-level node; significance from the variation-IRI classified_record chain.
+      TWO CAVEATS. (a) med2rdf:gene is MULTI-VALUED, so this query returns ONE ROW PER GENE, not per
+      variant: rs671/ALDH2 happens to be single-gene (ncbigene:217), but rs334 (HBB sickle-cell,
+      chr11:5227002 T>A) returns 3 rows — ncbigene:3043 (HBB, the real gene) plus the overlapping LOC
+      loci 107133510 and 106099062 — all repeating the same "Pathogenic" significance. To get one row
+      per variant, collapse the genes with GROUP_CONCAT/SAMPLE (see anti_patterns) or keep only the gene
+      matching the VEP tgvo:gene_symbol in the ensembl annotation graph. (b) The significance chain is
+      verified for rs671 ("drug response") and rs334 ("Pathogenic"), but is still not uniform across all
+      records — see the CLINICAL SIGNIFICANCE critical_warning.
     question: "For chr12:111803962 G>A (rs671), what gene, variant name and ClinVar germline significance does the embedded ClinVar dataset record?"
     complexity: advanced
     sparql: |
@@ -522,6 +578,9 @@ controlled_vocabularies:
       advanced_search_conditions.json, clinvar bucket — a superset of the mgend bucket);
       all codes are confirmed. Note PLP/LPLP are LOW-PENETRANCE variants, NOT the
       "Pathogenic/Likely pathogenic" combined class.
+      SINGLE SOURCE OF TRUTH: this legend and `_SIGNIFICANCE_LABELS` in
+      togo_mcp/togovar.py are the same mapping from the same upstream file — change
+      them together, or the tool's `interpretation_labels` will disagree with this MIE.
     legend:
       NC: Not in ClinVar
       P: Pathogenic
@@ -622,6 +681,7 @@ architectural_notes:
     - "Join keys: variant IRI (internal cross-graph), dbSNP rsID, Ensembl gene/transcript IRI, HGNC IRI, SO term IRI, and — into embedded ClinVar — clinvar:variation_id (xsd:integer), NOT dcterms:identifier."
     - "ClinVar clinical detail (significance, conditions) lives in the embedded <http://togovar.org/clinvar> graph — reuse the clinvar.yaml MIE for its deep schema. REST is the robust fallback for significance."
     - "Allele frequencies are external to this endpoint (TogoVar REST API only)."
+    - "REST is not a thin index: a raw row already carries per-transcript VEP (transcripts[]: SO consequence, hgvs_c/p/g, per-transcript SIFT/PolyPhen/AlphaMissense, gene_id/hgnc_id) and per-population frequencies[] (af/ac/an, filter, and — only on some panels — genotype counts). So VEP/HGVS/genotype are NOT SPARQL-only; REST can serve them for variants SPARQL lacks. Use SPARQL for graph joins over the annotated subset. See REST NOTES (4) for the per-panel genotype caveat and (3) for the 10,000-row paging cap."
   data_quality:
     - "The same variant IRI is re-typed in the clinvar annotation graph (union inflation trap)."
     - "Embedded-ClinVar dcterms:identifier is the AlleleID, whose numeric space overlaps VariationIDs — join on clinvar:variation_id or bind the wrong gene."
@@ -629,6 +689,8 @@ architectural_notes:
     - "gvo:ref/gvo:alt are empty strings for pure indels; use gvo:ref_vcf/gvo:alt_vcf for anchor-base VCF form."
     - "tgvo:sift and tgvo:polyphen have MIXED xsd:decimal/xsd:integer datatypes (numeric comparison works; exact equality does not)."
     - "hasConsequence fans out per transcript; count with COUNT(DISTINCT ?variant)."
+    - "Embedded-ClinVar med2rdf:gene is MULTI-VALUED (~10-14% of allele nodes; overlapping LOC loci — rs334 -> 3 genes), so the variation_id join fans out one row per gene; collapse with GROUP_CONCAT or match the VEP gene_symbol."
+    - "REST rows with tgv_id = null have NO record in the core variant graph even though a variant_iri is still constructed for them — this includes ClinVar-Pathogenic variants (e.g. CFTR 7:117480132-C-T)."
   text_search_justification:
     - "Number of the 7 example queries that use text search: 0."
     - "Every filter concept here is IRI- or controlled-literal-backed: genes (ENSG/HGNC IRIs), variants (dbSNP/variant IRIs), consequences (SO IRIs), impact/SIFT/PolyPhen (controlled literals), significance (clinvar:description literal)."
@@ -638,15 +700,16 @@ data_statistics:
   total_entities: 390725782
   rest_api_total_variants: 1097708150
   sparql_is_subset: true
-  verified_date: "2026-07-14"
-  verification_method: "GROUP BY type COUNT on GRAPH <http://togovar.org/variant> (indexed); REST total from togovar_search_variant stat"
+  subset_ratio: "REST total / SPARQL total = 1,097,708,150 / 390,725,782 = ~2.81x (re-pulled live 2026-07-15; unchanged since 2026-07-14)"
+  verified_date: "2026-07-15"
+  verification_method: "Per-class COUNT pinned to GRAPH <http://togovar.org/variant> with VALUES over the 5 gvo types (sums to total_entities); REST total from togovar_search_variant stat=True"
   by_class:
     SNV: 339076968
     Deletion: 29307469
     Insertion: 22340786
     MNV: 492
     Indel: 67
-    verified_date: "2026-07-14"
+    verified_date: "2026-07-15"
   coverage:
     vep_consequence: "~100% of variants (most_severe_consequence present)"
     vep_calculation: "sampling N=2000 SNV: all sampled had a most_severe_consequence"
@@ -693,6 +756,43 @@ anti_patterns:
           ?cv cvo:variation_id ?vid ; med2rdf:gene ?gene . }  # -> ncbigene:217 (ALDH2). CORRECT.
       } LIMIT 20
     explanation: "clinvar:variation_id (xsd:integer) is the only correct join key from the annotation layer; dcterms:identifier in the embedded graph is the AlleleID. Bind the cast integer and use it as a triple object — a cross-GRAPH FILTER on variation_id returns 0 rows in Virtuoso."
+
+  - title: "Multi-valued med2rdf:gene fans out the ClinVar join (one row per gene, not per variant)"
+    problem: "The allele-level node in <http://togovar.org/clinvar> can carry SEVERAL med2rdf:gene values — ClinVar assigns overlapping loci (often LOC/uncharacterized genes) to the same allele — so the variation_id join of example #7 returns one row PER GENE and repeats the significance literal on each. Verified: rs334 (HBB sickle-cell, chr11:5227002 T>A, VariationID 15333) returns 3 rows — ncbigene:3043 (HBB, correct), 107133510 and 106099062 — all 'Pathogenic'. Two 3,000-allele samples: ~10-14% of allele nodes carry >1 gene. Taking the first row (or COUNTing rows) therefore risks reporting an overlapping LOC locus as 'the' gene."
+    wrong_sparql: |
+      # 3 rows for ONE variant; picking row 1 can yield LOC107133510 instead of HBB
+      SELECT ?gene ?significance WHERE {
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          <http://identifiers.org/hco/11/GRCh38#5227002-T-A> dcterms:identifier ?variationId . }
+        BIND(xsd:integer(?variationId) AS ?vid)
+        GRAPH <http://togovar.org/clinvar> {
+          ?alleleNode cvo:variation_id ?vid ; med2rdf:gene ?gene .
+          ?varNode cvo:variation_id ?vid ;
+                   cvo:classified_record/cvo:classifications/cvo:germline_classification/cvo:description ?significance . }
+      }
+    correct_sparql: |
+      PREFIX dcterms: <http://purl.org/dc/terms/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX cvo:     <http://purl.jp/bio/10/clinvar/>
+      PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+      SELECT ?variationId
+             (GROUP_CONCAT(DISTINCT STR(?gene); separator=" | ") AS ?genes)
+             (SAMPLE(?significance) AS ?sig)
+      WHERE {
+        GRAPH <http://togovar.org/variant/annotation/clinvar> {
+          <http://identifiers.org/hco/11/GRCh38#5227002-T-A> dcterms:identifier ?variationId .
+        }
+        BIND(xsd:integer(?variationId) AS ?vid)
+        GRAPH <http://togovar.org/clinvar> {
+          ?alleleNode cvo:variation_id ?vid ;
+                      med2rdf:gene ?gene .
+          ?varNode cvo:variation_id ?vid ;
+                   cvo:classified_record/cvo:classifications/cvo:germline_classification/cvo:description ?significance .
+        }
+      }
+      GROUP BY ?variationId
+    explanation: "Executed live: returns exactly 1 row for rs334 — variationId 15333, genes 'http://ncbi.nlm.nih.gov/gene/106099062 | .../107133510 | .../3043', sig 'Pathogenic'. GROUP BY the variant/VariationID and collapse the genes with GROUP_CONCAT (SAMPLE for the significance, which is constant per variation). If you need THE causal gene rather than the list, intersect with the VEP tgvo:gene_symbol in <http://togovar.org/variant/annotation/ensembl> instead of trusting row order. Count variants with COUNT(DISTINCT ?variant)."
 
   - title: "Unscoped Variant-Class COUNT (cross-graph re-typing inflation)"
     problem: "Counting a variant class without pinning the graph double-counts the 2.94M ClinVar-annotated variants re-typed in the clinvar annotation graph."
@@ -745,6 +845,8 @@ common_errors:
     causes:
       - "Cross-graph re-typing: ClinVar-annotated variants counted in both variant and clinvar graphs"
       - "Multi-valued predicates (rdfs:seeAlso, tgvo:hasConsequence, tgvo:gene) inflating row counts in joins"
+      - "Multi-valued med2rdf:gene on the embedded-ClinVar allele node: the variation_id join returns one row per gene (rs334 -> 3 rows)"
     solutions:
       - "Pin GRAPH <http://togovar.org/variant> for class counts"
       - "Use COUNT(DISTINCT ?variant) and DISTINCT in projections when fanning out over consequences"
+      - "Collapse the ClinVar gene fan-out with GROUP_CONCAT/SAMPLE (see anti_patterns), or filter to the gene matching the VEP tgvo:gene_symbol"

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -446,20 +446,40 @@ def _build_variant_query(
     return {"and": clauses}
 
 
+# Genotype-count keys on a frequency panel. NOT universal — they are per-source
+# (verified on rs671: jga_wgs carries the full set, jga_snp only aac/arc/rrc, ncbn
+# only aac, tommo/jga_wes/gem_j_wga none, gnomAD neither), so each key is copied
+# only when the panel actually has it rather than defaulted to None.
+_GENOTYPE_KEYS = ("aac", "arc", "rrc", "hac", "hoc", "aoc", "ooc", "roc")
+
+
 def _project_variant(
-    row: dict[str, Any], include_full_alleles: bool = False
+    row: dict[str, Any],
+    include_full_alleles: bool = False,
+    include_transcripts: bool = False,
 ) -> dict[str, Any]:
     """Flatten a /search/variant data row into the fields agents actually use.
 
-    `tgv_id` (the row's `id`) and the reconstructed `variant_iri` are the two
-    stable keys for a SPARQL round-trip (frequency/significance via REST here ->
-    VEP/cross-references via SPARQL). Cross-database identifiers live under
-    `external_link` (dbsnp -> rs, clinvar -> VCV), surfaced as `rs`/`clinvar`.
-    Per-dataset frequencies are reshaped into a `{source: {af, ac, an}}` map.
+    `tgv_id` (the row's `id`) is the stable key for a SPARQL round-trip. It is
+    NULL for variants outside the SPARQL subset, and `variant_iri` is emitted ONLY
+    when it is non-null: the IRI is built mechanically from coordinates, so a row
+    with no tgv_id would otherwise carry an IRI that resolves to nothing (verified:
+    ClinVar-Pathogenic CFTR 7:117480132-C-T has tgv_id=null and no node in the
+    SPARQL variant graph). Cross-database identifiers live under `external_link`
+    (dbsnp -> rs, clinvar -> VCV), surfaced as `rs`/`clinvar`.
+
+    Per-dataset frequencies are reshaped into a `{source: {...}}` map carrying
+    af/ac/an plus the QC `filter` and whatever genotype counts that panel has
+    (hom-alt/het/hom-ref/hemizygous) — these drive carrier-frequency and
+    Hardy-Weinberg reasoning and are per-source, not universal.
 
     Opaque codes are given human-readable companions: `type_label`,
     `most_severe_consequence_label`, and `interpretation_labels` on each
     significance entry (the raw codes are kept for backward compatibility).
+
+    Per-transcript VEP (`transcripts`: HGVS c/p/g + per-transcript predictions) is
+    opt-in via include_transcripts — a variant in a transcript-dense locus can
+    carry 400+ transcript annotations, so it is kept out of the default payload.
 
     Large structural variants carry multi-kb REF/ALT; the `variant` label is
     length-bounded and `reference`/`alternate` are summarized (with true
@@ -476,7 +496,18 @@ def _project_variant(
     for f in row.get("frequencies") or []:
         src = f.get("source")
         if src:
-            freqs[src] = {"af": f.get("af"), "ac": f.get("ac"), "an": f.get("an")}
+            entry: dict[str, Any] = {
+                "af": f.get("af"),
+                "ac": f.get("ac"),
+                "an": f.get("an"),
+                "filter": f.get("filter"),
+            }
+            if f.get("quality") is not None:
+                entry["quality"] = f["quality"]
+            for gk in _GENOTYPE_KEYS:
+                if gk in f:
+                    entry[gk] = f[gk]
+            freqs[src] = entry
 
     significance = []
     for s in row.get("significance") or []:
@@ -487,7 +518,11 @@ def _project_variant(
             "interpretation_labels": [
                 _SIGNIFICANCE_LABELS.get(i, i) for i in interps
             ],
-            "conditions": [c.get("name") for c in s.get("conditions", [])],
+            "submission_count": s.get("submission_count"),
+            "conditions": [
+                {"name": c.get("name"), "medgen": c.get("medgen")}
+                for c in s.get("conditions", [])
+            ],
         })
 
     chrom = row.get("chromosome")
@@ -496,11 +531,13 @@ def _project_variant(
     alt = row.get("alternate")
     vtype = row.get("type")
     msc = row.get("most_severe_consequence")
+    tgv = row.get("id")
 
-    return {
-        "tgv_id": row.get("id"),
+    projected = {
+        "tgv_id": tgv,
         "variant": f"{chrom}:{pos}:{_compact_allele(ref)}>{_compact_allele(alt)}",
-        "variant_iri": _variant_iri(chrom, pos, ref, alt),
+        # Only emit an IRI that actually resolves in the SPARQL subset.
+        "variant_iri": _variant_iri(chrom, pos, ref, alt) if tgv else None,
         "type": vtype,
         "type_label": _SO_LABELS.get(vtype) if vtype else None,
         "chromosome": chrom,
@@ -520,6 +557,54 @@ def _project_variant(
         "significance": significance,
         "frequencies": freqs,
     }
+
+    if include_transcripts:
+        transcripts = []
+        for tr in row.get("transcripts") or []:
+            cons = tr.get("consequence") or []
+            transcripts.append({
+                "transcript_id": tr.get("transcript_id"),
+                "gene_id": tr.get("gene_id"),
+                "hgnc_id": tr.get("hgnc_id"),
+                "consequence": cons,
+                "consequence_labels": [_SO_LABELS.get(c, c) for c in cons],
+                "hgvs_c": tr.get("hgvs_c"),
+                "hgvs_p": tr.get("hgvs_p"),
+                "hgvs_g": tr.get("hgvs_g"),
+                "sift": tr.get("sift"),
+                "polyphen": tr.get("polyphen"),
+                "alphamissense": tr.get("alphamissense"),
+            })
+        projected["transcripts"] = transcripts
+
+    return projected
+
+
+def _label_facets(stats: dict[str, Any]) -> dict[str, Any]:
+    """Add `*_labeled` companions to the code-keyed stat facets (C7).
+
+    `type`/`consequence` are keyed by SO accession and `significance` by TogoVar's
+    abbreviation codes; neither is readable on its own. The raw facets are left
+    untouched for backward compatibility.
+
+    ZERO COUNTS ARE DROPPED here. The API returns the FULL vocabulary in every
+    facet — all 36 SO consequence terms and all 21 significance codes — mostly
+    zeros (rs671: 3 non-zero of 36). Mirroring those into a labelled copy would
+    double the noise, so the companion carries only what actually matched. Read the
+    raw facet if you need the zeros.
+    """
+    labeled: dict[str, Any] = {}
+    for facet, table in (
+        ("type", _SO_LABELS),
+        ("consequence", _SO_LABELS),
+        ("significance", _SIGNIFICANCE_LABELS),
+    ):
+        counts = stats.get(facet)
+        if isinstance(counts, dict):
+            labeled[f"{facet}_labeled"] = {
+                table.get(code, code): n for code, n in counts.items() if n
+            }
+    return labeled
 
 
 @togovar_mcp.tool()
@@ -658,6 +743,7 @@ async def search_variant(
     offset: Annotated[int, Field(ge=0)] = 0,
     stat: bool = False,
     include_full_alleles: bool = False,
+    include_transcripts: bool = False,
 ) -> str:
     """Search TogoVar for human genome variants with population frequencies.
 
@@ -688,8 +774,12 @@ async def search_variant(
     significance sums exceed `filtered` and must NOT be summed against it (they
     are not per-variant counts). See `statistics_caveats` for the per-facet rule.
 
-    ROUND-TRIP TO SPARQL: each row carries `tgv_id` and `variant_iri`; either
-    resolves in the `togovar` SPARQL graph for VEP/cross-reference deep dives.
+    ROUND-TRIP TO SPARQL: gate on `tgv_id`. It is NULL for variants that exist in
+    the REST backend but NOT in the (smaller) SPARQL subset — including some
+    ClinVar-Pathogenic ones. `variant_iri` is emitted ONLY when `tgv_id` is
+    non-null, so a non-null `variant_iri` is safe to query in the `togovar` SPARQL
+    graph; a row with `tgv_id: null` has no SPARQL record at all, and REST is the
+    only source for it.
 
     TWO-STEP WORKFLOW for gene/disease filters:
         1. `search_gene("ALDH2")` -> hgnc_id -> pass as `gene_hgnc_id`.
@@ -723,27 +813,44 @@ async def search_variant(
             significance). REQUIRED to get a count — e.g. "how many variants
             match". Left False by default because computing the aggregation is
             the slow part of the query; use stat=False when you only need rows.
-            See STATISTICS SCOPE above — the facets are not uniformly filtered.
+            See STATISTICS SCOPE above — every facet is scoped to the filtered
+            set, but they count at different granularities, so only `type` sums
+            to `filtered`.
         include_full_alleles: If True, return full REF/ALT sequences even for
             large structural variants. Default False summarizes alleles over
             ~50 bp as "<head>…(<n> bp)" to keep the response inline-readable;
             `ref_length`/`alt_length` always give the true lengths.
+        include_transcripts: If True, add a `transcripts` list to each row with
+            the per-transcript VEP annotation the REST backend already carries:
+            transcript/gene IDs, SO consequence(+labels), HGVS c/p/g, and
+            per-transcript SIFT/PolyPhen/AlphaMissense. Default False — a variant
+            in a transcript-dense locus (e.g. BRCA1) can carry 400+ transcript
+            annotations, which would dominate the response. Note this means HGVS
+            and per-transcript predictions do NOT require a SPARQL round-trip.
 
     Returns:
         str: JSON string
         `{"data": [...], "total"?, "filtered"?, "statistics"?,
           "statistics_caveats"?, "truncated"?}`.
-        Each data row carries `tgv_id`, `variant` (a length-bounded
-        chr:pos:ref>alt locus label), `variant_iri` (for SPARQL round-trip;
-        null for very long alleles), coordinates, `reference`/`alternate`
-        (summarized unless include_full_alleles) with `ref_length`/`alt_length`,
+        Each data row carries `tgv_id` (null if the variant is not in the SPARQL
+        subset), `variant` (a length-bounded chr:pos:ref>alt locus label),
+        `variant_iri` (non-null only when `tgv_id` is — see ROUND-TRIP above),
+        coordinates, `reference`/`alternate` (summarized unless
+        include_full_alleles) with `ref_length`/`alt_length`,
         `type`(+`type_label`), genes, `rs` (dbSNP) and `clinvar` (VCV)
         cross-links, `most_severe_consequence`(+`_label`),
         SIFT/PolyPhen/AlphaMissense scores, clinical `significance` (each with
-        `interpretations` codes + `interpretation_labels`), and a `frequencies`
-        map keyed by dataset ({af, ac, an}). `total`/`filtered`/`statistics`/
-        `statistics_caveats` are present ONLY when `stat=True`. `truncated` is
-        present (and data rows trimmed) only if the response would be oversized.
+        `interpretations` codes + `interpretation_labels`, `submission_count`,
+        and `conditions` as {name, medgen CUI}), and a `frequencies` map keyed by
+        dataset ({af, ac, an, filter, quality?} plus genotype counts where the
+        panel provides them: aac=hom-alt, arc=het, rrc=hom-ref, hac/hoc=hemizygous
+        — these are PER-SOURCE, so check the key rather than assuming it exists).
+        `transcripts` is present only with include_transcripts=True.
+        `total`/`filtered`/`statistics`/`statistics_caveats` are present ONLY when
+        `stat=True`; `statistics` also carries `*_labeled` companions for the
+        code-keyed facets (type/consequence/significance), and `scroll` reports the
+        API's paging cap. `truncated` is present (and data rows trimmed) only if
+        the response would be oversized.
 
         Clinical-significance codes (in `interpretations`): P=Pathogenic,
         LP=Likely pathogenic, PLP=Pathogenic low-penetrance, LPLP=Likely
@@ -788,10 +895,16 @@ async def search_variant(
 
     result: dict[str, Any] = {
         "data": [
-            _project_variant(row, include_full_alleles)
+            _project_variant(row, include_full_alleles, include_transcripts)
             for row in payload.get("data", [])
         ],
     }
+    # Surface the API's hard paging cap (offset + limit <= max_rows; HTTP 400
+    # beyond it) so a caller paging a large result set sees the ceiling instead of
+    # discovering it as an error.
+    scroll = payload.get("scroll")
+    if isinstance(scroll, dict) and scroll.get("max_rows") is not None:
+        result["scroll"] = scroll
     # Match counts and the category breakdown come from the statistics block,
     # which the API only computes (and it is the expensive part) when stat=1.
     # With stat=False the caller gets rows only — counts are omitted, not zero.
@@ -799,7 +912,9 @@ async def search_variant(
         stats = payload["statistics"]
         result["total"] = stats.get("total")
         result["filtered"] = stats.get("filtered")
-        result["statistics"] = stats
+        # The facets are keyed by SO accession / significance code, which are
+        # unreadable on their own; ship labelled companions alongside the raw ones.
+        result["statistics"] = {**stats, **_label_facets(stats)}
         # Every facet IS scoped to the filtered set; they just count at different
         # granularities (consequence per-transcript, significance per-condition), so
         # their sums exceed `filtered`. Ship the scope rules so the numbers are not

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -669,11 +669,15 @@ async def search_variant(
     All filters are optional and combined with AND. Supply zero filters to
     browse; but scope tightly — the database holds ~1 billion variants.
 
-    COUNTS: `total` is the size of the whole REST backend (~1.1 billion) and is
+    COUNTS: `total` is the size of the whole REST backend (1,097,708,150) and is
     constant across queries; `filtered` is the count matching your filters. Note
-    the REST backend is LARGER than TogoMCP's `togovar` SPARQL graph (~3.9x: the
-    SPARQL side is the annotated subset), so REST counts will not match SPARQL
-    `COUNT(*)` — they measure different sets.
+    the REST backend is LARGER than TogoMCP's `togovar` SPARQL graph (~2.8x: the
+    SPARQL side is the annotated subset, 390,725,782), so REST counts will not
+    match SPARQL `COUNT(*)` — they measure different sets.
+
+    PAGING CAP: the API allows `offset + limit <= 10,000` and returns HTTP 400
+    beyond it, so a result set larger than 10,000 cannot be fully paged. Narrow the
+    filters until `filtered` <= 10,000 to enumerate one exhaustively.
 
     STATISTICS SCOPE (stat=True): all facets are scoped to the filtered set, but
     they count at different granularities. `type` counts per variant (sums to
@@ -796,9 +800,10 @@ async def search_variant(
         result["total"] = stats.get("total")
         result["filtered"] = stats.get("filtered")
         result["statistics"] = stats
-        # The API filters facets inconsistently (consequence is whole-database,
-        # significance is a self-excluding facet); ship the scope rules so the
-        # numbers are not misread. Only annotate facets actually present.
+        # Every facet IS scoped to the filtered set; they just count at different
+        # granularities (consequence per-transcript, significance per-condition), so
+        # their sums exceed `filtered`. Ship the scope rules so the numbers are not
+        # misread as variant counts. Only annotate facets actually present.
         result["statistics_caveats"] = {
             k: v for k, v in _STATISTICS_CAVEATS.items() if k in stats
         }

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Ships four commits: one correctness fix, one capability expansion, and the MIE that documents them.

The through-line: the TogoVar REST wrapper was **discarding data the backend already returns**, and was emitting one identifier that doesn't resolve. Both are fixed, and `togovar.yaml` is brought in line so the MIE and the tool agree.

## The correctness fix (C5)

`variant_iri` is built mechanically from `chr:pos:ref:alt`, so the tool emitted one for **every** row — including variants with `tgv_id: null`, which are exactly the variants absent from the SPARQL graph. Those IRIs resolved to zero rows, so an agent handing a `variant_iri` to `run_sparql` would silently get nothing back for a variant that genuinely exists.

Verified live: ClinVar-Pathogenic CFTR `7:117480132-C-T` and `7:117480138-T-C` have `tgv_id: null` and no node in `<http://togovar.org/variant>` (ruled out both the normalized-vs-VCF allele artifact and the wrong-graph artifact). `variant_iri` is now gated on `tgv_id`, and the docstring's "either resolves" claim is replaced with the gate.

## New capability (C2–C4, C6–C7)

Per-transcript VEP is behind a new opt-in `include_transcripts` (a BRCA1-locus variant carries 400+ transcript annotations, so it stays out of the default payload). It returns HGVS c/p/g and per-transcript SIFT/PolyPhen/AlphaMissense — meaning **HGVS never required a SPARQL round-trip**.

Also now surfaced: QC `filter`/`quality` and genotype counts on frequency panels (per-source, not universal — copied only when present), `submission_count` and MedGen CUIs on significance, the `scroll` paging cap, and `*_labeled` companions for the code-keyed stat facets (zeros dropped — the API returns the full 36-term/21-code vocabulary mostly zeroed).

## MIE v1.3

`med2rdf:gene` on the embedded-ClinVar allele node is multi-valued (~10-14% of allele nodes; rs334 → HBB + 2 overlapping LOC loci), so the example-#7 join fans out one row per gene — shape corrected to `IRI *`, new anti-pattern with a live-tested `GROUP_CONCAT` collapse. Plus the `tgv_id` gate, the REST paging cap, and the clinical framing on the SUBSET warning.

## Verification

- 220 tests pass, including new regressions for each of C2–C5 and C7.
- Driven end-to-end against the live API, not just mocks: rs671 returns 6 transcripts with HGVS + per-transcript predictions, 8 frequency panels with the expected per-source genotype fields, MedGen `C5436906`, `scroll.max_rows=10000`; the three CFTR `7:117480132` alleles all come back with `tgv_id=null, variant_iri=null`.
- MIE independently re-validated: all 12 runnable queries and all 3 sample-RDF ASKs re-executed against the live endpoint by a separate agent.

## Versioning

MINOR (1.4.0 → 1.5.0): additive tool surface — one new optional parameter, new return fields, old calls still work. `uv.lock` synced in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)