### PR TITLE
docs: reconcile database catalogs (add HCO, MCO, TogoVar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ TogoMCP exposes tools for querying the following (via SPARQL or REST APIs):
 | Category | Resources |
 |---|---|
 | Proteins / Proteomics | UniProt, PDB, jPOST |
-| Genes / Genomics | NCBI Gene, Ensembl, HGNC, OMA, Bgee, DDBJ, MoG+ |
+| Genes / Genomics | NCBI Gene, Ensembl, HGNC, OMA, Bgee, HCO, MCO, DDBJ, MoG+, TogoVar |
 | Chemistry | ChEMBL, PubChem, ChEBI, Rhea, BRENDA, MassBank |
 | Pathways | Reactome |
 | Disease / Clinical | ClinVar, MedGen, MONDO, NANDO |

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1038,6 +1038,14 @@
         <div class="db-card-desc">Curated gene expression database integrating RNA-Seq, Affymetrix, EST, and in situ hybridization data across animal species, with calls tagged by anatomy (UBERON), developmental stage, sex, and strain for cross-species expression comparison.</div>
       </div>
       <div class="db-card">
+        <div class="db-card-name">HCO (Human Chromosome Ontology)</div>
+        <div class="db-card-desc">Ontology of the human cytogenetic map: every Giemsa-stained cytoband (ISCN nomenclature such as 13q14.2) with its GRCh37 and GRCh38 coordinates, stain type, and RefSeq/INSDC/Ensembl/UCSC chromosome accessions. 862 cytoband classes and 25 chromosomes across ~25,600 triples.</div>
+      </div>
+      <div class="db-card">
+        <div class="db-card-name">MCO (Mouse Chromosome Ontology)</div>
+        <div class="db-card-desc">The mouse counterpart of HCO: the Mus musculus chromosome set (1-19, X, Y, MT) with per-build instances on GRCm38 and GRCm39 carrying chromosome lengths and RefSeq/INSDC/Ensembl/UCSC cross-references. Whole-chromosome only — the canonical source of mouse-chromosome IRIs.</div>
+      </div>
+      <div class="db-card">
         <div class="db-card-name">MoG+ (Mouse Genomes plus)</div>
         <div class="db-card-desc">Genome-wide sequence variation across 62 inbred and wild-derived mouse strains on the GRCm39 assembly: ~146M variants (SNVs and indels) with per-strain genotypes, Ensembl VEP and SnpEff functional consequences, and Ensembl gene-overlap links.</div>
       </div>


### PR DESCRIPTION
Documentation-only follow-up to v1.5.0. Reconciles both public database catalogs against the MIE file set — no code, tool, or endpoint changes, so no version bump.

- **Landing page** (`d59d257`): adds HCO and MCO chromosome-ontology cards (shipped as MIE files but never carded). NBRC stays intentionally off per PR #129. 33 cards = 34 MIE files minus supercon and nbrc.
- **README** (`0372629`): adds HCO, MCO, and TogoVar to the Genes / Genomics row. The README is the full catalog (includes supercon and nbrc), so all 35 MIE files now have an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)