### PR TITLE
Release 1.6.0: add the `ontology` database; correct literal-form guidance

### DIFF
--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -181,11 +181,34 @@ Do this for every distinct bnode-valued predicate you encounter — typed-value 
 
 Note also that bnode shapes reached via different parent classes may differ in structure even when they share the same predicate name — the same property can resolve to an `ExactPosition` bnode (carrying an integer + a back-reference IRI) on one parent class and to a `Region` bnode (carrying `begin` and `end` sub-bnodes) on another. Never assume two bnode chains with the same predicate name have the same internal structure; verify each one independently via a parent-anchored query.
 
-#### 2d. Anchor IRIs via search tools
+#### 2d. Anchor IRIs via search tools — and resolve opaque IRIs back to labels
 
 If the database has a dedicated search tool (`search_uniprot_entity`, `search_chembl_molecule`, `search_chembl_target`, `search_pdb_entity`, `search_reactome_entity`, `search_rhea_entity`, `search_mesh_descriptor`, `OLS4:searchClasses`, `ncbi_esearch`), use it to turn human-readable terms ("TP53", "tumor protein p53", "kinase activity") into specific IRIs. Then DESCRIBE those IRIs to learn the canonical predicate names. This is the fastest path from "I know what concept I'm looking for" to "I have a structured-IRI query that works."
 
 If no search tool exists (BRENDA, BacDive, MediaDive, SuperCon, Glycosmos, NIMS): generate a short `bif:contains` (Virtuoso) probe to find one example, DESCRIBE it, and pivot to typed-predicate queries from there. Document this as the only legitimate text-search use, and note in `architectural_notes.text_search_justification` why no structured alternative existed.
+
+**The inverse direction — an opaque IRI whose meaning you don't know.** 2b/2c routinely surface bare numeric OBO IRIs (`SO_0000704`, `RO_0002211`, `BFO_0000050`, `ECO_0000269`) as predicates or objects. **Never guess one from its shape, and never gloss one in a comment you didn't resolve** — a wrong gloss in `shape_expressions` is invisible to Phase 5 (the query still runs) and ships as fact.
+
+The primary endpoint carries ~40 ontology graphs under `http://rdfportal.org/ontology/` (`go`, `hp`, `so`, `uberon`, `cl`, `clo`, `eco`, `efo`, `mondo`, `pro`, `fma`, `edam`, `sio`, `po`, `xco`, `cmo`, `meo`, `mmo`, `uo`, plus the `glycordf`/`orth`/`piero` schema vocabularies). Batch-resolve against them in **one** query — this works from any endpoint's survey, resolves many IRIs at once, and covers **object properties as well as classes**:
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?iri ?g ?label WHERE {
+  VALUES ?iri { <http://purl.obolibrary.org/obo/SO_0000704>
+                <http://purl.obolibrary.org/obo/RO_0002211> }
+  GRAPH ?g { ?iri rdfs:label ?label }
+  FILTER(LANG(?label) IN ("", "en"))
+}
+```
+(`database=go`, `endpoint_name=primary` — any registered member DB works as the routing hint.)
+
+Three verified traps, all of which produce a confidently wrong answer rather than an empty one:
+
+- **Never `FILTER(LANG(?label) = "en")`.** The authoritative labels in `ontology/go`, `ontology/hp`, and `ontology/so` carry **no language tag at all**; only the copies re-imported by other ontologies are tagged `en`. Filtering on `"en"` silently drops the owning ontology's label and leaves you quoting a second-hand one. Always `IN ("", "en")` — that also excludes the Japanese labels (e.g. PubCaseFinder's 発作 for `HP_0001250`).
+- **The same IRI gets conflicting labels from different graphs — take the owner's, not the first row.** Map the IRI prefix to its home graph (`SO_`→`ontology/so`, `HP_`→`ontology/hp`, `GO_`→`ontology/go`, `UBERON_`→`ontology/uberon`, `CL_`→`ontology/cl`, `ECO_`→`ontology/eco`, `EFO_`→`ontology/efo`). Real case: `RO_0002211` is "regulates" in `go`/`cl`/`clo`/`po`/`uberon` but **"has_component" in `ontology/xco`** — flatly wrong. Row order is arbitrary without an `ORDER BY`, so "the first row" is not a deterministic pick, let alone a correct one: bind the owning graph, or read all rows and take the majority.
+- **Shared-prefix predicates (`RO_`, `BFO_`) have no home graph** — there is no `ontology/ro`. They resolve only because OBO import closures embed them, so every hit is second-hand. Prefer the `ontology/go` copy, expect harmless variants (`part of` / `part_of`; `regulates` / `regulates (processual)`), and treat a lone dissenting label as noise.
+
+Use **OLS4** (`OLS4:searchClasses`, `fetch`, `getAncestors`/`getDescendants`) instead when the term's ontology isn't on the primary endpoint, or when you need the *definition*, synonyms, or hierarchy rather than a label. OLS4 is per-ontology authoritative, so it sidesteps the cross-graph collision above entirely — but it's one term per call and can't join to data. Rule of thumb: **many IRIs → the batch SPARQL above; one IRI you need to genuinely understand → OLS4.**
 
 #### 2e. Verify predicate cardinality for every shape
 

--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -131,28 +131,47 @@ SELECT ?ns (COUNT(*) AS ?n) WHERE {
 
 Run this on every predicate you plan to traverse in `sparql_query_examples`. If the object set is heterogeneous: enumerate **all** object kinds with their counts in the shape comment and `critical_warnings`, and show the disambiguating filter (e.g. `FILTER(CONTAINS(STR(?o), "/protein/"))`) in the example query. Real case: PubChem's `obo:RO_0000057` (MeasureGroup → target) resolves to protein **and** taxonomy, gene, cell, and anatomy IRIs — five object kinds under one predicate; a query filtering to only one silently loses the rest, and the first revision documented only three of the five until this GROUP BY was run.
 
-**Probe the literal datatype and language tag for every literal you'll match exactly.** Whenever a predicate's object is a literal that a downstream query will match in a `VALUES` block, a `FILTER(?x = …)`, or a triple-pattern object, the *stored* lexical form must match the *query* term exactly — including datatype and language tag. Guessing is a silent-failure trap: a query term of the wrong datatype returns 0 rows with no error. Never assume; probe how the literal is actually stored:
+**Probe the literal form for every literal you'll match exactly — EMPIRICALLY, by matching it.** Whenever a predicate's object is a literal that a downstream query will match in a `VALUES` block, a `FILTER(?x = …)`, or a triple-pattern object, the *stored* term must match the *query* term exactly — including datatype and language tag. A query term of the wrong form returns 0 rows with no error.
+
+> **`DATATYPE()` CANNOT ANSWER THIS QUESTION — DO NOT BUILD THE MATCH FORM FROM IT.** On Virtuoso (and any RDF-1.1 store), a *plain* literal and an *`xsd:string`-typed* literal BOTH report `DATATYPE() = xsd:string`, because RDF 1.1 defines them as the same value. But Virtuoso matches **terms, not values**: the two forms do NOT unify in a triple pattern *or* in `FILTER(?x = …)`. So `DATATYPE()` reports identically for two graphs whose required match form is **opposite**, and a probe-driven guess is right half the time and silently wrong the other half.
+>
+> Verified 2026-07-16 on the RDF Portal primary endpoint, both reporting `DATATYPE() = xsd:string`:
+> - `<ontology/hp>` — `HP_0001250 rdfs:label "Seizure"^^xsd:string` MATCHES; plain `"Seizure"` → 0 rows.
+> - `<ontology/efo>` — `EFO_0000305 rdfs:label "obsolete_breast carcinoma"` MATCHES; the `^^xsd:string` form → 0 rows.
+>
+> This is exactly how a previous `ontology.yaml` shipped the false lead warning "every literal here is xsd:string" — true for hp/go, inverted for uberon/cl/efo/edam.
+
+`DATATYPE()`/`LANG()` remain useful for what they *can* see — a language tag, and genuine non-string types (`xsd:integer`, `xsd:boolean`, `xsd:date`) — so still run the survey to spot those and any mixed typing:
 
 ```sparql
 SELECT ?dt ?lang (COUNT(*) AS ?n) WHERE {
-  GRAPH <…> {
-    ?s <predicate> ?o .
-    BIND(DATATYPE(?o) AS ?dt)
-    BIND(LANG(?o) AS ?lang)
-  }
+  GRAPH <…> { ?s <predicate> ?o . BIND(DATATYPE(?o) AS ?dt) BIND(LANG(?o) AS ?lang) }
 } GROUP BY ?dt ?lang ORDER BY DESC(?n)
+```
+
+But when the survey says "string-ish" (`xsd:string` with no lang), you have learned nothing about the match form. **Settle it by trying each candidate form against a known term** — one ASK per form, cheap and decisive:
+
+```sparql
+ASK { GRAPH <…> { <known-subject> <predicate> "known value" } }                    # plain
+ASK { GRAPH <…> { <known-subject> <predicate> "known value"^^xsd:string } }        # typed
+ASK { GRAPH <…> { <known-subject> <predicate> "known value"@en } }                 # lang-tagged
 ```
 
 Map the result to the exact-match rule, and record it in `critical_warnings` whenever a query would break by getting it wrong:
 
-| Observed storage | Exact-match query term must be |
+| Established by ASK | Exact-match query term must be |
 |---|---|
-| `xsd:string` (typed) | `"value"^^xsd:string` — a plain `"value"` joins to nothing |
-| plain literal (`?dt` is blank, no lang) | `"value"` — adding `^^xsd:string` joins to nothing |
-| language-tagged (`?lang` = `en`, …) | `"value"@en`, or compare via `STR(?o) = "value"` / `langMatches()` |
-| `xsd:integer` / `xsd:decimal` / `xsd:double` | the matching numeric type — `"2"^^xsd:integer` ≠ `"2"^^xsd:decimal` ≠ `2.0` |
+| only the typed ASK is true | `"value"^^xsd:string` — a plain `"value"` joins to nothing |
+| only the plain ASK is true | `"value"` — adding `^^xsd:string` joins to nothing |
+| only the `@en` ASK is true | `"value"@en` — both bare forms join to nothing |
+| `xsd:integer` / `xsd:decimal` / `xsd:double` (visible to `DATATYPE()`) | the matching numeric type — `"2"^^xsd:integer` ≠ `"2"^^xsd:decimal` ≠ `2.0` |
 
-The nastiest variant is **inconsistent typing within one predicate** (some values `xsd:string`, some plain, or mixed numeric types): the GROUP BY shows two or more rows for the same predicate. Then no single exact-match form catches everything — document it and use `STR()`-based comparison (or a `VALUES` block listing both forms) in the example query. Real case: Reactome stores `bp:db` / `bp:id` / `bp:name` / `bp:eCNumber` / `bp:controlType` as `xsd:string`, so every `VALUES`/`FILTER =`/object literal needs `^^xsd:string` — its single most common silent-failure mode, now the file's lead `critical_warning`. `VALUES` is the highest-miss spot because the typing requirement isn't visually cued there the way it is in a triple object.
+Two rules that follow, both verified:
+
+- **`FILTER(?x = "value")` is NOT a workaround.** It is term-based on Virtuoso and fails identically to the triple pattern (`FILTER(?l = "Seizure")` on hp → false; `FILTER(?l = "Seizure"^^xsd:string)` → true). Only **`FILTER(STR(?x) = "value")`** unifies all three forms — verified matching in go (typed), uberon + edam (plain) and fma + sio (`@en`) alike. Prefer `STR()` in any example query that spans graphs or whose form you have not established by ASK; use the bare typed/plain form only where you have (it is faster and index-friendly).
+- **The form can vary BY GRAPH inside ONE endpoint, and even by predicate inside one graph.** Never generalize from one probe to "this database stores X". Real case: `<ontology/fma>` stores `rdfs:label` as `@en` (104,919 of 104,936) while its *sibling* predicates `fma:preferred_name` / `fma:definition` on the very same subject are `xsd:string`. Probe per graph, and per predicate you will match.
+
+The nastiest variant is **inconsistent typing within one predicate** (some values `xsd:string`, some plain, or mixed numeric types): the GROUP BY shows two or more rows for the same predicate. Then no single exact-match form catches everything — document it and use `STR()`-based comparison (or a `VALUES` block listing every form) in the example query. Real case: Reactome stores `bp:db` / `bp:id` / `bp:name` / `bp:eCNumber` / `bp:controlType` as `xsd:string`, so every `VALUES`/`FILTER =`/object literal needs `^^xsd:string` — its single most common silent-failure mode, now the file's lead `critical_warning`. `VALUES` is the highest-miss spot because the typing requirement isn't visually cued there the way it is in a triple object.
 
 #### 2c. DESCRIBE 3–5 representative entities
 
@@ -204,7 +223,7 @@ SELECT ?iri ?g ?label WHERE {
 
 Three verified traps, all of which produce a confidently wrong answer rather than an empty one:
 
-- **Never `FILTER(LANG(?label) = "en")`.** The authoritative labels in `ontology/go`, `ontology/hp`, and `ontology/so` carry **no language tag at all**; only the copies re-imported by other ontologies are tagged `en`. Filtering on `"en"` silently drops the owning ontology's label and leaves you quoting a second-hand one. Always `IN ("", "en")` — that also excludes the Japanese labels (e.g. PubCaseFinder's 発作 for `HP_0001250`).
+- **Never `FILTER(LANG(?label) = "en")` — and never `= ""` either.** The authoritative labels in `ontology/go`, `ontology/hp`, and `ontology/so` carry **no language tag at all**; only the copies re-imported by other ontologies are tagged `en`. Filtering on `"en"` silently drops the owning ontology's label and leaves you quoting a second-hand one. But the rule **inverts** for the non-OBO graphs: in `ontology/fma`, `ontology/sio` and `ontology/meo` the ontology's OWN label IS `@en` (verified 2026-07-16: 104,919 of FMA's 104,936 labels are `@en`; only 17 are `xsd:string`), so `= ""` drops ~99.98% of them. Always `IN ("", "en")` — the only form correct on both halves of the endpoint. It also excludes the Japanese labels (e.g. PubCaseFinder's 発作 for `HP_0001250`).
 - **The same IRI gets conflicting labels from different graphs — take the owner's, not the first row.** Map the IRI prefix to its home graph (`SO_`→`ontology/so`, `HP_`→`ontology/hp`, `GO_`→`ontology/go`, `UBERON_`→`ontology/uberon`, `CL_`→`ontology/cl`, `ECO_`→`ontology/eco`, `EFO_`→`ontology/efo`). Real case: `RO_0002211` is "regulates" in `go`/`cl`/`clo`/`po`/`uberon` but **"has_component" in `ontology/xco`** — flatly wrong. Row order is arbitrary without an `ORDER BY`, so "the first row" is not a deterministic pick, let alone a correct one: bind the owning graph, or read all rows and take the majority.
 - **Shared-prefix predicates (`RO_`, `BFO_`) have no home graph** — there is no `ontology/ro`. They resolve only because OBO import closures embed them, so every hit is second-hand. Prefer the `ontology/go` copy, expect harmless variants (`part of` / `part_of`; `regulates` / `regulates (processual)`), and treat a lone dissenting label as noise.
 
@@ -401,7 +420,9 @@ If this fails, fix the YAML before calling the work done.
    } GROUP BY ?objType ORDER BY DESC(?n)
    ```
 
-5. **Probe the value type of *every* literal-valued predicate in the shape — not only the ones a query will filter on.** Phase 2's datatype probe (the `DATATYPE()` table) is scoped to literals you plan to match exactly; this is the blanket pass that catches a wrong `xsd:…` annotation on an incidental field. For each predicate whose shape value is a literal datatype, GROUP BY its actual datatype and confirm the shape's annotation matches the stored form. A mismatch (e.g. shape says `xsd:integer`, data stores plain or `xsd:string`), or a predicate that stores **mixed** datatypes, must be corrected in the shape and — if it affects exact matching — surfaced in `critical_warnings`.
+5. **Probe the value type of *every* literal-valued predicate in the shape — not only the ones a query will filter on.** Phase 2's literal probe is scoped to literals you plan to match exactly; this is the blanket pass that catches a wrong `xsd:…` annotation on an incidental field. For each predicate whose shape value is a literal datatype, GROUP BY its actual datatype and confirm the shape's annotation matches the stored form. A mismatch (e.g. shape says `xsd:integer`, data stores plain or `xsd:string`), or a predicate that stores **mixed** datatypes, must be corrected in the shape and — if it affects exact matching — surfaced in `critical_warnings`.
+
+   **Remember what this GROUP BY cannot see** (Phase 2b): it does NOT distinguish a plain literal from an `xsd:string`-typed one — both report `xsd:string` — so it can neither confirm nor refute a `xsd:string` annotation in the shape. It catches genuine type errors (`xsd:integer` vs string) and language tags only. For any literal the shape's downstream queries will match exactly, settle the form with the per-form ASK from Phase 2b and annotate the shape from THAT. A shape saying `xsd:string` is a claim about the match form; it must be earned by an ASK, not inferred from `DATATYPE()`.
 
    ```sparql
    SELECT (DATATYPE(?o) AS ?dt) (COUNT(*) AS ?n) WHERE {

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ TogoMCP exposes tools for querying the following (via SPARQL or REST APIs):
 | Literature | PubMed, PubTator |
 | Microbiology | BacDive, MediaDive, AMR Portal, NBRC |
 | Glycomics | GlyCosmos |
-| Ontologies / Vocabulary | MeSH, GO |
+| Ontologies / Vocabulary | MeSH, GO, Ontology Graphs (HP, UBERON, CL, SO, ECO, EFO, PRO, FMA, …) |
 | Taxonomy | NCBI Taxonomy |
 | Materials Science | SuperCon |
 

--- a/benchmark/ablation/ablation_analysis.py
+++ b/benchmark/ablation/ablation_analysis.py
@@ -207,12 +207,12 @@ def paired_effort(base: dict[str, dict], abl: dict[str, dict],
 # --- Exact-answer correctness (secondary, tolerance-based) -------------------
 # The judge's 4x(1-5) score has a large per-question SD. A crisper 0/1 match of
 # the agent's answer against the question YAML's `exact_answer` gold is a
-# lower-variance (if coarser) lens. Tolerance matters for factoids: the gold
-# integer is frozen at question-creation and the live DB count drifts, so an
-# exact-integer match penalizes DB drift, not the agent — a relative tolerance
-# separates "wrong" from "gold is a bit stale". Caveats baked into the report:
-# `choice` sits near a 100% ceiling (no discrimination), and factoids remain
-# confounded by drift beyond the tolerance band. Summary questions have no gold.
+# lower-variance (if coarser) lens. Factoids use a relative tolerance as a safety
+# margin for minor DB drift, but spot-checks (re-running the gold queries live)
+# show factoid mismatches are mostly REAL agent miscounts on multi-step
+# aggregations — the golds re-run to their stored values — not stale golds. So low
+# factoid correctness is a valid signal the graded score smooths over. `choice`
+# sits near a 100% ceiling (no discrimination). Summary questions have no gold.
 _UNITS = {w: i for i, w in enumerate(
     "zero one two three four five six seven eight nine ten eleven twelve thirteen "
     "fourteen fifteen sixteen seventeen eighteen nineteen".split())}
@@ -543,10 +543,11 @@ def write_report(rows: list[dict], path: Path, metric: str,
             "",
             f"0/1 match of the answer against the question's `exact_answer` gold (list: "
             f"fractional recall), paired per question; Δ = baseline − ablated in percentage "
-            f"points.{base_c} Lower variance than the graded score, but **read with care**: "
-            "`choice` sits near a 100% ceiling (no discrimination) and `factoid` stays "
-            "confounded by live-DB drift beyond the tolerance band — `yes_no`/`list` are the "
-            "cleaner bands.",
+            f"points.{base_c} Lower variance than the graded score. `choice` sits near a "
+            "100% ceiling (no discrimination); `factoid` mismatches are mostly REAL agent "
+            "miscounts on multi-step aggregations (the gold queries re-run to their stored "
+            "values), which the graded score smooths over — the tolerance only absorbs minor "
+            "DB drift, not these genuine errors.",
             "",
             "| Section | Baseline % | Ablated % | Δ correct (pp) | n |",
             "|---|---:|---:|---:|---:|",

--- a/benchmark/ablation/ablation_analysis.py
+++ b/benchmark/ablation/ablation_analysis.py
@@ -403,13 +403,13 @@ def main() -> int:
             "n": n,
             "mean_baseline": None if mb is None else round(mb, 3),
             "mean_ablated": None if ma is None else round(ma, 3),
-            "contribution": None if mb is None else round(mb - ma, 3),
+            "contribution": None if mb is None or ma is None else round(mb - ma, 3),
             "n_relevant": n_r,
-            "contribution_relevant": None if mb_r is None else round(mb_r - ma_r, 3),
+            "contribution_relevant": None if mb_r is None or ma_r is None else round(mb_r - ma_r, 3),
         }
         for sm in SUBMETRICS:
             smb, sma, _ = paired_mean(baseline, ablated, sm, None)
-            row[f"delta_{sm}"] = None if smb is None else round(smb - sma, 3)
+            row[f"delta_{sm}"] = None if smb is None or sma is None else round(smb - sma, 3)
 
         # Effort delta: how much harder the agent worked with this section removed.
         eff = paired_effort(base_effort, load_effort(f"ablate_{section}", results), exclude)

--- a/benchmark/ablation/ablation_analysis.py
+++ b/benchmark/ablation/ablation_analysis.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import csv
 import glob
+import re
 from pathlib import Path
 from statistics import mean
 
@@ -203,6 +204,124 @@ def paired_effort(base: dict[str, dict], abl: dict[str, dict],
     return out
 
 
+# --- Exact-answer correctness (secondary, tolerance-based) -------------------
+# The judge's 4x(1-5) score has a large per-question SD. A crisper 0/1 match of
+# the agent's answer against the question YAML's `exact_answer` gold is a
+# lower-variance (if coarser) lens. Tolerance matters for factoids: the gold
+# integer is frozen at question-creation and the live DB count drifts, so an
+# exact-integer match penalizes DB drift, not the agent — a relative tolerance
+# separates "wrong" from "gold is a bit stale". Caveats baked into the report:
+# `choice` sits near a 100% ceiling (no discrimination), and factoids remain
+# confounded by drift beyond the tolerance band. Summary questions have no gold.
+_UNITS = {w: i for i, w in enumerate(
+    "zero one two three four five six seven eight nine ten eleven twelve thirteen "
+    "fourteen fifteen sixteen seventeen eighteen nineteen".split())}
+_TENS = {w: (i + 2) * 10 for i, w in enumerate(
+    "twenty thirty forty fifty sixty seventy eighty ninety".split())}
+_SCALES = {"hundred": 100, "thousand": 1000, "million": 1_000_000, "billion": 1_000_000_000}
+
+
+def _word_numbers(text: str) -> list[int]:
+    """Integer values of spelled-out English cardinals ('four hundred twenty-eight')."""
+    vals, cur, res, on = [], 0, 0, False
+    for w in re.findall(r"[a-z]+", text.lower()):
+        if w in _UNITS:
+            cur += _UNITS[w]; on = True
+        elif w in _TENS:
+            cur += _TENS[w]; on = True
+        elif w == "hundred":
+            cur = (cur or 1) * 100; on = True
+        elif w in _SCALES:
+            res += (cur or 1) * _SCALES[w]; cur = 0; on = True
+        elif w == "and" and on:
+            continue
+        else:
+            if on:
+                vals.append(res + cur)
+            cur = res = 0; on = False
+    if on:
+        vals.append(res + cur)
+    return vals
+
+
+def grade_exact(answer: str | None, gtype: str, gexact, tol: float) -> float | None:
+    """0/1 correctness (list: fractional recall) vs the gold, or None if ungradable."""
+    a = (answer or "").strip()
+    if gtype == "summary" or gexact in (None, "", []):
+        return None
+    al = a.lower()
+    if gtype == "yes_no":
+        stance = "yes" if re.match(r"\W*yes\b", al) else "no" if re.match(r"\W*no\b", al) else None
+        return 1.0 if stance == str(gexact).strip().lower() else 0.0
+    if gtype == "factoid":
+        try:
+            gold = int(str(gexact).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+        cands = [int(x.replace(",", "")) for x in re.findall(r"\d[\d,]*", a)] + _word_numbers(a)
+        if gold == 0:
+            return 1.0 if 0 in cands else 0.0
+        return 1.0 if any(abs(c - gold) <= tol * gold for c in cands) else 0.0
+    items = gexact if isinstance(gexact, list) else [gexact]
+    if gtype == "choice":
+        s = str(items[0]).strip().strip("[]'\"").lower()
+        hit = re.search(rf"\b{re.escape(s)}\b", al) if len(s) <= 4 else (s in al)
+        return 1.0 if hit else 0.0
+    if gtype == "list":                       # fractional recall of gold entities
+        got = 0
+        for it in items:
+            key = re.split(r"\s*\(", str(it))[0].strip().lower()
+            key = key.split()[0] if key else key
+            if key and (re.search(rf"\b{re.escape(key)}\b", al) if len(key) <= 4 else key in al):
+                got += 1
+        return got / len(items) if items else 0.0
+    return None
+
+
+def load_gold() -> dict[str, dict]:
+    gold = {}
+    for f in glob.glob(str(QUESTIONS_DIR / "question_*.yaml")):
+        q = yaml.safe_load(open(f, encoding="utf-8")) or {}
+        qid = q.get("id", Path(f).stem)
+        gold[qid] = {"type": q.get("type"), "exact": q.get("exact_answer")}
+    return gold
+
+
+def load_correctness(condition: str, gold: dict, tol: float, results: Path) -> dict[str, float]:
+    """question_id -> per-run-averaged exact-answer correctness for a condition."""
+    files = sorted(glob.glob(str(results / f"{condition}-scored-v*.csv")))
+    if not files:
+        merged = results / f"{condition}-scored.csv"
+        files = [str(merged)] if merged.exists() else []
+    per: dict[str, list[float]] = {}
+    for f in files:
+        for r in csv.DictReader(open(f, encoding="utf-8")):
+            qid = r.get("question_id")
+            if not qid:
+                continue
+            g = gold.get(qid)
+            if not g:
+                continue
+            c = grade_exact(r.get("togomcp_answer"), g["type"], g["exact"], tol)
+            if c is not None:
+                per.setdefault(qid, []).append(c)
+    return {qid: mean(v) for qid, v in per.items() if v}
+
+
+def paired_correctness(base: dict[str, float], abl: dict[str, float],
+                       exclude: set[str]) -> dict | None:
+    """Mean(baseline − ablated) exact-answer correctness, paired per question."""
+    qids = (base.keys() & abl.keys()) - exclude
+    if not qids:
+        return None
+    return {
+        "n": len(qids),
+        "base": mean(base[q] for q in qids),
+        "abl": mean(abl[q] for q in qids),
+        "contribution": mean(base[q] - abl[q] for q in qids),
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -219,6 +338,9 @@ def main() -> int:
     ap.add_argument("--exclude-floor", type=float, default=None, metavar="N",
                     help="also auto-drop every question whose BASELINE metric is <= N "
                          "(bounces up under ablation → variance, no signal). Try 12.")
+    ap.add_argument("--exact-tolerance", type=float, default=0.10, metavar="FRAC",
+                    help="relative tolerance for factoid exact-answer matching (default 0.10 "
+                         "= within 10%%; absorbs live-DB drift from the frozen gold count).")
     args = ap.parse_args()
     exclude = set(args.exclude)
 
@@ -257,6 +379,10 @@ def main() -> int:
     # ablation below. Empty when no per-run/merged answer data carries tools_used.
     base_effort = load_effort("baseline", results)
 
+    # Exact-answer correctness baseline (secondary, lower-variance quality lens).
+    gold = load_gold()
+    base_correct = load_correctness("baseline", gold, args.exact_tolerance, results)
+
     rows = []
     for section in CANONICAL_SECTIONS:
         csv_path = results / f"ablate_{section}-scored.csv"
@@ -292,6 +418,15 @@ def main() -> int:
         row["delta_tools"] = None if eff is None else round(eff["delta_n_tools"], 2)
         row["delta_wall_s"] = None if eff is None else round(eff["delta_wall_s"], 1)
         row["delta_cost"] = None if eff is None else round(eff["delta_cost"], 4)
+
+        # Exact-answer correctness delta (secondary quality lens): baseline − ablated.
+        cor = paired_correctness(base_correct,
+                                 load_correctness(f"ablate_{section}", gold,
+                                                  args.exact_tolerance, results), exclude)
+        row["correct_baseline"] = None if cor is None else round(cor["base"], 3)
+        row["correct_ablated"] = None if cor is None else round(cor["abl"], 3)
+        row["correct_contribution"] = None if cor is None else round(cor["contribution"], 3)
+        row["n_correct"] = None if cor is None else cor["n"]
         rows.append(row)
 
     if not rows:
@@ -303,6 +438,7 @@ def main() -> int:
     fieldnames = ["section", "spotlight", "n", "mean_baseline", "mean_ablated",
                   "contribution", *[f"delta_{m}" for m in SUBMETRICS],
                   "delta_sparql", "pct_sparql", "delta_tools", "delta_wall_s", "delta_cost",
+                  "correct_baseline", "correct_ablated", "correct_contribution", "n_correct",
                   "n_relevant", "contribution_relevant"]
     with out_csv.open("w", newline="", encoding="utf-8") as fh:
         w = csv.DictWriter(fh, fieldnames=fieldnames)
@@ -311,13 +447,18 @@ def main() -> int:
 
     base_vals = [r[metric] for r in baseline.values() if r.get(metric) is not None]
     base_mean = mean(base_vals) if base_vals else float("nan")
-    write_report(rows, results / "ablation_report.md", metric, base_mean, len(baseline))
+    base_correct_overall = mean(base_correct.values()) if base_correct else None
+    write_report(rows, results / "ablation_report.md", metric, base_mean, len(baseline),
+                 base_correct_overall)
 
     # console summary
     has_effort = any(r.get("delta_sparql") is not None for r in rows)
+    has_correct = any(r.get("correct_contribution") is not None for r in rows)
     hdr = f"{'section':28s} {'spot':4s} {'n':>3s} {'base':>6s} {'abl':>6s} {'contrib':>8s}"
     if has_effort:
         hdr += f" {'Δsparql':>8s} {'Δcost$':>7s}"
+    if has_correct:
+        hdr += f" {'Δcorr':>7s}"
     print(hdr)
     for r in rows:
         spot = "yes" if r["spotlight"] != "-" else ""
@@ -326,6 +467,9 @@ def main() -> int:
                 f"{_fmt(r['contribution']):>8s}")
         if has_effort:
             line += f" {_fmt(r.get('delta_sparql')):>8s} {_fmt(r.get('delta_cost'), '+.3f'):>7s}"
+        if has_correct:
+            cc = r.get("correct_contribution")
+            line += f" {('n/a' if cc is None else f'{cc*100:+.0f}pp'):>7s}"
         print(line)
     print(f"\nwrote {out_csv}")
     print(f"wrote {results / 'ablation_report.md'}")
@@ -333,7 +477,8 @@ def main() -> int:
 
 
 def write_report(rows: list[dict], path: Path, metric: str,
-                 base_mean: float, n_baseline_q: int) -> None:
+                 base_mean: float, n_baseline_q: int,
+                 base_correct: float | None = None) -> None:
     lines = [
         "# MIE Subcomponent Ablation — Contribution Report",
         "",
@@ -387,6 +532,33 @@ def write_report(rows: list[dict], path: Path, metric: str,
                 f"{('n/a' if pct is None else f'{pct:+.0f}%')} | "
                 f"{_fmt(r.get('delta_tools'))} | {_fmt(r.get('delta_wall_s'), '+.0f')} | "
                 f"{_fmt(r.get('delta_cost'), '+.3f')} |"
+            )
+
+    # Exact-answer correctness — secondary, lower-variance quality lens.
+    if any(r.get("correct_contribution") is not None for r in rows):
+        base_c = "" if base_correct is None else f" Baseline correctness: **{base_correct*100:.1f}%**."
+        lines += [
+            "",
+            "## Exact-answer correctness (secondary quality lens)",
+            "",
+            f"0/1 match of the answer against the question's `exact_answer` gold (list: "
+            f"fractional recall), paired per question; Δ = baseline − ablated in percentage "
+            f"points.{base_c} Lower variance than the graded score, but **read with care**: "
+            "`choice` sits near a 100% ceiling (no discrimination) and `factoid` stays "
+            "confounded by live-DB drift beyond the tolerance band — `yes_no`/`list` are the "
+            "cleaner bands.",
+            "",
+            "| Section | Baseline % | Ablated % | Δ correct (pp) | n |",
+            "|---|---:|---:|---:|---:|",
+        ]
+        for r in sorted(rows, key=lambda r: (r.get("correct_contribution") is None,
+                                             -(r.get("correct_contribution") or 0))):
+            cc, cb, ca = (r.get("correct_contribution"), r.get("correct_baseline"),
+                          r.get("correct_ablated"))
+            lines.append(
+                f"| `{r['section']}` | {('n/a' if cb is None else f'{cb*100:.1f}')} | "
+                f"{('n/a' if ca is None else f'{ca*100:.1f}')} | "
+                f"{('n/a' if cc is None else f'{cc*100:+.1f}')} | {r.get('n_correct', '-')} |"
             )
 
     lines += [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "1.5.0"
+version = "1.6.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1070,6 +1070,10 @@
         <div class="db-card-desc">NLM's Medical Subject Headings — controlled vocabulary for biomedical literature indexing, with hierarchical descriptors and qualifiers across 16 main categories.</div>
       </div>
       <div class="db-card">
+        <div class="db-card-name">Ontology Graphs</div>
+        <div class="db-card-desc">Cross-ontology term resolution and hierarchy expansion over 37 ontology graphs — 785,551 classes covering HP, UBERON, CL, SO, ECO, EFO, PRO and FMA. Resolves opaque IRIs to labels and expands subtrees for joins against co-located data.</div>
+      </div>
+      <div class="db-card">
         <div class="db-card-name">NCBI Taxonomy</div>
         <div class="db-card-desc">Biological taxonomic classification covering 3M+ organisms from bacteria to mammals, with hierarchical relationships, scientific names, and genetic code assignments.</div>
       </div>

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -37,9 +37,9 @@ schema_info:
     - search_chembl_molecule
     - search_chembl_target
   version:
-    mie_version: "3.3"
+    mie_version: "3.4"
     mie_created: "2025-02-10"
-    mie_updated: "2026-07-14"
+    mie_updated: "2026-07-16"
     data_version: ChEMBL 34.0
     update_frequency: Quarterly
   license:
@@ -98,11 +98,22 @@ critical_warnings: |
     (no exact FILTER — descriptions are free text): ?a a cco:Assay ; dcterms:description ?d . ?d
     bif:contains "acetylcholinesterase" . Tissues use dcterms:title for the same role; CellLines use
     dcterms:description.
-  - XSD:STRING TYPING (exact match): rdfs:label, skos:prefLabel, skos:altLabel, dcterms:description
-    and the identifier sio:SIO_000300 values are stored as typed xsd:string. A plain-literal exact
-    match — FILTER(?label = "Liver") or VALUES ?label { "Liver" } — joins to NOTHING. Use STR()-based
-    comparison (FILTER(STR(?label) = "Liver")) or append ^^xsd:string. Numeric sio:SIO_000300 values
-    (full_mwt, alogp, psa, ...) are xsd:double, not string — cast accordingly.
+  - STRING LITERALS ARE PLAIN — DO NOT ADD ^^xsd:string (exact-match trap). rdfs:label,
+    skos:prefLabel, skos:altLabel, dcterms:description and the string-valued sio:SIO_000300
+    (canonical_smiles, ...) are stored as PLAIN literals. Appending ^^xsd:string matches NOTHING.
+    VERIFIED 2026-07-16, each by a two-form ASK:
+      rdfs:label     "Aminopeptidase N" -> matches; "Aminopeptidase N"^^xsd:string -> 0 rows
+      skos:prefLabel "CETIRIZINE"       -> matches; "CETIRIZINE"^^xsd:string       -> 0 rows
+      sio:SIO_000300 "O"                -> matches; "O"^^xsd:string                -> 0 rows
+    DO NOT be misled by a DATATYPE() probe: it reports xsd:string for these (RDF 1.1 treats a
+    plain literal and an xsd:string-typed one as the same VALUE), but Virtuoso matches TERMS, so
+    the two do not unify — in a triple pattern OR in FILTER(?x = ...). An earlier version of this
+    file inverted exactly this and told callers to append ^^xsd:string, which returns 0 rows.
+    Use the PLAIN form, or FILTER(STR(?label) = "Liver") if you want to be form-agnostic.
+    Numeric sio:SIO_000300 values (full_mwt, alogp, psa, ...) are genuinely xsd:double — that IS
+    visible to DATATYPE() — so cast accordingly; isNumeric(?v) separates them from the strings.
+    NOTE this is why the Reactome bridge below uses STRDT: Reactome DOES store typed xsd:string,
+    so crossing ChEMBL (plain) -> Reactome (typed) requires an explicit re-type.
 
 shape_expressions: |
   PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -53,6 +53,12 @@ schema_info:
     - tissue expression
     - human protein atlas
     - hpa
+    - lectin name
+    - lectin grounding
+    - carbogrove
+    - lfdb
+    - unilectin
+    - agglutinin
   categories:
     - glycan
     - disease
@@ -105,6 +111,8 @@ schema_info:
     - http://rdf.glytoucan.org/partner/bcsdb
     - http://rdf.glycosmos.org/glycans/glycobase
     - http://rdf.glycosmos.org/sugarbind
+    # Lectin-name grounding HUB: 5,100 curated GL lectins (rdfs:label + skos:altLabel) with
+    # rdfs:seeAlso → UniProt(100%)/UniLectin3D/CarboGrove/LfDB. (LectinHubShape)
     - http://rdf.glycosmos.org/lectin
     # ── CATALOG (present on the endpoint; not shaped here — probe before use) ───────
     # Glycan structure/derivation graphs:
@@ -143,8 +151,8 @@ schema_info:
     - http://purl.obolibrary.org/obo/eco.owl           # ~75k: Evidence & Conclusion Ontology
     - http://semanticscience.org/ontology/sio.owl      # ~16k: SIO upper ontology
     # Lectin / binding / array graphs:
-    - http://rdf.glycosmos.org/carbogrove              # ~1.3M: CarboGrove glycan-array binding
-    - http://rdf.glycoinfo.org/lfdb                    # ~266k: Lectin Frontier DB (LfDB) affinities
+    - http://rdf.glycosmos.org/carbogrove              # ~1.3M: CarboGrove glycan-array binding; lectin names on cg:LectinName/cg:CommonName (CarboGroveLectinShape)
+    - http://rdf.glycoinfo.org/lfdb                    # ~266k: Lectin Frontier DB (LfDB) affinities; lectin names on lfdb:has_lectin_name (LfdbLectinShape)
     - http://rdf.glycoinfo.org/gpdb2gtc                # GlycoProtDB↔GlyTouCan mapping
     # Species-/domain-specific glyco graphs (glycoinfo.org partners):
     - http://rdf.glycoinfo.org/gdgdb                   # GDGDB (glyco-disease genes)
@@ -161,9 +169,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "4.1"
+    mie_version: "4.2"
     mie_created: "2026-07-01"
-    data_version: "2025.04 snapshot (glycan/protein counts verified 2026-06-27; disease/GO layer + gene-protein bridge verified 2026-07-01; CAZy + HPA-expression layers + full graph catalog added and verified 2026-07-01)"
+    data_version: "2025.04 snapshot (glycan/protein counts verified 2026-06-27; disease/GO layer + gene-protein bridge verified 2026-07-01; CAZy + HPA-expression layers + full graph catalog added and verified 2026-07-01; lectin-name grounding layer — GL hub + LfDB + CarboGrove — added and verified 2026-07-16)"
     update_frequency: "Quarterly"
   access:
     backend: "Virtuoso (bif:contains IS enabled — verified 2026-06-27)"
@@ -272,6 +280,9 @@ shape_expressions: |
   PREFIX gn: <http://glyconavi.org/owl#>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX glycodm: <http://glycodm/ontology#>   # note: non-dereferenceable host, but this IS the stored namespace
+  PREFIX lfdb: <http://purl.jp/bio/12/lfdb/2014/7/owl#>          # Lectin Frontier DB (LfDB) 2014 ontology
+  PREFIX cg: <http://rdf.glycoinfo.org/carbogrove/Ontology#>     # CarboGrove ontology (note: /Ontology# with capital O)
+  PREFIX sb: <http://rdf.glycoinfo.org/SugarBind/ontology#>      # SugarBind ontology — the sb:Lectin class (used by the GL hub AND CarboGrove)
 
   # 117,864 glycans. Entity IRI: <http://rdf.glycoinfo.org/glycan/G[0-9]{5}[A-Z]{2}>
   # type + has_primary_id live in <http://rdf.glytoucan.org/core>.
@@ -447,6 +458,60 @@ shape_expressions: |
     a [ <http://purl.jp/bio/12/glyco/glycan/saccharide> ] ;
     rdfs:label xsd:string ;                      # "saccharide <trivialName>"
     <http://purl.jp/bio/12/glyco/glycan/has_glycosequence> IRI *   # sequence node(s)
+  }
+
+  # ── LECTIN-NAME GROUNDING (three tiers; START at the hub) ─────────────────────
+  # 5,100 curated GlyCosmos lectins — the PRIMARY lectin-name index and the place to START a
+  # name→ID lookup. Entity IRI: <http://glycosmos.org/lectin/GL_[0-9]{6}>. In
+  # <http://rdf.glycosmos.org/lectin>. Typed sb:Lectin (SugarBind ontology class). Unlike LfDB /
+  # CarboGrove below, names are on STANDARD predicates (rdfs:label + skos:altLabel), and rdfs:seeAlso
+  # fans out to UniProt (100% of labeled lectins), UniLectin3D, CarboGrove, and LfDB — so ONE name
+  # lookup yields the UniProt AC plus every source-DB ID. This is the lectin→protein handoff.
+  <LectinHubShape> {
+    a [ sb:Lectin ] ;
+    rdfs:label xsd:string ? ;                    # full lectin name e.g. "Concanavalin-A"; 99.9% (5,095/5,100); xsd:string typed
+    skos:altLabel xsd:string * ;                 # abbreviations/synonyms e.g. "ABL","jacalin","ConA"; 126 lectins, 241 values; xsd:string
+    glycan:has_taxon IRI ? ;                      # <http://identifiers.org/taxonomy/[taxid]>; 99.9% (5,095)
+    rdfs:seeAlso IRI + ;                          # 100% (5,100); POLYMORPHIC handoff (5,856 links): UniProt
+                                                 #   <http://purl.uniprot.org/uniprot/[AC]> (5,095=100%), UniLectin3D
+                                                 #   <https://unilectin.unige.ch/rdf/…> (595), CarboGrove
+                                                 #   <http://rdf.glycoinfo.org/dbid/carbogrove/[AC]> (82), LfDB <http://acgg.asia/lfdb2/LfDB####> (81)
+    dcterms:references IRI * ;                    # PubMed evidence <http://identifiers.org/pubmed/[PMID]>; 326 links
+    <http://mcawdb.glycoinfo.org/term#has_mcawdb_resource> IRI *   # MCAW-DB glycan-alignment resource; 140
+  }
+
+  # SOURCE DB — Lectin Frontier DB (LfDB). 398 lectins. Entity IRI: <http://acgg.asia/lfdb2/LfDB[0-9]{4}>.
+  # In <http://rdf.glycoinfo.org/lfdb>. The lectin NAME is on the BESPOKE predicate lfdb:has_lectin_name
+  # (473 names over 398 lectins, incl. short names like "RSL") — there is NO rdfs:label here, so a naive
+  # rdfs:label lookup returns 0. bif:contains the name literal to ground. seeAlso goes to PDB/Pfam/INSDC,
+  # NOT UniProt (reach a protein via the GL hub, or via PDB/INSDC here).
+  <LfdbLectinShape> {
+    a [ glycan:Lectin ] ;
+    dcterms:identifier xsd:string ;              # LfDB ID e.g. "LfDB0001"; 100% (398); xsd:string (also encoded in the IRI)
+    lfdb:has_lectin_name xsd:string + ;          # NAME→ID target; 473 over 398 (multi-valued); xsd:string; e.g. "Annexin IV","RSL"
+    up:organism IRI ;                            # 100% (398) → a <…/LfDB####/#taxon> organism node (not an identifiers.org taxon IRI)
+    lfdb:has_number_of_CRDs xsd:int ;            # 100% (398); carbohydrate-recognition-domain count; xsd:int (NOT xsd:integer)
+    lfdb:in_pfam_family IRI ? ;                   # 297; Pfam family IRI
+    lfdb:has_monosaccharide_specificity IRI ? ;  # 231; → MonosaccharideDB IRI (an IRI, NOT a string)
+    glycan:has_AA_sequence xsd:string ? ;        # 96; amino-acid sequence; xsd:string
+    glycan:published_in IRI ? ;                  # 106; citation/journal node
+    dcterms:image IRI ? ;                        # 216; depiction image
+    rdfs:seeAlso IRI *                           # 913 over 398; POLYMORPHIC: PDB <http://identifiers.org/pdb/> (371),
+                                                 #   Pfam <http://identifiers.org/pfam/> (299), INSDC <http://identifiers.org/insdc/> (243) — NOT UniProt
+    # (also carries boilerplate dcterms:publisher/hasVersion/license, 398 each — metadata, omitted)
+  }
+
+  # SOURCE DB — CarboGrove (glycan-array binding). 200 lectin entities; 100 carry curated names.
+  # Entity IRI: <http://rdf.glycoinfo.org/dbid/carbogrove/[UniProtAC]> — UniProt-AC-keyed, so the IRI
+  # accession IS the UniProt link (no seeAlso hop needed). In <http://rdf.glycosmos.org/carbogrove>.
+  # Typed sb:Lectin (same SugarBind class as the hub). Names are on BESPOKE predicates cg:LectinName /
+  # cg:CommonName (NOT rdfs:label). The PubDictionaries `lectin-name_carbogrove` set mirrors these.
+  <CarboGroveLectinShape> {
+    a [ sb:Lectin ] ;
+    cg:LectinName xsd:string * ;                 # full name e.g. "Datura Stramonium Agglutinin"; 103 over 100 lectins (50%); xsd:string
+    cg:CommonName xsd:string * ;                 # abbreviation e.g. "DSA","ConA","RSL"; 103 over 100 lectins; xsd:string
+    cg:ResultID IRI * ;                          # 367; glycan-array binding-result nodes <…/carbogrove/result/[N]>
+    rdfs:seeAlso IRI ?                            # 100/200; → other carbogrove nodes (self-refs), not UniProt
   }
 
 sample_rdf_entries:
@@ -830,6 +895,49 @@ sparql_query_examples:
       }
       LIMIT 50
 
+  - title: Ground a lectin name to a UniProt AC + source-DB IDs via the GL hub
+    description: |
+      The PRIMARY lectin-name lookup. The curated GL lectins in <http://rdf.glycosmos.org/lectin>
+      carry the name on the STANDARD rdfs:label (and abbreviations on skos:altLabel), so bif:contains
+      resolves a free-text lectin name to a GL_###### hub entity; rdfs:seeAlso then hands off to the
+      UniProt AC (present for 100% of labeled lectins) plus the LfDB / CarboGrove / UniLectin3D source
+      IDs. One query grounds the name AND yields every cross-reference — no bespoke predicate needed.
+    question: What is the UniProt accession (and source-DB IDs) for concanavalin lectins?
+    complexity: intermediate
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX sb: <http://rdf.glycoinfo.org/SugarBind/ontology#>
+
+      SELECT DISTINCT ?lectin ?label ?xref
+      FROM <http://rdf.glycosmos.org/lectin>
+      WHERE {
+        ?lectin a sb:Lectin ;
+                rdfs:label ?label .
+        ?label bif:contains "'Concanavalin'" .
+        OPTIONAL { ?lectin rdfs:seeAlso ?xref }
+      }
+      LIMIT 30
+
+  - title: Ground a lectin name (or synonym) directly in LfDB
+    description: |
+      LfDB carries the lectin name on the BESPOKE predicate lfdb:has_lectin_name (473 names over 398
+      lectins, incl. short names like "RSL") — there is NO rdfs:label path, so this is the only direct
+      grounding route into LfDB. bif:contains (Virtuoso, enabled) the name literal to resolve a free-text
+      lectin name/synonym to an LfDB ID <http://acgg.asia/lfdb2/LfDB####>. (For a UniProt handoff, prefer
+      the GL-hub query above; LfDB's own seeAlso targets are PDB/Pfam/INSDC, not UniProt.)
+    question: What is the LfDB lectin ID for annexin lectins?
+    complexity: basic
+    sparql: |
+      PREFIX lfdb: <http://purl.jp/bio/12/lfdb/2014/7/owl#>
+
+      SELECT DISTINCT ?lectin ?name
+      FROM <http://rdf.glycoinfo.org/lfdb>
+      WHERE {
+        ?lectin lfdb:has_lectin_name ?name .
+        ?name bif:contains "'Annexin'" .
+      }
+      LIMIT 20
+
 cross_database_queries:
   shared_endpoint: glycosmos
   co_located_databases: [glycosmos]
@@ -923,6 +1031,23 @@ cross_references:
       lipid:
         - "LipidMaps (lipidmaps.org/rdf/<LM_ID>) + PubChem Compound (rdf.glycoinfo.org/pubchem/compound/CID<n>)"
 
+  - pattern: lectin names — GL hub (standard predicates) + LfDB + CarboGrove (bespoke); name→UniProt handoff
+    description: |
+      Lectin name→ID grounding lives in three tiers. START at the HUB: the lectin graph's curated GL
+      lectins carry the name on STANDARD rdfs:label + skos:altLabel and rdfs:seeAlso out to UniProt (100%
+      of labeled lectins), UniLectin3D, CarboGrove, and LfDB — so a single name lookup grounds the name
+      AND returns the UniProt AC and every source-DB ID. The two source DBs put names on BESPOKE
+      predicates (no rdfs:label): LfDB lfdb:has_lectin_name (473 names / 398 lectins, incl. short names)
+      and CarboGrove cg:LectinName / cg:CommonName (100 of 200 lectins; the PubDictionaries
+      `lectin-name_carbogrove` set mirrors these). CarboGrove entity IRIs are UniProt-AC-keyed.
+    databases:
+      hub:
+        - "GL hub: <http://rdf.glycosmos.org/lectin> <http://glycosmos.org/lectin/GL_######> (sb:Lectin, 5,100); rdfs:label (5,095) + skos:altLabel (126)"
+        - "hub seeAlso: UniProt purl.uniprot.org/uniprot/<AC> (5,095=100%), UniLectin3D (595), CarboGrove dbid/carbogrove/<AC> (82), LfDB acgg.asia/lfdb2/LfDB#### (81)"
+      source:
+        - "LfDB: <http://rdf.glycoinfo.org/lfdb> lfdb:has_lectin_name (473/398); seeAlso → PDB/Pfam/INSDC"
+        - "CarboGrove: <http://rdf.glycosmos.org/carbogrove> cg:LectinName / cg:CommonName (103 each / 100 lectins); IRI keyed by UniProt AC"
+
 architectural_notes:
   query_strategy:
     - "MANDATORY FIRST STEP: get_MIE_file('glycosmos'); read critical_warnings (predicate-case trap, dual motif IRI, sio:SIO_000255 dual use, multi-species disease genes)"
@@ -937,18 +1062,16 @@ architectural_notes:
     - "CAZy family→protein: INDIRECT — family rdfs:seeAlso ?gb; ?gb owl:sameAs ?emblcds; ?prot rdfs:seeAlso ?emblcds (no direct link)"
     - "CAZy proteins have NO has_taxon — filter the genbank member node for organism, not the up:Protein"
     - "Tissue expression: HPA graph (glycodm:tissue/cellType/level); join glycogene→HPA by SYMBOL (glycodm:geneSymbol == glycogene rdfs:label)"
+    - "Lectin name→ID grounding — START at the hub: <http://rdf.glycosmos.org/lectin> GL lectins (<…/GL_######>, sb:Lectin, 5,100) carry rdfs:label + skos:altLabel (STANDARD) and rdfs:seeAlso → UniProt(100%)/UniLectin3D/CarboGrove/LfDB. bif:contains the label; one lookup yields the UniProt AC + every source-DB ID."
+    - "Direct into the bespoke source DBs (NO rdfs:label — naive rdfs:label search returns 0): LfDB lfdb:has_lectin_name (<http://rdf.glycoinfo.org/lfdb>, 473/398, incl. short names; seeAlso→PDB/Pfam/INSDC not UniProt); CarboGrove cg:LectinName/cg:CommonName (<http://rdf.glycosmos.org/carbogrove>, 100/200; IRI is UniProt-AC-keyed). lfdb:=…/lfdb/2014/7/owl#, cg:=…/carbogrove/Ontology#."
     - "Entity IRIs use http://glycosmos.org/ (proteins/sites/genes/diseases); graphs use http://rdf.glycosmos.org/"
     - "Organisms: specific taxonomy IRIs (human=9606, mouse=10090, rat=10116, arabidopsis=3702)"
     - "Priority: Specific IRIs > VALUES with IRIs > typed predicates / graph navigation > bif:contains > FILTER(CONTAINS())"
 
-  schema_design:   # per-graph shapes are in shape_expressions; only cross-graph facts here
-    - "ENTITY base http://glycosmos.org/ (proteins/sites/genes/diseases/glycolipids) ≠ GRAPH base http://rdf.glycosmos.org/; glycans/motifs use http://rdf.glycoinfo.org/"
-    - "sio:SIO_000255 is REUSED: disease graph → gene link (sio:SIO_000001); glycogenes graph → GO term (up:classifiedWith). Both attribute bnodes are untyped"
-    - "Glycogene↔glycoprotein bridge: shared <http://purl.uniprot.org/geneid/[GeneID]> node (glycogene rdfs:seeAlso ↔ UniProt IRI rdfs:seeAlso)"
-    - "CAZy family↔protein bridge: family rdfs:seeAlso genbank/<ACC> owl:sameAs embl-cds/<ACC> ← protein rdfs:seeAlso (no direct link)"
-    - "HPA↔glycogene bridge: HPA glycodm:geneSymbol == glycogene rdfs:label (Ensembl-keyed HPA vs NCBI-GeneID glycogene)"
-    - "Ontology labels live in separate graphs: DOID→obo/doid, GO→obo/go.owl; entity nodes carry no label"
-    - "Taxonomy IRI pattern: <http://identifiers.org/taxonomy/[NCBI_TaxID]> (human=9606, mouse=10090, rat=10116, arabidopsis=3702)"
+  schema_design:   # cross-graph structural facts; per-graph shapes are in shape_expressions, operational steps in query_strategy
+    - "ENTITY base http://glycosmos.org/ (proteins/sites/genes/diseases/glycolipids) ≠ GRAPH base http://rdf.glycosmos.org/; glycans/motifs use http://rdf.glycoinfo.org/; ontology labels live in obo/doid & obo/go.owl (entity nodes carry no label)"
+    - "sio:SIO_000255 is REUSED: disease graph → gene (sio:SIO_000001); glycogenes graph → GO (up:classifiedWith). Both attribute bnodes are untyped"
+    - "Internal join bridges: glycogene↔glycoprotein via shared <http://purl.uniprot.org/geneid/[ID]>; CAZy family↔protein via genbank/<ACC> owl:sameAs embl-cds/<ACC>; HPA↔glycogene via glycodm:geneSymbol == glycogene rdfs:label; lectin GL-hub↔source via rdfs:seeAlso"
 
   performance:
     - "Pin FROM <graph> (or GRAPH <graph>) for class-wide scans; the endpoint hosts 140+ graphs"
@@ -959,20 +1082,15 @@ architectural_notes:
 
   # (data_integration removed in v4.1 — see cross_references for the full xref map.)
 
-  data_quality:
-    - "GlyTouCan IDs: pattern G[0-9]{5}[A-Z]{2}; has_primary_id 99.75%"
-    - "Labels well populated: glycoprotein 90.8%, glycogene 100% (label/description/taxon). Glycan rdfs:label <1% — use has_primary_id"
-    - "Glycoprotein/glycogene taxon coverage 90.8% / 100% — taxon filtering is reliable"
-    - "GO annotation coverage on glycogenes: 97.8% (413,865/423,164) carry ≥1 up:classifiedWith term"
-    - "Every disease (4,372) has ≥1 gene link, but gene sets are MULTI-SPECIES — always taxon-filter for a single organism"
-    - "Disease and GO attribute bnodes are UNTYPED — reachable only via the parent + sio:SIO_000255"
-    - "Site position data: 98.3% have faldo:ExactPosition"
-    - "Multi-valued labels: motifs (e.g. G00031MO has 3) and ChEBI Resource_entry (name + 'ChEBI') — use DISTINCT"
-    - "Counts may shift between quarterly releases — re-verify with COUNT if precision is needed"
+  data_quality:   # coverage figures live in data_statistics; only non-obvious query-affecting facts here
+    - "Glycan rdfs:label is <1% populated — key glycans by glytoucan:has_primary_id (99.75%; pattern G[0-9]{5}[A-Z]{2}), not label"
+    - "Disease→gene sets are MULTI-SPECIES — always taxon-filter (has_taxon 9606); disease & GO attribute bnodes are UNTYPED (reach via parent + sio:SIO_000255)"
+    - "Multi-valued labels: motifs (G00031MO has 3), ChEBI Resource_entry (name + 'ChEBI'), lectin skos:altLabel / has_lectin_name — use DISTINCT/aggregate"
+    - "Counts may shift between quarterly releases — re-COUNT if precision matters"
 
   text_search_justification:
-    - "Number of the 10 example queries using text search: 0 — every concept used has a structured IRI or typed predicate (CAZy class/family, HPA symbol/level, disease DOID, GO term all keyed)"
-    - "Legitimate text-search fields IF needed: rdfs:label/skos:altLabel on glycan:Glycan_epitope (free-text names like 'Lewis x'); dcterms:description on glycan:Glycogene and CAZy families (enzyme activities); disease/GO labels in obo/doid & obo/go.owl"
+    - "Number of the 12 example queries using text search: 2 — both are lectin-NAME grounding (GL-hub rdfs:label and LfDB lfdb:has_lectin_name). This is the one place text search is unavoidable: a lectin name/synonym is a free-text human label with no controlled-vocabulary IRI to look it up by, so grounding the name via bif:contains IS the entry point. Every OTHER concept (CAZy class/family, HPA symbol/level, disease DOID, GO term) has a structured IRI or typed predicate and uses no text search."
+    - "Legitimate text-search fields: lectin names (GL-hub rdfs:label/skos:altLabel; LfDB lfdb:has_lectin_name; CarboGrove cg:LectinName/cg:CommonName); rdfs:label/skos:altLabel on glycan:Glycan_epitope (free-text names like 'Lewis x'); dcterms:description on glycan:Glycogene and CAZy families (enzyme activities); disease/GO labels in obo/doid & obo/go.owl"
     - "bif:contains is enabled (verified 2026-06-27): use ?label bif:contains \"'Lewis'\" for indexed search; FILTER(CONTAINS()) only as fallback"
     - "Organisms, motifs, chemicals, proteins, genes, diseases (DOID), and GO terms all have specific IRIs — text search is not needed for them"
 
@@ -989,8 +1107,8 @@ data_statistics:
     cazy_enzyme_sequences: 869966
     glycolipids: 6046
     hpa_expression_genes: 13468
-  verified_date: "2026-06-27 (glycan/protein/gene); 2026-07-01 (diseases, CAZy, HPA, glycolipid)"
-  verification_method: "Direct COUNT(DISTINCT) queries on each named graph"
+  verified_date: "2026-06-27 (glycan/protein/gene); 2026-07-01 (diseases, CAZy, HPA, glycolipid); 2026-07-16 (lectin grounding)"
+  verification_method: "Direct COUNT(DISTINCT) queries on each named graph (applies to every block below)"
   coverage:
     glycans_with_primary_id: "99.75% (117,571/117,864)"
     glycans_with_self_resource_entry_capital: "86.2% (101,600/117,864)"
@@ -1000,30 +1118,27 @@ data_statistics:
     glycogenes_with_label_description_taxon: "100% (423,164/423,164)"
     glycogenes_with_go_annotation: "97.8% (413,865/423,164)"
     sites_with_position_data: "98.3% (407,793/414,798)"
-    verified_date: "2026-06-27 (glycan/protein); 2026-07-01 (GO coverage)"
   cazy_layer:
     families: 821
     families_by_class: { GH: 430, GT: 135, PL: 107, CBM: 102, AA: 27, CE: 20 }
     enzyme_sequences: 869966
     sequences_with_ec: 357511
     example_GH13_alpha_amylase_proteins: 2867
-    verified_date: "2026-07-01"
-    verification_method: "COUNT(DISTINCT) on the cazy graph; family→protein via genbank/embl-cds bridge"
   hpa_expression_layer:
     genes: 13468
     expression_measurement_bnodes: 1195665
     levels: ["High", "Medium", "Low", "Not detected"]
     example_INSR_tissues: 43
-    verified_date: "2026-07-01"
-    verification_method: "COUNT on the HPA graph; gene keyed by Ensembl Gene ID + glycodm:geneSymbol"
   disease_layer:
     disease_entities: 4372
     disease_gene_links: 26827
-    example_doid_9352_type2_diabetes:
-      genes_all_species: 326
-      genes_human_only: 129
-    verified_date: "2026-07-01"
-    verification_method: "COUNT(DISTINCT) on the disease graph; human count via join to glycogenes has_taxon 9606"
+    example_doid_9352_type2_diabetes: { genes_all_species: 326, genes_human_only: 129 }
+  lectin_name_grounding_layer:
+    gl_hub_lectins: 5100                 # <http://rdf.glycosmos.org/lectin>, sb:Lectin, GL_###### IRIs
+    gl_hub_with_rdfs_label: 5095         # 99.9%; + skos:altLabel on 126 (241 values)
+    gl_hub_with_uniprot_seealso: 5095    # 100% of labeled → uniprot/<AC>; seeAlso also → CarboGrove(82), LfDB(81), UniLectin3D(595)
+    lfdb_lectins: 398                    # <http://rdf.glycoinfo.org/lfdb>, glycan:Lectin; lfdb:has_lectin_name = 473 values (all ≥1)
+    carbogrove_lectin_entities: 200      # <http://rdf.glycosmos.org/carbogrove>, sb:Lectin; cg:LectinName/CommonName on 100 (103 values each)
   external_xref_glycan_counts:
     pubchem_compound: 31774
     pubchem_substance: 31774
@@ -1035,14 +1150,12 @@ data_statistics:
     bcsdb: 5448
     hmdb: 276
     glycoshape: 217
-    verified_date: "2026-06-27"
   sequence_format_nodes:
     wurcs: 254078
     iupac_extended: 193073
     iupac_condensed: 124929
     glycoct: 117466
     glycam_condensed: 25050
-    verified_date: "2026-06-27"
   species_distribution_glycoproteins:
     human_9606: 16604
     mouse_10090: 10713
@@ -1050,7 +1163,6 @@ data_statistics:
     arabidopsis_3702: 2251
     c_elegans_6239: 1447
     cow_9913: 1249
-    verified_date: "2026-06-27"
 
 anti_patterns:
   - title: "Schema Check Before Text Search"
@@ -1095,25 +1207,6 @@ anti_patterns:
       }
       LIMIT 20
     explanation: "The two predicates differ only by the case of 'Resource'. Capital = GlyTouCan self-ref; lowercase = external cross-references."
-
-  - title: "Joining the Two Motif IRI Forms Directly"
-    problem: "Trying to read a motif's label off the has_motif object IRI returns nothing — that IRI carries no label."
-    wrong_sparql: |
-      # WRONG: the glycan-form motif IRI has no rdfs:label in motif_label
-      ?glycan glycan:has_motif ?motif .
-      ?motif rdfs:label ?label .       # 0 rows: label is on http://glycoinfo.org/motif/[ID], not glycan/[ID]
-    correct_sparql: |
-      # CORRECT: bridge by GlyTouCan ID — has_motif uses glycan/ form, the label uses motif/ form
-      PREFIX glycan: <http://purl.jp/bio/12/glyco/glycan#>
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      SELECT DISTINCT ?label
-      FROM <http://rdf.glycosmos.org/glycans/motif_label>
-      WHERE {
-        <http://glycoinfo.org/motif/G00030MO> a <http://glyconavi.org/owl#Motif> ;
-            rdfs:label ?label .
-      }
-      LIMIT 10
-    explanation: "has_motif object = <http://rdf.glycoinfo.org/glycan/[ID]>; motif label lives on <http://glycoinfo.org/motif/[ID]>. Same ID suffix, different namespace — bridge, don't equate."
 
   - title: "Using TogoID or External UniProt to Link Glycogene ↔ Glycoprotein"
     problem: "Reaching for an external ID-conversion hop to connect a glycogene to its glycoprotein, when GlyCosmos already shares a join node internally."
@@ -1161,43 +1254,38 @@ anti_patterns:
       LIMIT 50
     explanation: "CAZy family and UniProt Protein are separate nodes joined only through GenBank/EMBL-CDS accessions (family rdfs:seeAlso genbank/<ACC> owl:sameAs embl-cds/<ACC> ← protein rdfs:seeAlso). Proteins carry EC (up:enzyme) but no family predicate and no taxon."
 
-common_errors:
-  - error: "Empty result fetching external glycan IDs, or a motif label"
-    causes:
-      - "Used has_Resource_entry (capital R) — returns only the GlyTouCan self-reference"
-      - "Restricted FROM to one graph while the external Resource_entry node lives in a partner graph"
-      - "Tried to read a motif label off the has_motif object IRI (wrong namespace)"
-    solutions:
-      - "Use LOWERCASE glycan:has_resource_entry for external DB IDs"
-      - "Omit FROM for a single-glycan xref fetch, or include the partner graphs (glycome-db, jcggdb_aist, bcsdb)"
-      - "Bridge motif IRIs by GlyTouCan ID: has_motif -> glycan/[ID]; label -> http://glycoinfo.org/motif/[ID]"
+  - title: "Searching rdfs:label for a Lectin Name in LfDB / CarboGrove"
+    problem: "LfDB and CarboGrove put lectin names on BESPOKE predicates, not rdfs:label — a naive rdfs:label search over those graphs returns 0, and the source graphs don't hand off to UniProt anyway."
+    wrong_sparql: |
+      # WRONG: LfDB lectins carry NO rdfs:label — 0 rows
+      SELECT ?lectin WHERE {
+        GRAPH <http://rdf.glycoinfo.org/lfdb> {
+          ?lectin a <http://purl.jp/bio/12/glyco/glycan#Lectin> ; rdfs:label ?l .
+          FILTER(CONTAINS(?l, "Concanavalin"))
+        }
+      }
+    correct_sparql: |
+      # CORRECT: START at the GL hub (standard rdfs:label) and follow rdfs:seeAlso to UniProt + source IDs
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX sb: <http://rdf.glycoinfo.org/SugarBind/ontology#>
+      SELECT DISTINCT ?lectin ?label ?xref
+      FROM <http://rdf.glycosmos.org/lectin>
+      WHERE {
+        ?lectin a sb:Lectin ; rdfs:label ?label .
+        ?label bif:contains "'Concanavalin'" .
+        OPTIONAL { ?lectin rdfs:seeAlso ?xref }
+      }
+      LIMIT 30
+    explanation: "The lectin graph's GL_###### hub uses standard rdfs:label + skos:altLabel and seeAlso-links to UniProt (100%), LfDB, CarboGrove, UniLectin3D. To search LfDB or CarboGrove directly, use their bespoke name predicates (lfdb:has_lectin_name; cg:LectinName/cg:CommonName), not rdfs:label."
 
-  - error: "Disease query returns mixed-species genes, over-counts, or shows no disease name"
-    causes:
-      - "Omitted the taxon filter — disease→gene sets mix human/mouse/rat (e.g. 326 vs 129 human for DOID:9352)"
-      - "Looked for rdfs:label on the disease entity — it has none"
-      - "Assumed sio:SIO_000255 means the same thing in the disease and glycogenes graphs"
-    solutions:
-      - "Join the gene into <…/glycogenes> and filter glycan:has_taxon <http://identifiers.org/taxonomy/9606>"
-      - "Get the disease name from obo:DOID_<n> rdfs:label in the <http://purl.obolibrary.org/obo/doid> graph"
-      - "Branch on the attribute bnode's inner predicate: sio:SIO_000001 = gene (disease graph); up:classifiedWith = GO (glycogenes graph)"
-
+common_errors:   # concrete wrong/correct SPARQL for each of these is in anti_patterns above
+  - error: "Empty external-glycan-ID or motif-label result"
+    fix: "Use LOWERCASE glycan:has_resource_entry (capital R = GlyTouCan self-ref only); for one glycan omit FROM or add partner graphs (glycome-db/jcggdb_aist/bcsdb). Motif label: bridge has_motif glycan/[ID] → <http://glycoinfo.org/motif/[ID]>."
+  - error: "Disease query over-counts, mixes species, or shows no disease name"
+    fix: "Join the gene into <…/glycogenes> + filter has_taxon 9606 (326→129 for DOID:9352); disease name is on obo:DOID_<n> in the doid graph; sio:SIO_000255 = gene in the disease graph but GO in the glycogenes graph."
   - error: "Empty CAZy protein list, or 'GlyCosmos has no expression data'"
-    causes:
-      - "Tried a direct family↔protein predicate — none exists; the join is via a GenBank/embl-cds bridge"
-      - "Filtered CAZy up:Protein by glycan:has_taxon — proteins carry no taxon (it is on the genbank member node)"
-      - "Believed HPA holds only ID cross-references — it actually holds IHC tissue/cell expression (glycodm:level)"
-    solutions:
-      - "Bridge: family rdfs:seeAlso genbank/<ACC> owl:sameAs embl-cds/<ACC> ← protein rdfs:seeAlso"
-      - "For CAZy family metadata use dbid/cazy/<FAM> (dcterms:title/description, rdfs:label=CAZy class)"
-      - "For expression query the HPA graph: gene glycodm:geneSymbol → rdfs:seeAlso bnode → glycodm:tissue/cellType/level; join to a glycogene by symbol"
-
-  - error: "Empty or wrong glycogene↔glycoprotein join, or timeout on a class-wide scan"
-    causes:
-      - "Tried to equate the NCBI GeneID IRI with a UniProt AC directly, or used TogoID instead of the internal bridge"
-      - "Missing FROM/GRAPH on a class-wide scan (140+ graphs), or wrong entity IRI base (rdf.glycosmos.org instead of glycosmos.org)"
-      - "No LIMIT on the 414K-site or 423K-gene graphs"
-    solutions:
-      - "Join on the shared <http://purl.uniprot.org/geneid/[GeneID]> node (glycogene rdfs:seeAlso ↔ UniProt IRI rdfs:seeAlso)"
-      - "Pin GRAPH/FROM <graph>; entities use http://glycosmos.org/, graphs use http://rdf.glycosmos.org/"
-      - "Add LIMIT; pre-filter by glycan:has_taxon or rdf:type before aggregation; nested SELECT for aggregations"
+    fix: "CAZy family→protein is INDIRECT (family rdfs:seeAlso genbank/<ACC> owl:sameAs embl-cds/<ACC> ← protein rdfs:seeAlso); CAZy proteins carry no taxon. HPA DOES hold IHC expression (glycodm:tissue/cellType/level) — join to a glycogene by symbol."
+  - error: "Empty/wrong glycogene↔glycoprotein join, or class-scan timeout"
+    fix: "Join on the shared <http://purl.uniprot.org/geneid/[GeneID]> node (never TogoID); pin GRAPH/FROM (entities use glycosmos.org, graphs use rdf.glycosmos.org); LIMIT + pre-filter big scans."
+  - error: "Zero rows searching a lectin name by rdfs:label in LfDB/CarboGrove"
+    fix: "Those use bespoke predicates (lfdb:has_lectin_name; cg:LectinName/cg:CommonName). Start at the GL hub (<http://rdf.glycosmos.org/lectin>, standard rdfs:label + skos:altLabel) and follow rdfs:seeAlso to UniProt + source IDs."

--- a/togo_mcp/data/mie/nando.yaml
+++ b/togo_mcp/data/mie/nando.yaml
@@ -31,9 +31,9 @@ schema_info:
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "2.1"
+    mie_version: "2.2"
     mie_created: "2025-04-21"
-    mie_updated: "2026-04-29"
+    mie_updated: "2026-07-16"
     data_version: Current release
     update_frequency: Quarterly
   license:
@@ -53,9 +53,16 @@ critical_warnings: |
   - ACTIVE DISEASE COUNT: Total owl:Class = 2,777; active (non-deprecated) = 2,769. Most queries
     should use the active set. Pre-filter with STRSTARTS(STR(?disease), "http://nanbyodata.jp/ontology/NANDO_")
     to exclude blank nodes and OWL scaffolding classes.
-  - skos:closeMatch COVERS MULTIPLE TARGETS: The 2,341 closeMatch triples include both MONDO
-    (2,150) and a small number of other targets. Always add
-    FILTER(STRSTARTS(STR(?match), "http://purl.obolibrary.org/obo/MONDO_")) when targeting MONDO.
+  - skos:closeMatch IS MANY-TO-MANY — COUNT(*) IS NOT A DISEASE COUNT: 2,341 closeMatch triples
+    span 2,150 distinct diseases and 1,572 distinct MONDO terms (verified 2026-07-16). 157 diseases
+    carry 2 MONDO mappings and 17 carry 3, so COUNT(*) over-reports diseases by 191 (+8.9%);
+    conversely 617 MONDO terms are each claimed by more than one NANDO disease, so the reverse
+    direction collapses. Use COUNT(DISTINCT ?disease) or COUNT(DISTINCT ?mondo) deliberately —
+    whichever side you actually mean.
+  - ALL closeMatch TARGETS ARE MONDO — 2,341 of 2,341, zero non-MONDO (verified 2026-07-16). The
+    FILTER(STRSTARTS(STR(?match), "http://purl.obolibrary.org/obo/MONDO_")) used in the examples
+    below is DEFENSIVE, not corrective: it is currently a no-op. Keep it so queries stay correct
+    if NANDO adds other targets, but do not expect it to remove any rows today.
 
 shape_expressions: |
   PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -234,7 +241,10 @@ sparql_query_examples:
       LIMIT 50
 
   - title: Find Diseases with MONDO Cross-References
-    description: Uses STRSTARTS to filter skos:closeMatch to MONDO-only targets; avoids returning non-MONDO closeMatch values.
+    description: >
+      All closeMatch targets are MONDO today, so the STRSTARTS filter is defensive (a no-op) rather
+      than corrective — it guards against NANDO adding other targets later. Note ?disease repeats
+      for the 174 diseases that carry 2-3 MONDO mappings; add DISTINCT if you want one row each.
     question: Which NANDO diseases have MONDO mappings for international harmonization?
     complexity: intermediate
     sparql: |
@@ -419,11 +429,12 @@ cross_references:
     description: |
       Semantic mapping to MONDO Disease Ontology for international harmonization.
       77% coverage enables Japanese researchers to access international disease resources.
-      2,341 total triples; 2,150 are MONDO targets; remaining are other ontologies.
-      Always add FILTER(STRSTARTS(STR(?match), "http://purl.obolibrary.org/obo/MONDO_")) for MONDO-only.
+      Many-to-many: 2,341 triples span 2,150 distinct diseases (77% of 2,777) and 1,572 distinct
+      MONDO terms — see critical_warnings before counting either side. All 2,341 targets are MONDO
+      (verified 2026-07-16); the STRSTARTS filter below is defensive, not corrective.
     databases:
       disease_ontologies:
-        - "MONDO: 2,150 mappings (77% of 2,777 diseases)"
+        - "MONDO: 2,150 diseases mapped (77% of 2,777) via 2,341 triples to 1,572 distinct MONDO terms"
     sparql: |
       PREFIX owl:  <http://www.w3.org/2002/07/owl#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/togo_mcp/data/mie/ontology.yaml
+++ b/togo_mcp/data/mie/ontology.yaml
@@ -5,11 +5,17 @@ schema_info:
     The primary endpoint hosts 37 named graphs under http://rdfportal.org/ontology/ carrying
     ~785,551 owl:Class definitions — HP, UBERON, CL, SO, ECO, EFO, PRO, FMA, CLO, EDAM, SIO,
     PO, XCO, CMO, MEO, MMO, UO — plus the GO/MONDO/taxonomy graphs and the glycordf/orth/piero
-    schema vocabularies. Use this entry to (1) resolve an opaque OBO IRI (SO_0000704,
-    RO_0002211) to a label/definition/synonym set, and (2) expand a term to its subsumption
-    subtree and JOIN that subtree against data co-located on the same endpoint — the one thing
-    OLS4 cannot do. For deep single-ontology work on GO, MONDO, or taxonomy use their own MIE
-    files (go, mondo, taxonomy); this entry covers the ~20 ontologies that have none.
+    schema vocabularies. Use this entry to (1) resolve an opaque IRI (SO_0000704, RO_0002211,
+    fma7088) to a label/definition/synonym set, and (2) expand a term to its subsumption subtree
+    and JOIN that subtree against data co-located on the same endpoint — the one thing OLS4
+    cannot do. For deep single-ontology work on GO, MONDO, or taxonomy use their own MIE files
+    (go, mondo, taxonomy); this entry covers the ~20 ontologies that have none.
+
+    READ THIS FIRST — two assumptions that look safe and are not:
+      1. NOT every ontology uses the obo namespace. EFO/SIO/EDAM/MEO/FMA do not — an obo-form
+         IRI returns ZERO rows for them. See schema_info.iri_namespaces + critical_warnings #1.
+      2. NOT every ontology uses the same predicates. FMA has no skos:notation, no oboInOwl:*
+         and no IAO_0000115 at all. See cross_references.predicate_by_ontology + FmaClassShape.
   keywords:
     - ontology
     - controlled vocabulary
@@ -18,8 +24,10 @@ schema_info:
     - iri resolution
     - subsumption hierarchy
     - subclass expansion
-    - phenotype
+    - partonomy
+    - part of
     - anatomy
+    - phenotype
     - cell type
     - evidence code
     - sequence feature type
@@ -29,25 +37,56 @@ schema_info:
   categories:
     - ontology
   endpoint: https://rdfportal.org/primary/sparql
+  # base_uri applies ONLY to the obo-based graphs below. It is NOT a global default —
+  # see iri_namespaces. Assuming it for EFO/SIO/EDAM/MEO/FMA yields a silent 0 rows.
   base_uri: http://purl.obolibrary.org/obo/
+  iri_namespaces:
+    obo_based:
+      - prefixes: [HP, GO, UBERON, CL, SO, ECO, PR, CLO, CMO, MMO, UO, PO, XCO, MONDO, NCBITaxon]
+        namespace: "http://purl.obolibrary.org/obo/"
+        curie_rule: "PREFIX_NNNNNNN — underscore, e.g. HP:0001250 -> obo/HP_0001250"
+    non_obo:
+      # VERIFIED 2026-07-16: an obo-form IRI returns 0 rows for every entry below.
+      - ontology: EFO
+        graph: efo
+        namespace: "http://www.ebi.ac.uk/efo/EFO_"
+        curie_rule: "EFO:0000305 -> ebi.ac.uk/efo/EFO_0000305 (underscore)"
+      - ontology: SIO
+        graph: sio
+        namespace: "http://semanticscience.org/resource/SIO_"
+        curie_rule: "SIO:000776 -> semanticscience.org/resource/SIO_000776 (underscore)"
+      - ontology: EDAM
+        graph: edam
+        namespace: "http://edamontology.org/"
+        curie_rule: "NO 'EDAM_' prefix exists. Terms are {data_,operation_,format_,topic_}NNNN,
+                     e.g. data_0863, operation_0477. The branch word IS part of the local name."
+      - ontology: MEO
+        graph: meo
+        namespace: "https://mdatahub.org/data/meo/MEO_"
+        curie_rule: "MEO:0000001 -> mdatahub.org/data/meo/MEO_0000001 (https, underscore)"
+      - ontology: FMA
+        graph: fma
+        namespace: "http://purl.org/sig/ont/fma/fma"
+        curie_rule: "FMA:7088 -> purl.org/sig/ont/fma/fma7088 — LOWERCASE 'fma', NO underscore.
+                     104,720 of fma's 104,721 owl:Class use this form (the 1 other is dcterms:Agent)."
   graphs:
     # --- Substantive ontologies WITHOUT their own MIE (this entry's primary scope) ---
     - http://rdfportal.org/ontology/pro            # PRotein Ontology — 365,852 classes (asserted)
     - http://rdfportal.org/ontology/pro-reasoned   # PRO inference closure — 13.8M triples (see critical_warnings)
-    - http://rdfportal.org/ontology/fma            # Foundational Model of Anatomy 5.0.0 — 104,721
-    - http://rdfportal.org/ontology/efo            # Experimental Factor Ontology 3.90.0 — 93,358
+    - http://rdfportal.org/ontology/fma            # Foundational Model of Anatomy 5.0.0 — 104,721 (NON-obo IRIs)
+    - http://rdfportal.org/ontology/efo            # Experimental Factor Ontology 3.90.0 — 93,358 (NON-obo IRIs)
     - http://rdfportal.org/ontology/clo            # Cell Line Ontology 2.1.188 — 43,327
     - http://rdfportal.org/ontology/uberon         # Uberon anatomy — 27,295
     - http://rdfportal.org/ontology/hp             # Human Phenotype Ontology 2026-06-06 — 23,829
     - http://rdfportal.org/ontology/cl             # Cell Ontology 2026-06-08 — 19,167
     - http://rdfportal.org/ontology/cmo            # Clinical Measurement Ontology 2026-05-30 — 4,149
-    - http://rdfportal.org/ontology/edam           # EDAM 1.26-unstable — 3,524
+    - http://rdfportal.org/ontology/edam           # EDAM 1.26-unstable — 3,524 (NON-obo IRIs)
     - http://rdfportal.org/ontology/so             # Sequence Ontology — 2,747
-    - http://rdfportal.org/ontology/meo            # Metagenome/Environment Ontology 1.0 — 2,390
+    - http://rdfportal.org/ontology/meo            # Metagenome/Environment Ontology 1.0 — 2,390 (NON-obo IRIs)
     - http://rdfportal.org/ontology/eco            # Evidence & Conclusion Ontology — 2,304
     - http://rdfportal.org/ontology/po             # Plant Ontology — 2,027
     - http://rdfportal.org/ontology/xco            # Experimental Condition Ontology 2026-06-06 — 1,839
-    - http://rdfportal.org/ontology/sio            # Semanticscience Integrated Ontology 1.61 — 1,585
+    - http://rdfportal.org/ontology/sio            # Semanticscience Integrated Ontology 1.61 — 1,585 (NON-obo IRIs)
     - http://rdfportal.org/ontology/mmo            # Measurement Method Ontology — 851
     - http://rdfportal.org/ontology/uo             # Units of measurement 2026-01-16 — 574
     # --- Schema vocabularies (predicates you USE, not terms you look up) ---
@@ -78,62 +117,134 @@ schema_info:
        BFO_0000050 in 10, RO_0002211 in 7. An unscoped lookup returns one row PER GRAPH."
     - "http://rdfportal.org/ontology/uberon, /cl, /po, /efo, /clo, /pro — assert rdfs:subClassOf
        edges on GO_/other foreign terms. Unscoped subtree expansion inherits them and returns a
-       DIFFERENT answer set, not merely inflated rows. See critical_warnings #2."
+       DIFFERENT answer set, not merely inflated rows. See critical_warnings."
+    - "http://rdf.glycosmos.org/glycogenes — 1,996,752 sio:SIO_000772 refs to 24 ECO terms.
+       The LARGEST ontology-to-data link on this endpoint. Hierarchy-aware; see cross_database_queries."
     - "https://pubcasefinder.dbcls.jp/rdf — 379,263 oa:hasBody annotations over 10,392 HP terms.
-       The richest join target on this endpoint; also carries Japanese (@ja) HP labels."
+       A rich, hierarchy-aware join target; also carries Japanese (@ja) HP labels."
+    - "http://nanbyodata.jp/ontology/nando — 2,341 skos:closeMatch to 1,572 MONDO terms.
+       Hierarchy-aware via <ontology/mondo>. Documented in full in the `nando` MIE — use that."
     - "http://rdfportal.org/dataset/open-tggates — cites UBERON, but only 2 terms (liver 20,415 /
        kidney 4,149). No hierarchy value."
-    - "http://rdfportal.org/dataset/hgnc — cites SO_0000704 ('gene') on 44,997 genes: a single flat
-       type tag, not a discriminative axis."
+    - "http://rdfportal.org/dataset/hgnc — cites SO_0000704 ('gene') via rdf:type on 44,997 genes:
+       a single flat type tag, not a discriminative axis."
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "1.0"
+    mie_version: "2.0"
     mie_created: "2026-07-16"
+    mie_updated: "2026-07-16"
     data_version: "Per-graph; see graphs list. Snapshot verified 2026-07-16."
     update_frequency: "Per upstream ontology release (OBO ontologies typically monthly)"
   access:
     backend: "Virtuoso"
 
 critical_warnings: |
-  - xsd:STRING EXACT-MATCH TRAP (the #1 silent failure): every literal here is stored as
-    xsd:string. A plain-literal match returns ZERO rows with no error.
-    WRONG:   ?t oboInOwl:hasExactSynonym "Epileptic seizure"        -> 0 rows
-    CORRECT: ?t oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string -> HP_0001250
-    Applies to rdfs:label, skos:notation, oboInOwl:hasExactSynonym, oboInOwl:id,
-    oboInOwl:hasOBONamespace, IAO_0000115. VALUES blocks are the highest-miss spot.
+  - NAMESPACE TRAP — obo IS NOT UNIVERSAL (the #1 silent failure). EFO, SIO, EDAM, MEO and FMA
+    do NOT use http://purl.obolibrary.org/obo/. An obo-form IRI for them returns ZERO rows, no
+    error. VERIFIED 2026-07-16: <obo/EFO_0022223>, <obo/FMA_7088>, <obo/SIO_000776>,
+    <obo/EDAM_0863>, <obo/MEO_0000001> -> 0 rows each; the real-namespace forms all resolve.
+    Build every IRI from schema_info.iri_namespaces. Worst offenders: FMA is lowercase with NO
+    underscore (FMA:7088 -> .../fma/fma7088); EDAM has no "EDAM_" prefix at all (data_0863).
+  - LITERAL FORM IS PER-GRAPH, AND DATATYPE() CANNOT TELL YOU WHICH. This is the single most
+    dangerous trap in this file, because the correct exact-match form is INVERTED between
+    graphs and every wrong form fails silently. There are THREE storage forms — VERIFIED
+    2026-07-16 by matching each form against a known term in each graph:
+      TYPED  (^^xsd:string matches; plain fails):  hp, go
+      PLAIN  (plain matches; ^^xsd:string FAILS):  uberon, cl, efo, edam, mondo
+      @en    (only "x"@en matches; both above fail): fma, sio, meo
+    Note hp/go (TYPED) and uberon/cl/mondo (PLAIN) are all on the SAME endpoint — the form is a
+    property of the GRAPH, not of the server. Probe each graph you match a literal in.
+    Evidence: HP_0001250 rdfs:label "Seizure"^^xsd:string -> MATCH but "Seizure" -> 0 rows;
+    UBERON_0002107 rdfs:label "liver" -> MATCH but "liver"^^xsd:string -> 0 rows; fma7088
+    rdfs:label "Heart"@en -> MATCH while BOTH "Heart" and "Heart"^^xsd:string -> 0 rows
+    (104,919 of fma's 104,936 labels are @en; only 17 are xsd:string).
+    DO NOT trust a DATATYPE() probe to decide: Virtuoso reports xsd:string for BOTH the typed
+    and the plain form (RDF 1.1 semantics), so the probe says "xsd:string" for hp AND efo while
+    only ONE of them matches ^^xsd:string. This is why the previous version of this file
+    asserted "every literal here is xsd:string" — true for hp/go, false and inverted for
+    uberon/cl/efo/edam.
+    THE SAFE, UNIVERSAL FORM — verified to match in go (typed), uberon + edam (plain) and
+    fma + sio (@en) alike:
+      ?t rdfs:label ?l . FILTER(STR(?l) = "liver")
+    Use STR() whenever you are not certain of the graph, or are querying more than one graph.
+    Use the bare typed form ONLY in hp/go (it is faster and index-friendly); the examples below
+    do exactly that, and are graph-pinned so they stay correct.
+    VALUES blocks are the highest-miss spot — the typing requirement is not visually cued there.
   - GRAPH-PINNING IS MANDATORY FOR HIERARCHY EXPANSION — and COUNT(DISTINCT) does NOT fix it.
     Foreign graphs assert rdfs:subClassOf on terms they do not own. Measured on GO_0006915
     (apoptotic process): unscoped `?c rdfs:subClassOf* GO_0006915` -> 1,537 rows / 77 distinct
     terms; pinned to GRAPH <ontology/go> -> 104 rows / 72 distinct terms. The 5 extra terms are
-    NOT duplicates: e.g. GO_0003276's ONLY subClassOf edge lives in <ontology/uberon>, not in
-    <ontology/go> at all. The ANSWER SET differs, so DISTINCT masks nothing. Always pin the
-    owning graph.
-  - OBSOLETE TERMS CARRY LABELS AND RESOLVE SILENTLY. owl:deprecated true"^^xsd:boolean marks
-    13,704 GO / 4,019 HP / 1,390 UBERON classes. Of these, 10,058 GO / 574 HP / 1,098 UBERON /
-    214 CL / 211 SO are ALSO labelled — so 21% of labelled GO classes are obsolete and a naive
-    label lookup returns them as if current. Add `FILTER NOT EXISTS { ?t owl:deprecated true }`
-    unless you specifically want obsolete terms.
-  - NEVER FILTER(LANG(?label) = "en"). Each ontology's OWN terms are xsd:string with NO language
-    tag; only the imported RO_/BFO_ upper-ontology properties are @en-tagged, and they are ~1%
-    of labels (287 of 21,643 in CL; 250 of 28,764 in UBERON). LANG="en" therefore drops ~99% of
-    labels silently. Use FILTER(LANG(?label) IN ("", "en")) — which also excludes PubCaseFinder's
-    Japanese (@ja) HP labels.
+    NOT duplicates: GO_0003276, GO_1900204, GO_1900205, GO_1901146 and GO_1901147 have their
+    ONLY subClassOf edge in <ontology/uberon>, not in <ontology/go> at all. The ANSWER SET
+    differs, so DISTINCT masks nothing. Always pin the owning graph.
+  - PREDICATES ARE NOT UNIFORM ACROSS ONTOLOGIES. OboClassShape describes the obo/oboInOwl
+    family ONLY. VERIFIED 2026-07-16: FMA has NO skos:notation, NO oboInOwl:*, NO IAO_0000115 —
+    it uses <fma/FMAID> (xsd:integer), <fma/preferred_name>, <fma/definition>. EDAM's definition
+    is oboInOwl:hasDefinition, NOT IAO_0000115. SIO's is dcterms:description and its ID is
+    dc:identifier. EFO has IAO_0000115 but NO skos:notation and NO oboInOwl:id. Hard-coding
+    IAO_0000115 or skos:notation across ontologies silently returns nothing. See
+    cross_references.predicate_by_ontology.
+  - subClassOf IS NOT ANATOMICAL CONTAINMENT. In UBERON/FMA/PO the partonomy lives in
+    part_of (BFO_0000050) owl:Restriction bnodes — the very bnodes an isIRI(?parent) filter
+    discards. VERIFIED 2026-07-16: `?c rdfs:subClassOf* UBERON_0000955` (brain) returns just 5
+    terms, ALL taxon variants (brain, insect embryonic brain, insect embryonic/larval brain,
+    insect adult brain, neural tube derived brain) — not one brain part. The 72 direct
+    anatomical parts (diencephalon, cerebellum, ...) are reachable ONLY via part_of. is_a means
+    "is a kind of", not "is part of". See query example 6 and the anatomy anti-pattern.
+  - DAG PATH MULTIPLICITY — COUNT(*) OVER subClassOf* IS NOT AN ENTITY COUNT. These are DAGs,
+    not trees: a multi-parent term is returned once PER PATH. VERIFIED 2026-07-16:
+    `?t rdfs:subClassOf* HP_0000707` -> 4,767 rows but only 2,825 distinct terms. Joining that
+    expansion to data multiplies every joined row by the term's path count: the HP x
+    PubCaseFinder join yields 111,591 raw rows but only 75,562 DISTINCT annotations (+48%), and
+    per-term counts inflate exactly 2x for two-parent terms (Intellectual disability 4,984 raw
+    vs 2,492 true) while single-parent terms are untouched. That unevenness CHANGES THE RANKING,
+    not just the magnitude. Always COUNT(DISTINCT ?annotation) / COUNT(DISTINCT ?term).
+  - OBSOLETE TERMS CARRY LABELS AND RESOLVE SILENTLY. owl:deprecated true^^xsd:boolean marks
+    13,704 GO / 4,019 HP / 1,390 UBERON classes (verified 2026-07-16). Of these, 10,058 GO /
+    574 HP / 1,098 UBERON / 214 CL / 211 SO are ALSO labelled — so 21% of labelled GO classes
+    are obsolete and a naive label lookup returns them as if current. Add
+    `FILTER NOT EXISTS { ?t owl:deprecated true }` unless you specifically want obsolete terms.
+  - EFO MARKS OBSOLETES TWICE: owl:deprecated true AND an "obsolete_" rdfs:label prefix.
+    VERIFIED 2026-07-16: EFO_0000305 -> "obsolete_breast carcinoma", EFO_0000270 ->
+    "obsolete_asthma", EFO_0000616 -> "obsolete_neoplasm" — well-known EFO IDs are heavily
+    obsoleted in this snapshot (4,930 of 18,382 native EFO classes = 26.8%). owl:deprecated
+    catches 4,930 and the label prefix catches only 4,915, so owl:deprecated is the RELIABLE
+    filter and the label prefix ALONE misses 15. Use owl:deprecated; add
+    FILTER(!STRSTARTS(STR(?label), "obsolete")) as a belt-and-suspenders guard.
+  - NEVER FILTER(LANG(?label) = "en") — AND NEVER FILTER(LANG(?label) = "") EITHER. Both fail,
+    on opposite halves of the endpoint. In the obo graphs a term's OWN label carries NO language
+    tag and @en marks a second-hand import, so LANG="en" drops ~99% of labels (CL: 287 @en vs
+    21,643 untagged; UBERON: 250 vs 28,764). But in fma/sio/meo the OWN label IS @en, so
+    LANG="" drops ~99.98% of FMA's (104,919 @en of 104,936). Verified 2026-07-16.
+    ALWAYS use FILTER(LANG(?label) IN ("", "en")) — the only form correct for both halves, and
+    the reason the flagship example resolves all 6 of its mixed-namespace IRIs. It also excludes
+    PubCaseFinder's Japanese (@ja) HP labels.
   - CONFLICTING LABELS ACROSS GRAPHS — take the OWNING graph's, never "the first row" (row order
     is arbitrary without ORDER BY). RO_0002211 is "regulates" in go/cl/clo/efo/po/uberon but
     "has_component" in <ontology/xco> — flatly wrong. <ontology/uberon> additionally carries the
     variant "regulates (processual)". IAO_0000115 is "definition" in all 15 graphs that declare
     it, but <ontology/clo> carries BOTH "definition" AND "textual definition" — so a single graph
-    can yield two labels for one IRI. Pin the owner via the prefix map in
-    architectural_notes.schema_design, and expect to pick among several rows even then.
+    can yield two labels for one IRI. Pin the owner via iri_namespaces + schema_design, and
+    expect to pick among several rows even then.
   - RO_/BFO_ PREDICATES HAVE NO HOME GRAPH — there is no <ontology/ro> or <ontology/bfo>. They
     resolve only because OBO import closures embed them, so EVERY hit is second-hand. Prefer the
-    <ontology/go> copy; expect benign variants ("part of"/"part_of", "regulates"/"regulates
-    (processual)"); treat a lone dissenter as noise.
-  - IAO_0100001 ("term replaced by") IS POLYMORPHIC WITHIN THE SAME GRAPH: <ontology/go> stores
-    3,646 IRI objects AND 2,211 xsd:string CURIE literals ("GO:0039502"); <ontology/hp> 3,961 IRI
-    + 494 literal; <ontology/uberon> 536 IRI only. Assuming either form silently drops the other
-    (38% of GO's mappings if you assume IRI). Normalize both — see query example 5.
+    <ontology/go> copy; expect benign variants ("part of"/"part_of"); treat a lone dissenter as noise.
+  - IAO_0100001 ("term replaced by") IS POLYMORPHIC — IN THREE FORMS, not two.
+    (a) an IRI node; (b) an xsd:string CURIE literal ("GO:0039502"); (c) an xsd:string literal
+    holding a FULL IRI ("http://purl.obolibrary.org/obo/MONDO_0004989"). VERIFIED 2026-07-16:
+    <ontology/go> stores 3,646 (a) AND 2,211 (b); <ontology/hp> 3,961 (a) + 494 (b);
+    <ontology/uberon> 536 (a) only; <ontology/efo> uses (c) — EFO_0000305's replacement LOOKS
+    like an IRI in results but isIRI() is false. Assuming (a) silently drops 38% of GO's
+    mappings. Worse, the CURIE normalizer in query example 5 MANGLES form (c): it would
+    CONCAT the obo prefix onto a string that is already a full IRI. Example 5 is safe only
+    because it is pinned to <ontology/go>, which has no (c). Outside go/hp, test with
+    STRSTARTS(STR(?o), "http") before normalizing.
+  - CLASS COUNTS INCLUDE IMPORTED CLASSES — "93,358 EFO classes" is NOT 93,358 EFO terms.
+    Several graphs embed their upstream import closure: EFO is only 20% native (18,382 of
+    93,358; 62,233 are obo imports such as NCBITaxon), CL is 19% (3,607 of 19,167), UBERON 60%,
+    PRO 71%. But this does NOT generalize — GO, HP, MONDO, SIO, MEO, CMO, MMO and UO are 100%
+    native. Read data_statistics.by_class, which gives total AND native per graph.
   - <ontology/pro-reasoned> IS THE MATERIALIZED INFERENCE CLOSURE of <ontology/pro> (13.8M vs
     PRO's asserted graph). Querying the union of both double-counts. Pick one deliberately:
     /pro for asserted axioms, /pro-reasoned for entailed ones.
@@ -152,20 +263,28 @@ shape_expressions: |
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
   PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+  PREFIX dcterms: <http://purl.org/dc/terms/>
+  PREFIX dc: <http://purl.org/dc/elements/1.1/>
+  PREFIX fma: <http://purl.org/sig/ont/fma/>
   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-  # One shape describes an OBO class in ANY of the ontology graphs — the schema is uniform
-  # across hp/go/uberon/cl/so/eco/... Counts below are from <ontology/hp> (23,829 classes)
-  # unless noted; the same predicates and datatypes were confirmed in go/uberon/cl.
+  # ---------------------------------------------------------------------------
+  # SCOPE: OboClassShape describes the obo/oboInOwl FAMILY ONLY — hp, go, uberon,
+  # cl, so, eco, clo, cmo, mmo, uo, po, xco, mondo, pro. It does NOT describe fma
+  # (see FmaClassShape), nor sio / edam / efo (see cross_references.predicate_by_ontology).
+  # Counts below are from <ontology/hp> (23,829 classes) unless noted.
+  # ---------------------------------------------------------------------------
   <OboClassShape> {
     a [ owl:Class ] ;                                  # 23,829 in hp — always present
-    skos:notation xsd:string ;                         # 23,829 (100%) — the CURIE, e.g. "HP:0001250"
+    skos:notation xsd:string ;                         # 23,829 (100%) in hp — the CURIE "HP:0001250".
+                                                       #   ABSENT ENTIRELY in fma/sio/edam/efo.
     rdfs:subClassOf (IRI OR BNODE) * ;                 # POLYMORPHIC, and the mix varies BY GRAPH:
                                                        #   hp:     24,330 — ALL IRI, no bnodes
                                                        #   go:     66,148 IRI + 16,215 bnode(owl:Restriction)
-                                                       #   uberon: 36,670 IRI + 43,981 bnode — 54% BNODE,
-                                                       #           incl. 428 bnodes typed owl:Class
-                                                       #   Filter isIRI(?parent) when walking; see below.
+                                                       #   uberon: 36,670 IRI + 43,981 bnode — 54% BNODE
+                                                       #   isIRI(?parent) walks the is_a tree, but in
+                                                       #   ANATOMY that DISCARDS the partonomy — the
+                                                       #   bnodes ARE the anatomy. See critical_warnings.
     rdfs:label xsd:string ? ;                          # 20,384 (85.5%) — ABSENT on 3,445 deprecated hp
                                                        #   classes; in cl/uberon some ACTIVE classes
                                                        #   also lack it (189 / 45). NO lang tag.
@@ -181,20 +300,44 @@ shape_expressions: |
     oboInOwl:hasAlternativeId xsd:string * ;           # 3,961 — merged-in obsolete CURIEs
     oboInOwl:inSubset IRI * ;                          # 845 — e.g. slim membership (VERIFIED IRI)
     oboInOwl:consider xsd:string * ;                   # 85 — suggested replacement for an obsolete
-                                                       #   term. A CURIE LITERAL, not an IRI —
-                                                       #   same trap as IAO_0100001/hasDbXref.
-    obo:IAO_0000115 xsd:string ? ;                     # 17,344 — "definition" (VERIFIED label, 14 graphs)
+                                                       #   term. A CURIE LITERAL, not an IRI.
+    obo:IAO_0000115 xsd:string ? ;                     # 17,344 — "definition" (VERIFIED label, 15 graphs).
+                                                       #   Present in efo; ABSENT in fma/sio/edam.
     obo:IAO_0100001 (IRI OR xsd:string) ? ;            # "term replaced by" — POLYMORPHIC, see warnings
     obo:IAO_0000231 IRI ? ;                            # 3,961 — "has obsolescence reason"
     obo:IAO_0000233 xsd:anyURI ? ;                     # 1,461 — "term tracker item" (a LITERAL, not IRI)
     owl:deprecated xsd:boolean ? ;                     # 4,019 in hp — only ever true^^xsd:boolean
     rdfs:comment xsd:string ? ;                        # 4,685
-    owl:incompatibleWith IRI * ;                       # 2
   }
   # NOT documented (bioportal export artifact, no query value):
   #   <http://data.bioontology.org/metadata/treeView>  # 24,330 in hp — BioPortal UI hint
   # obo:terms_date / terms_creator / terms_contributor (13,387 / 11,270 / 6,520 in hp) are
   # provenance literals; excluded deliberately — no retrieval use case.
+
+  # ---------------------------------------------------------------------------
+  # FMA IS A DIFFERENT SCHEMA ENTIRELY. 104,720 of 104,721 owl:Class in <ontology/fma>
+  # use http://purl.org/sig/ont/fma/fmaNNNNN (lowercase, no underscore); the 1 remainder
+  # is dcterms:Agent. VERIFIED on fma7088 ("Heart") 2026-07-16.
+  # NOTE what is ABSENT: skos:notation, oboInOwl:*, IAO_0000115 — all zero.
+  # ---------------------------------------------------------------------------
+  <FmaClassShape> {
+    a [ owl:Class ] ;
+    rdfs:label rdf:langString ;                        # "Heart"@en — @en-TAGGED, NOT xsd:string!
+                                                       #   104,919 of 104,936 fma labels are @en;
+                                                       #   only 17 are xsd:string. The INVERSE of
+                                                       #   every obo graph. "Heart"^^xsd:string
+                                                       #   matches NOTHING. See critical_warnings.
+    fma:FMAID xsd:integer ;                            # 7088 — an INTEGER, not a CURIE string.
+                                                       #   This is FMA's identifier field; there is
+                                                       #   no skos:notation to fall back on.
+    fma:preferred_name xsd:string ? ;                  # "Heart"
+    fma:definition xsd:string ? ;                      # the current definition
+    fma:non-English_equivalent xsd:string * ;          # 6 on fma7088: Coeur, Cor, Corazon, Cuore,
+                                                       #   Herz, Puso — FMA's multilingual channel
+                                                       #   (NOT lang-tagged; plain xsd:string)
+    rdfs:comment xsd:string ? ;                        # often the superseded "Old definition: ..."
+    rdfs:subClassOf (IRI OR BNODE) * ;                 # fma7088 -> fma55673 + owl:Restriction bnodes
+  }
 
 sample_rdf_entries:
   rdf_prefixes: |
@@ -203,9 +346,11 @@ sample_rdf_entries:
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
     @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
     @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+    @prefix fma: <http://purl.org/sig/ont/fma/> .
+    @prefix efo: <http://www.ebi.ac.uk/efo/> .
     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
   entries:
-    - title: "Active HP term — the canonical resolution target"
+    - title: "Active obo term — the canonical resolution target"
       description: >
         HP_0001250 in GRAPH <http://rdfportal.org/ontology/hp>. Every literal is xsd:string with
         no language tag: an exact match MUST carry ^^xsd:string.
@@ -219,38 +364,49 @@ sample_rdf_entries:
             oboInOwl:hasAlternativeId "HP:0001275"^^xsd:string ;
             obo:IAO_0000115 "A seizure is an intermittent abnormality of nervous system physiology characterized by a transient occurrence of signs and/or symptoms due to abnormal excessive or synchronous neuronal activity in the brain."^^xsd:string ;
             rdfs:subClassOf obo:HP_0012638 .
-    - title: "Obsolete GO term — labelled, and its replacement is a CURIE LITERAL"
+    - title: "FMA term — a NON-obo IRI with an entirely different predicate set"
       description: >
-        GO_0039501 in GRAPH <http://rdfportal.org/ontology/go>. It is deprecated yet still carries
-        rdfs:label, so an unfiltered lookup returns it as if current. IAO_0100001 here is an
-        xsd:string CURIE — NOT an IRI — so `?replacement rdfs:label ?l` joins to nothing.
+        fma7088 ("Heart") in GRAPH <http://rdfportal.org/ontology/fma>. Three traps in one entry:
+        the IRI is lowercase with no underscore; NONE of skos:notation / oboInOwl:* / IAO_0000115
+        exist here; and rdfs:label is @en-TAGGED while every sibling literal is xsd:string — so
+        "Heart"^^xsd:string matches nothing. An obo-form <obo/FMA_7088> returns 0 rows.
       rdf: |
-        obo:GO_0039501 a owl:Class ;
+        fma:fma7088 a owl:Class ;
+            rdfs:label "Heart"@en ;
+            fma:FMAID 7088 ;
+            fma:preferred_name "Heart"^^xsd:string ;
+            fma:definition "Organ with cavitated organ parts, each instance of which is continuous with some systemic and pulmonary arterial and venous trees. Examples: There is only one heart."^^xsd:string ;
+            fma:non-English_equivalent "Coeur"^^xsd:string , "Cor"^^xsd:string , "Herz"^^xsd:string ;
+            rdfs:subClassOf fma:fma55673 .
+    - title: "Obsolete EFO term — NON-obo IRI, deprecated AND 'obsolete_' label prefix"
+      description: >
+        EFO_0000305 in GRAPH <http://rdfportal.org/ontology/efo>. Demonstrates two traps at once:
+        the IRI is ebi.ac.uk/efo (an obo form returns 0 rows), and EFO marks obsoletes twice —
+        owl:deprecated AND the label prefix. Note EFO HAS IAO_0000115 but NO skos:notation, and
+        its IAO_0100001 is a full IRI stored as a string LITERAL (isIRI() is false) — the third
+        form of that predicate's polymorphism.
+        Every literal below is PLAIN: efo does NOT store ^^xsd:string, so the typed form matches
+        nothing here — the exact inverse of the HP entry above. The per-graph literal trap, in
+        one entry.
+      rdf: |
+        efo:EFO_0000305 a owl:Class ;
+            rdfs:label "obsolete_breast carcinoma" ;
             owl:deprecated true ;
-            rdfs:label "obsolete suppression by virus of host type I interferon production"^^xsd:string ;
-            skos:notation "GO:0039501"^^xsd:string ;
-            oboInOwl:hasOBONamespace "biological_process"^^xsd:string ;
-            obo:IAO_0100001 "GO:0039502"^^xsd:string ;
-            obo:IAO_0000233 "https://github.com/geneontology/go-ontology/issues/29194"^^xsd:anyURI ;
-            rdfs:comment "This term was obsoleted because it represents the same process as symbiont-mediated suppression of host type I interferon-mediated signaling pathway ; GO:0039502."^^xsd:string .
-    - title: "Cross-graph label collision — the same IRI, two contradictory labels"
-      description: >
-        RO_0002211 has no home graph (there is no <ontology/ro>). Six graphs agree on "regulates";
-        <ontology/xco> says "has_component". Both triples below are real and simultaneously
-        retrievable — which one an unpinned query returns is arbitrary.
-      rdf: |
-        # GRAPH <http://rdfportal.org/ontology/go>
-        obo:RO_0002211 rdfs:label "regulates"^^xsd:string .
-
-        # GRAPH <http://rdfportal.org/ontology/xco>   <-- WRONG, but present
-        obo:RO_0002211 rdfs:label "has_component"^^xsd:string .
+            obo:IAO_0000115 "A carcinoma that arises from epithelial cells of the breast" ;
+            obo:IAO_0100001 "http://purl.obolibrary.org/obo/MONDO_0004989" ;
+            oboInOwl:hasDbXref "EFO:0000305" , "DOID:3459" ;
+            oboInOwl:hasExactSynonym "breast carcinoma" ;
+            skos:exactMatch obo:DOID_3459 , obo:NCIT_C4872 ;
+            rdfs:subClassOf owl:Thing .
 
 sparql_query_examples:
-  - title: "Resolve a batch of opaque OBO IRIs to labels (owner-graph pinned)"
+  - title: "Resolve a batch of opaque IRIs across MIXED namespaces (owner-graph pinned)"
     description: >
-      The flagship pattern. VALUES pairs each IRI with its OWNING graph, which sidesteps the
-      cross-graph label collision entirely and resolves classes AND properties in one round trip.
-    question: "What do SO_0000704, UBERON_0002107, CL_0000236, HP_0001250, ECO_0000269 and GO_0006915 mean?"
+      The flagship pattern, and this file's namespace regression test. VALUES pairs each IRI with
+      its OWNING graph AND builds each IRI from that ontology's REAL namespace (schema_info.
+      iri_namespaces) — obo for HP, ebi.ac.uk for EFO, purl.org/sig/ont for FMA, semanticscience
+      for SIO, edamontology for EDAM, mdatahub for MEO. Assuming obo throughout drops 5 of 6 rows.
+    question: "What do HP_0001250, EFO_0022223, fma7088, SIO_000776, data_0863 and MEO_0000001 mean?"
     complexity: basic
     sparql: |
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -259,12 +415,12 @@ sparql_query_examples:
       SELECT ?iri ?label ?obsolete
       WHERE {
         VALUES (?iri ?g) {
-          (<http://purl.obolibrary.org/obo/HP_0001250>     <http://rdfportal.org/ontology/hp>)
-          (<http://purl.obolibrary.org/obo/SO_0000704>     <http://rdfportal.org/ontology/so>)
-          (<http://purl.obolibrary.org/obo/UBERON_0002107> <http://rdfportal.org/ontology/uberon>)
-          (<http://purl.obolibrary.org/obo/GO_0006915>     <http://rdfportal.org/ontology/go>)
-          (<http://purl.obolibrary.org/obo/CL_0000236>     <http://rdfportal.org/ontology/cl>)
-          (<http://purl.obolibrary.org/obo/ECO_0000269>    <http://rdfportal.org/ontology/eco>)
+          (<http://purl.obolibrary.org/obo/HP_0001250>       <http://rdfportal.org/ontology/hp>)
+          (<http://www.ebi.ac.uk/efo/EFO_0022223>            <http://rdfportal.org/ontology/efo>)
+          (<http://purl.org/sig/ont/fma/fma7088>             <http://rdfportal.org/ontology/fma>)
+          (<http://semanticscience.org/resource/SIO_000776>  <http://rdfportal.org/ontology/sio>)
+          (<http://edamontology.org/data_0863>               <http://rdfportal.org/ontology/edam>)
+          (<https://mdatahub.org/data/meo/MEO_0000001>       <http://rdfportal.org/ontology/meo>)
         }
         GRAPH ?g {
           ?iri rdfs:label ?label .
@@ -273,38 +429,43 @@ sparql_query_examples:
         FILTER(LANG(?label) IN ("", "en"))
         BIND(COALESCE(?dep, false) AS ?obsolete)
       }
-    # Verified 2026-07-16: 6 rows, exactly one label each — gene / liver / B cell / Seizure /
-    # experimental evidence used in manual assertion / apoptotic process. All obsolete=false.
+    # Verified 2026-07-16: 6 rows — Seizure / metabolite ratio / Heart / object /
+    # Sequence alignment / atmosphere. All obsolete=false.
+    # The obo-form variant (<obo/EFO_0022223>, <obo/FMA_7088>, <obo/SIO_000776>,
+    # <obo/EDAM_0863>, <obo/MEO_0000001>) returns 0 rows for all five — silently.
 
-  - title: "Full term record — label, CURIE, definition and synonyms"
+  - title: "Full term record for a NON-obo ontology (FMA)"
     description: >
-      Everything an agent needs to confirm it has the right term before building a query on it.
-      skos:notation carries the CURIE (100% coverage); IAO_0000115 is the definition.
-    question: "What is HP:0001250 — its CURIE, definition and exact synonyms?"
+      Proves the predicate set is per-ontology. FMA carries no skos:notation, no oboInOwl:*, no
+      IAO_0000115 — its ID is fma:FMAID (an integer) and its definition is fma:definition. The
+      obo-family query (skos:notation + IAO_0000115) returns nothing here.
+    question: "What is FMA:7088 — its FMAID, preferred name, definition and translations?"
     complexity: basic
     sparql: |
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-      PREFIX obo: <http://purl.obolibrary.org/obo/>
-      PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+      PREFIX fma: <http://purl.org/sig/ont/fma/>
 
-      SELECT ?label ?curie ?definition
-             (GROUP_CONCAT(DISTINCT ?syn; separator=" | ") AS ?synonyms)
+      SELECT ?label ?fmaid ?preferred ?definition
+             (GROUP_CONCAT(DISTINCT ?nonEng; separator=" | ") AS ?translations)
       WHERE {
-        GRAPH <http://rdfportal.org/ontology/hp> {
-          <http://purl.obolibrary.org/obo/HP_0001250> rdfs:label ?label ;
-              skos:notation ?curie ;
-              obo:IAO_0000115 ?definition .
-          OPTIONAL { <http://purl.obolibrary.org/obo/HP_0001250> oboInOwl:hasExactSynonym ?syn }
+        GRAPH <http://rdfportal.org/ontology/fma> {
+          <http://purl.org/sig/ont/fma/fma7088> rdfs:label ?label ;
+              fma:FMAID ?fmaid ;
+              fma:definition ?definition .
+          OPTIONAL { <http://purl.org/sig/ont/fma/fma7088> fma:preferred_name ?preferred }
+          OPTIONAL { <http://purl.org/sig/ont/fma/fma7088> fma:non-English_equivalent ?nonEng }
         }
       }
-      GROUP BY ?label ?curie ?definition
-    # Verified 2026-07-16: Seizure / HP:0001250 / full definition / "Epileptic seizure | Seizures".
+      GROUP BY ?label ?fmaid ?preferred ?definition
+    # Verified 2026-07-16: Heart / 7088 / Heart / "Organ with cavitated organ parts..." /
+    # Coeur | Cor | Corazon | Cuore | Herz | Puso.
 
-  - title: "Expand a term to its active subsumption subtree (graph-pinned)"
+  - title: "Expand a term to its active subsumption subtree (graph-pinned, DISTINCT)"
     description: >
-      The core hierarchy operation. Pinning <ontology/hp> keeps foreign subClassOf edges out;
-      the owl:deprecated filter keeps obsolete terms out. Both are mandatory — see warnings.
+      The core hierarchy operation for a NON-anatomical ontology, where is_a is the real
+      hierarchy. Pinning <ontology/hp> keeps foreign subClassOf edges out; the owl:deprecated
+      filter keeps obsolete terms out; COUNT(DISTINCT) collapses DAG path multiplicity. All
+      three are mandatory — see critical_warnings.
     question: "How many active HP terms are descendants of 'Abnormality of the nervous system'?"
     complexity: intermediate
     sparql: |
@@ -319,7 +480,8 @@ sparql_query_examples:
           FILTER NOT EXISTS { ?term owl:deprecated true }
         }
       }
-    # Verified 2026-07-16: 2,825 active descendants.
+    # Verified 2026-07-16: 2,825 active descendants — from 4,767 raw path rows, because the DAG
+    # returns multi-parent terms once per path. COUNT(DISTINCT) is what makes this correct.
 
   - title: "Find a term by its exact synonym (structured, no text search)"
     description: >
@@ -370,40 +532,42 @@ sparql_query_examples:
       }
       ORDER BY ?obsolete
       LIMIT 6
-    # Verified 2026-07-16: e.g. GO_0000003 "obsolete reproduction" -> GO_0022414
-    # "reproductive process". Resolves rows of BOTH object forms.
+    # Verified 2026-07-16: GO_0000003 "obsolete reproduction" -> GO_0022414 "reproductive
+    # process"; GO_0000108 -> GO_0000109; ... Resolves rows of BOTH object forms.
 
-  - title: "Subtree expansion JOINED to co-located annotation data"
+  - title: "Walk the ANATOMICAL partonomy with part_of (subClassOf finds almost nothing)"
     description: >
-      The capability OLS4 cannot provide: expand HP to a 2,825-term subtree and join it to
-      PubCaseFinder's 379,263 phenotype annotations in ONE query, with no 1,546-IRI VALUES block.
-      Both graphs are pinned.
-    question: "Which nervous-system phenotypes are most frequently annotated in PubCaseFinder?"
+      The correct hierarchy operation for UBERON/FMA/PO. Anatomical containment is asserted as
+      an owl:Restriction on BFO_0000050 (part of), NOT as subClassOf — so the is_a expansion in
+      example 3 is the WRONG tool here. Pattern: match the bnode restriction inline.
+    question: "What are the direct anatomical parts of the brain in UBERON?"
     complexity: advanced
     sparql: |
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX owl: <http://www.w3.org/2002/07/owl#>
-      PREFIX oa: <http://www.w3.org/ns/oa#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
 
-      SELECT ?label (COUNT(*) AS ?annotations)
+      SELECT ?part ?label
       WHERE {
-        GRAPH <http://rdfportal.org/ontology/hp> {
-          ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ;
+        GRAPH <http://rdfportal.org/ontology/uberon> {
+          ?part rdfs:subClassOf [ a owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;   # part of
+                                  owl:someValuesFrom obo:UBERON_0000955 ] ;
                 rdfs:label ?label .
-          FILTER NOT EXISTS { ?term owl:deprecated true }
         }
-        GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term }
       }
-      GROUP BY ?label
-      ORDER BY DESC(?annotations)
-      LIMIT 10
-    # Verified 2026-07-16: Intellectual disability 4,984 / Microcephaly 3,624 / Seizure 2,979 /
-    # Dandy-Walker malformation 2,232 / Global developmental delay 2,134 ...
+      ORDER BY ?label
+    # Verified 2026-07-16: 72 direct parts (diencephalon, cerebellum, ...). By contrast
+    # `?c rdfs:subClassOf* UBERON_0000955` returns only 5 rows, ALL taxon variants of "brain"
+    # (insect embryonic brain, neural tube derived brain, ...) — zero actual brain parts.
+    # Transitive part_of is NOT pre-materialized: a multi-level partonomy needs a recursive walk
+    # over nested restrictions, which is expensive — bound the depth.
 
   - title: "Detect cross-graph label collisions before trusting a resolution"
     description: >
-      The diagnostic for critical_warning #5. Compare on STR(?label), NOT on ?label — the latter
-      counts "Seizure"^^xsd:string and "Seizure"@en as distinct and reports false collisions.
+      The diagnostic for the conflicting-labels warning. Compare on STR(?label), NOT on ?label —
+      the latter counts "Seizure"^^xsd:string and "Seizure"@en as distinct and reports false
+      collisions.
     question: "Which of these IRIs are labelled inconsistently across the ontology graphs?"
     complexity: advanced
     sparql: |
@@ -432,15 +596,52 @@ sparql_query_examples:
 
 cross_database_queries:
   shared_endpoint: primary
-  co_located_databases: [go, mondo, taxonomy, mesh, nando, hgnc, bacdive, mediadive, brenda, jpostdb, massbank, nbrc, mogplus, hco, mco]
+  co_located_databases: [go, mondo, taxonomy, mesh, nando, hgnc, bacdive, mediadive, brenda, jpostdb, massbank, nbrc, mogplus, hco, mco, glycosmos]
   examples:
+    - title: "ECO subtree x GlyCosmos glycogenes — split manual from automatic evidence"
+      description: |
+        The LARGEST ontology-to-data join on this endpoint (1,996,752 refs), and it is fully
+        hierarchy-aware. Linking strategy:
+        - ontology/eco: rdfs:subClassOf* expands ECO_0000352 ("evidence used in manual
+          assertion") to its subtree — 23 of the 24 ECO terms glycogenes actually uses
+        - glycosmos/glycogenes: sio:SIO_000772 points at the SAME obo ECO IRIs — direct IRI
+          match, no bridging
+        - COUNT(DISTINCT ?s) is mandatory: the ECO subtree is a DAG (800 path rows / 735
+          distinct terms), so COUNT(*) inflates to 620,815 against a true 463,051.
+      databases_used: [ontology, glycosmos]
+      complexity: advanced
+      sparql: |
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX owl: <http://www.w3.org/2002/07/owl#>
+        PREFIX sio: <http://semanticscience.org/resource/>
+
+        SELECT (COUNT(DISTINCT ?eco) AS ?ecoTermsUsed)
+               (COUNT(DISTINCT ?s) AS ?manualAssertions)
+        WHERE {
+          GRAPH <http://rdfportal.org/ontology/eco> {
+            ?eco rdfs:subClassOf* <http://purl.obolibrary.org/obo/ECO_0000352> .
+            FILTER NOT EXISTS { ?eco owl:deprecated true }
+          }
+          GRAPH <http://rdf.glycosmos.org/glycogenes> {
+            ?s sio:SIO_000772 ?eco .
+          }
+        }
+      notes: |
+        - Linking via: obo ECO_ IRIs, identical on both sides (no namespace translation)
+        - Verified 2026-07-16: 23 terms / 463,051 distinct manually-asserted glycogene annotations
+        - The complement is ECO_0000501 ("evidence used in automatic assertion"): 1,533,701 refs,
+          the single largest term. 463,051 + 1,533,701 = 1,996,752 = the full ECO ref count,
+          which is how this figure was cross-checked.
+        - COUNT(*) instead of COUNT(DISTINCT ?s) returns 620,815 — a 34% over-count.
+        - MIE files checked: ontology, glycosmos
+
     - title: "HP subtree x PubCaseFinder phenotype annotations"
       description: |
         Linking strategy:
         - ontology/hp: rdfs:subClassOf* expands the term to its subtree (IRI-keyed)
-        - pubcasefinder: oa:hasBody points at the SAME obo HP_ IRIs — direct IRI match, no bridging
-        - Both graphs pinned; deprecated terms excluded
-        This is the only rich ontology-to-data join on the endpoint (10,392 distinct HP terms).
+        - pubcasefinder: oa:hasBody points at the SAME obo HP_ IRIs — direct IRI match
+        - Both graphs pinned; deprecated terms excluded; COUNT(DISTINCT ?annotation) mandatory
+          because HP is a DAG (see critical_warnings on path multiplicity).
       databases_used: [ontology, pubcasefinder]
       complexity: advanced
       sparql: |
@@ -448,28 +649,68 @@ cross_database_queries:
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
         PREFIX oa: <http://www.w3.org/ns/oa#>
 
-        SELECT (COUNT(DISTINCT ?term) AS ?termsUsed) (COUNT(*) AS ?annotations)
+        SELECT ?label (COUNT(DISTINCT ?annotation) AS ?annotations)
         WHERE {
           GRAPH <http://rdfportal.org/ontology/hp> {
-            ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> .
+            ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ;
+                  rdfs:label ?label .
             FILTER NOT EXISTS { ?term owl:deprecated true }
           }
           GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term }
         }
+        GROUP BY ?label
+        ORDER BY DESC(?annotations)
+        LIMIT 10
       notes: |
         - Linking via: obo HP_ IRIs, identical on both sides (no namespace translation)
-        - Verified 2026-07-16: 1,546 terms / 111,591 annotations
-        - PubCaseFinder is NOT a registered TogoMCP database; query it via this entry
+        - Verified 2026-07-16: Seizure 2,979 / Intellectual disability 2,492 / Global
+          developmental delay 2,134 / Microcephaly 1,812 / Ataxia 1,311 / Hydrocephalus 841 /
+          Dysarthria 815 / Dysphagia 810 / Spasticity 761 / Headache 752.
+          Subtree totals: 1,546 terms / 75,562 DISTINCT annotations.
+        - COUNT(*) instead returns 111,591 (+48%) AND REORDERS the ranking — it promotes
+          Intellectual disability (4,984) above Seizure and pulls four terms into the top 10
+          that do not belong there. Two-parent terms inflate exactly 2x, single-parent terms
+          not at all. The DISTINCT is a correctness fix, not a tidiness one.
+        - PubCaseFinder is NOT a registered TogoMCP database; query it via this entry.
   notes: |
-    Most ontology graphs here are INERT — joined to nothing on this endpoint. PRO (365,852
+    Many ontology graphs here are INERT — joined to nothing on this endpoint. PRO (365,852
     classes), FMA, EFO and CLO have no data consumer; their only inbound references come from
-    other ontology graphs. The measured ontology-to-data links are: HP <- pubcasefinder
-    (10,392 terms, rich); ECO <- glycosmos glycogenes (1,121 refs, 1 term); UBERON <-
-    open-tggates (2 terms only); SO <- hgnc (1 term only); CL <- refex/fantom5 (14 refs).
-    Only the HP link supports hierarchy-aware querying. Do not assume a graph's size implies
-    it is queryable against data.
+    other ontology graphs. Do not assume a graph's size implies it is queryable against data.
+    The measured ontology-to-data links, largest first:
+      - ECO <- glycosmos/glycogenes: 1,996,752 refs over 24 terms. HIERARCHY-AWARE.
+      - pubcasefinder -> HP: 379,263 annotations over 10,392 terms. HIERARCHY-AWARE.
+      - nando -> MONDO: 2,341 skos:closeMatch over 1,572 terms. HIERARCHY-AWARE — but it is
+        documented properly in the `nando` MIE (trilingual labels, coverage, many-to-many
+        caveat). Use that file; this entry only records that the link exists.
+      - open-tggates -> UBERON: 2 terms only (liver 20,415 / kidney 4,149). No hierarchy value.
+      - hgnc -> SO: 1 term (SO_0000704 "gene" via rdf:type on 44,997 genes). A flat tag.
+      - CL <- refex/fantom5: a handful of refs (not re-measured 2026-07-16; an unfiltered scan
+        of that graph times out — probe with a VALUES list of candidate CL terms instead).
 
 cross_references:
+  - pattern: predicate_by_ontology
+    description: |
+      THE definition / ID / synonym predicate is NOT the same across ontologies. Hard-coding the
+      obo form silently returns nothing for the four exceptions. VERIFIED 2026-07-16:
+
+      DEFINITION:
+        obo family (hp, go, uberon, cl, so, eco, clo, cmo, mondo, pro, po, xco, efo)
+                          -> obo:IAO_0000115
+        EDAM              -> oboInOwl:hasDefinition        (NOT IAO_0000115)
+        SIO               -> dcterms:description
+        FMA               -> <http://purl.org/sig/ont/fma/definition>
+
+      CURIE / IDENTIFIER:
+        obo family        -> skos:notation (hp = 100%) and/or oboInOwl:id
+        FMA               -> <http://purl.org/sig/ont/fma/FMAID>, an xsd:INTEGER (7088)
+        SIO               -> dc:identifier ("SIO_000776")
+        EFO, EDAM         -> NEITHER skos:notation NOR oboInOwl:id. Derive the ID from the IRI
+                             local name, or read oboInOwl:hasDbXref (EFO carries "EFO:0000305").
+
+      SYNONYMS:
+        obo family + EDAM -> oboInOwl:hasExactSynonym / hasRelatedSynonym / hasBroad / hasNarrow
+        FMA               -> <fma/preferred_name>, <fma/non-English_equivalent>
+        SIO               -> no synonym predicate observed on the probed term
   - pattern: oboInOwl:hasDbXref
     description: |
       Cross-references to external vocabularies, stored as xsd:string CURIEs — NOT as IRIs.
@@ -481,85 +722,139 @@ cross_references:
   - pattern: skos:notation
     description: |
       The term's own CURIE ("HP:0001250"), xsd:string, on 23,829 of 23,829 hp classes (100%) —
-      the most reliable identifier field here, and more complete than rdfs:label (85.5%). Use it
-      to render an IRI as the ID form a user recognizes.
+      the most reliable identifier field IN THE OBO FAMILY, and more complete than rdfs:label
+      (85.5%). It does NOT exist at all in fma / sio / edam / efo — see predicate_by_ontology.
   - pattern: rdfs:subClassOf
     description: |
-      The subsumption backbone. Objects are IRIs for named parents and BNODEs for owl:Restriction
-      axioms — but the mix varies sharply by graph: hp is 100% IRI (24,330, no bnodes at all),
-      whereas uberon is 54% BNODE (43,981 bnode vs 36,670 IRI) and go is ~20% (16,215 vs 66,148).
-      Filter isIRI(?parent) when walking the hierarchy or the restriction axioms pollute the
-      result — harmless in hp, dominant in uberon. MUST also be graph-pinned; see
-      critical_warnings #2.
+      The subsumption backbone — "is a kind of", NOT "is part of". Objects are IRIs for named
+      parents and BNODEs for owl:Restriction axioms, and the mix varies sharply by graph: hp is
+      100% IRI (24,330, no bnodes at all), whereas uberon is 54% BNODE (43,981 bnode vs 36,670
+      IRI) and go is ~20% (16,215 vs 66,148).
+      Filtering isIRI(?parent) is right for HP/GO but WRONG for anatomy: in UBERON/FMA/PO the
+      bnodes carry the part_of partonomy, which IS the hierarchy a user means.
+      MUST also be graph-pinned, and expansions counted with COUNT(DISTINCT) — the graph is a
+      DAG, so a multi-parent term is returned once per path.
+  - pattern: obo:BFO_0000050 (part of)
+    description: |
+      The anatomical partonomy, asserted as owl:Restriction bnodes hanging off rdfs:subClassOf:
+      `?part rdfs:subClassOf [ a owl:Restriction ; owl:onProperty BFO_0000050 ;
+      owl:someValuesFrom ?whole ]`. Verified on UBERON_0000955 (brain): 72 direct parts, versus
+      5 taxon variants from subClassOf*. NOT transitively materialized — a multi-level walk must
+      recurse over nested restrictions and is expensive. BFO_0000050 has no home graph (10 graphs
+      declare its label as "part of"/"part_of"); the restriction axioms themselves live in the
+      owning anatomy graph, so pin that.
 
 architectural_notes:
   query_strategy:
     - "FIRST: read this MIE; check whether the target ontology has its OWN MIE (go, mondo, taxonomy) — use that for deep single-ontology work"
+    - "SECOND: build the IRI from schema_info.iri_namespaces. Do NOT assume obo — that is the #1 silent failure here."
     - "Many IRIs to resolve -> the owner-pinned VALUES batch (query example 1), one round trip"
     - "One IRI you must genuinely understand (definition, synonyms, ancestors) -> OLS4 fetch / getAncestors / getDescendants — per-ontology authoritative, so no cross-graph collision"
-    - "EXACT term name -> the pinned rdfs:label \"X\"^^xsd:string match, NOT OLS4:searchClasses. VERIFIED: searchClasses('seizure', hp) buries the exact term HP_0001250 below rank 20 of 364 behind its own narrower subtypes. OLS4 search is for FUZZY/exploratory lookup only."
+    - "EXACT term name -> a pinned rdfs:label match, NOT OLS4:searchClasses. VERIFIED: searchClasses('seizure', hp) buries the exact term HP_0001250 below rank 20 of 364 behind its own narrower subtypes. OLS4 search is for FUZZY/exploratory lookup only."
+    - "For that label match, pick the literal form BY GRAPH (see critical_warnings): \"X\"^^xsd:string in hp/go; plain \"X\" in uberon/cl/efo/edam; \"X\"@en in fma/sio/meo. If unsure, or across graphs, use FILTER(STR(?label) = \"X\") — it is correct everywhere."
     - "Hierarchy + a join against data -> SPARQL here; OLS4 cannot join (it would need a 1,546-IRI VALUES block)"
-    - "ALWAYS pin the owning GRAPH; ALWAYS annotate exact-match literals ^^xsd:string"
-    - "Priority: Specific IRIs > owner-pinned label lookup > subtree expansion > text search (never needed here)"
+    - "ANATOMY (uberon/fma/po) -> part_of restrictions, not subClassOf. Every other ontology -> subClassOf."
+    - "ALWAYS pin the owning GRAPH; ALWAYS annotate exact-match literals ^^xsd:string; ALWAYS COUNT(DISTINCT) over a subClassOf* expansion"
+    - "Priority: Specific IRIs > owner-pinned label lookup > subtree/partonomy expansion > text search (never needed here)"
   schema_design:
-    - "IRI prefix -> owning graph (the pin map): HP_ -> ontology/hp; GO_ -> ontology/go; UBERON_ -> ontology/uberon; CL_ -> ontology/cl; CLO_ -> ontology/clo; SO_ -> ontology/so; ECO_ -> ontology/eco; EFO_ -> ontology/efo; MONDO_ -> ontology/mondo; PR_ -> ontology/pro; FMA_ -> ontology/fma; PO_ -> ontology/po; XCO_ -> ontology/xco; CMO_ -> ontology/cmo; MMO_ -> ontology/mmo; UO_ -> ontology/uo. RO_/BFO_/IAO_ have NO home graph — prefer the ontology/go copy."
-    - "The class schema is uniform across all OBO graphs (owl:Class + skos:notation + rdfs:label + oboInOwl:* + IAO_*), so one shape serves every ontology — only the counts differ."
-    - "Every graph is a self-contained import closure. That is WHY the upper-ontology properties are re-declared 7-15 times and why pinning is mandatory rather than merely tidy."
+    - "IRI prefix -> owning graph (the pin map). obo-namespace: HP_ -> ontology/hp; GO_ -> ontology/go; UBERON_ -> ontology/uberon; CL_ -> ontology/cl; CLO_ -> ontology/clo; SO_ -> ontology/so; ECO_ -> ontology/eco; MONDO_ -> ontology/mondo; PR_ -> ontology/pro; PO_ -> ontology/po; XCO_ -> ontology/xco; CMO_ -> ontology/cmo; MMO_ -> ontology/mmo; UO_ -> ontology/uo. NON-obo namespace (see iri_namespaces): ebi.ac.uk/efo/EFO_ -> ontology/efo; purl.org/sig/ont/fma/fma -> ontology/fma; semanticscience.org/resource/SIO_ -> ontology/sio; edamontology.org/{data_,operation_,format_,topic_} -> ontology/edam; mdatahub.org/data/meo/MEO_ -> ontology/meo. RO_/BFO_/IAO_ have NO home graph — prefer the ontology/go copy."
+    - "The obo/oboInOwl class schema is uniform across the obo-family graphs, so OboClassShape serves all of them — but FMA, SIO, EDAM and EFO diverge (see predicate_by_ontology and FmaClassShape). 'One shape serves every ontology' is FALSE."
+    - "Every graph is a self-contained import closure. That is WHY the upper-ontology properties are re-declared 7-15 times, why pinning is mandatory, and why a graph's owl:Class count can overstate its native vocabulary (EFO 20% native, CL 19%) — though many graphs are 100% native. See by_class."
   performance:
     - "Pin the GRAPH in every pattern — it is a correctness requirement AND the main performance lever (unscoped GO_0006915 expansion: 1,537 rows vs 104 pinned)."
     - "Property paths (rdfs:subClassOf*) fail inside FILTER NOT EXISTS on Virtuoso with 'transitive start not given' — restructure as a subquery + MINUS instead."
     - "Aggregates over unbound ?g across all 37 graphs time out at 60s. Bind ?g via VALUES."
     - "A UNION of one predicate across 3+ graphs also times out; split into per-graph queries."
+    - "An unfiltered ?s ?p ?o scan of a large DATA graph (open-tggates, refex/fantom5) to find ontology refs times out at 60s; probe with a VALUES list of candidate terms instead."
   data_integration:
-    - "The only rich ontology-to-data join on this endpoint is HP <-> pubcasefinder (379,263 annotations, 10,392 terms)."
+    - "The two rich, hierarchy-aware ontology-to-data joins are ECO <-> glycosmos/glycogenes (1,996,752 refs) and HP <-> pubcasefinder (379,263 annotations). nando <-> MONDO is a third, documented in the nando MIE."
     - "oboInOwl:hasDbXref values are CURIE literals, not IRIs — not directly joinable; use TogoID for external ID mapping."
   data_quality:
-    - "Obsolete terms are retained in-graph and mostly still labelled (10,058 labelled obsolete GO terms) — filter owl:deprecated deliberately."
+    - "Obsolete terms are retained in-graph and mostly still labelled (10,058 labelled obsolete GO terms) — filter owl:deprecated deliberately. EFO additionally prefixes labels with 'obsolete_', but owl:deprecated is the reliable signal (4,930 vs 4,915)."
     - "Label coverage: 100% of ACTIVE terms in hp/go/so, but cl has 189 and uberon 45 active classes with no label. Use OPTIONAL when enumerating."
     - "Foreign graphs assert subClassOf edges on terms they do not own (GO_0003276's only edge is in ontology/uberon) — an unpinned expansion silently changes the answer set."
     - "One label disagreement is a genuine upstream error, not a variant: xco labels RO_0002211 'has_component' where six graphs say 'regulates'."
+    - "owl:Class totals include imported classes and overstate native vocabulary size for efo/cl/uberon/pro/clo — but NOT for go/hp/mondo/sio/meo/cmo/mmo/uo, which are 100% native."
   text_search_justification:
     - "Number of the 7 example queries that use text search: 0"
-    - "Text search is never justified here: every term carries skos:notation (100%), rdfs:label and hasExactSynonym as controlled xsd:string fields, so an exact pinned match answers a known name deterministically."
+    - "Text search is never justified here: every term carries a controlled label/ID/synonym field as an exact-match xsd:string, so a pinned exact match answers a known name deterministically."
     - "For a name you only know approximately, OLS4:searchClasses is the fallback — but VERIFIED caveat: it ranks by relevance, not exactness, and buries an exact match whose name is a substring of its descendants' names (searchClasses('seizure', hp): HP_0001250 absent from the top 20 of 364). Always try the exact ^^xsd:string match first."
 
 data_statistics:
   total_entities: 785551
   verified_date: "2026-07-16"
-  verification_method: "COUNT(DISTINCT ?c) of owl:Class per graph (isIRI-filtered), summed over the 22 substantive ontology graphs"
+  verification_method: |
+    COUNT(*) of `?c a owl:Class` per graph with FILTER(isIRI(?c)), summed over the 22 substantive
+    ontology graphs (the 22 totals below sum to exactly 785,551).
+    `native` = the same count restricted to that ontology's OWN IRI namespace (see
+    schema_info.iri_namespaces) via STRSTARTS. total - native = classes embedded from the
+    upstream import closure (NCBITaxon, CHEBI, CL, ...). So `total` is "owl:Class present in this
+    graph", NOT "size of this ontology". Native sums to ~574,578 over the 19 measured graphs;
+    the 3 schema vocabularies are not native-measured.
   graphs_total: 37
-  by_class:
-    pro: 365852
-    fma: 104721
-    efo: 93358
-    go: 51967
-    clo: 43327
-    mondo: 33840
-    uberon: 27295
-    hp: 23829
-    cl: 19167
-    cmo: 4149
-    edam: 3524
-    so: 2747
-    meo: 2390
-    eco: 2304
-    po: 2027
-    xco: 1839
-    sio: 1585
-    mmo: 851
-    uo: 574
-    glycordf: 136
-    piero: 35
-    orth: 34
+  by_class:                       # {graph: {total, native}} — native omitted for schema vocabularies
+    pro:      {total: 365852, native: 260942}   # native ns: obo/PR_ (71%)
+    fma:      {total: 104721, native: 104720}   # native ns: sig/ont/fma/fma — the 1 other is dcterms:Agent
+    efo:      {total: 93358,  native: 18382}    # native ns: ebi.ac.uk/efo/EFO_ (20%) — 62,233 are obo imports
+    go:       {total: 51967,  native: 51967}    # 100% native
+    clo:      {total: 43327,  native: 39082}    # (90%)
+    mondo:    {total: 33840,  native: 33840}    # 100% native
+    uberon:   {total: 27295,  native: 16358}    # (60%)
+    hp:       {total: 23829,  native: 23829}    # 100% native
+    cl:       {total: 19167,  native: 3607}     # (19%) — the most import-heavy graph
+    cmo:      {total: 4149,   native: 4149}     # 100% native
+    edam:     {total: 3524,   native: 3522}     # native ns: edamontology.org
+    so:       {total: 2747,   native: 2650}     # (96%)
+    meo:      {total: 2390,   native: 2390}     # native ns: mdatahub.org/data/meo — 100% native
+    eco:      {total: 2304,   native: 2303}
+    po:       {total: 2027,   native: 1996}
+    xco:      {total: 1839,   native: 1831}
+    sio:      {total: 1585,   native: 1585}     # native ns: semanticscience.org — 100% native
+    mmo:      {total: 851,    native: 851}
+    uo:       {total: 574,    native: 574}
+    glycordf: {total: 136}                      # schema vocabulary
+    piero:    {total: 35}                       # schema vocabulary
+    orth:     {total: 34}                       # schema vocabulary
   coverage:
     hp_skos_notation: "100%"
     hp_rdfs_label: "85.5%"
     calculation: "20,384 labelled / 23,829 hp classes; the 3,445 unlabelled are all deprecated"
     hp_deprecated: "16.9%"
+    go_deprecated: "13,704 classes"
     go_labelled_but_obsolete: "20.8%"
     go_obsolete_calculation: "10,058 labelled-obsolete / 48,321 labelled go classes"
+    efo_deprecated: "26.8%"
+    efo_deprecated_calculation: "4,930 deprecated / 18,382 native EFO classes; 4,915 of those also carry an 'obsolete_' label prefix"
 
 anti_patterns:
+  - title: "Assuming the obo namespace for a non-obo ontology (silent 0 rows)"
+    problem: "Minting <http://purl.obolibrary.org/obo/EFO_...> / FMA_ / SIO_ / EDAM_ / MEO_ because every other ontology on this endpoint uses obo. These five do not. The query is syntactically perfect and returns nothing, with no error and no hint that the namespace is the cause."
+    wrong_sparql: |
+      # 0 rows — the IRI simply does not exist in the graph
+      GRAPH <http://rdfportal.org/ontology/fma> {
+        <http://purl.obolibrary.org/obo/FMA_7088> rdfs:label ?label
+      }
+    correct_sparql: |
+      # "Heart" — lowercase 'fma', no underscore
+      GRAPH <http://rdfportal.org/ontology/fma> {
+        <http://purl.org/sig/ont/fma/fma7088> rdfs:label ?label
+      }
+    explanation: "Verified 2026-07-16. Likewise EFO -> http://www.ebi.ac.uk/efo/EFO_0022223, SIO -> http://semanticscience.org/resource/SIO_000776, EDAM -> http://edamontology.org/data_0863 (no 'EDAM_' prefix exists at all), MEO -> https://mdatahub.org/data/meo/MEO_0000001. Build every IRI from schema_info.iri_namespaces."
+
+  - title: "Expanding an anatomy term with subClassOf* only (drops the partonomy)"
+    problem: "UBERON/FMA/PO express sub-structure with part_of (BFO_0000050) owl:Restriction bnodes. subClassOf* — especially with the isIRI(?parent) filter that is correct for HP/GO — returns only taxon-specific is_a variants, so every actual body part silently disappears."
+    wrong_sparql: |
+      # 5 rows, and NOT ONE is a part of the brain — all are taxon variants of "brain" itself
+      SELECT ?c WHERE { GRAPH <http://rdfportal.org/ontology/uberon> {
+        ?c rdfs:subClassOf* <http://purl.obolibrary.org/obo/UBERON_0000955> . FILTER(isIRI(?c)) } }
+    correct_sparql: |
+      # 72 direct anatomical parts (diencephalon, cerebellum, ...)
+      SELECT ?part WHERE { GRAPH <http://rdfportal.org/ontology/uberon> {
+        ?part rdfs:subClassOf [ a owl:Restriction ;
+          owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          owl:someValuesFrom <http://purl.obolibrary.org/obo/UBERON_0000955> ] } }
+    explanation: "Verified 2026-07-16. The anatomical hierarchy is part_of, not is_a. subClassOf means 'is a kind of', not 'is part of' — a distinction that silently returns 5 wrong rows instead of 72 right ones."
+
   - title: "Unpinned Hierarchy Expansion (changes the ANSWER SET, not just the row count)"
     problem: "Expanding a subtree without a GRAPH clause on a 37-graph endpoint. Foreign ontologies assert subClassOf edges on terms they do not own, so the union returns terms the owning ontology does not place in that subtree. COUNT(DISTINCT) does NOT repair this."
     wrong_sparql: |
@@ -574,15 +869,25 @@ anti_patterns:
           ?c rdfs:subClassOf* <http://purl.obolibrary.org/obo/GO_0006915> .
         }
       }
-    explanation: "Verified 2026-07-16. GO_0003276's ONLY subClassOf edge lives in <ontology/uberon>, so the union makes it an apoptosis descendant while GO itself does not. Pin the owning graph."
+    explanation: "Verified 2026-07-16. GO_0003276, GO_1900204, GO_1900205, GO_1901146 and GO_1901147 have their ONLY subClassOf edge in <ontology/uberon>, so the union makes them apoptosis descendants while GO itself does not. Pin the owning graph."
 
-  - title: "Plain Literal Where xsd:string Is Stored"
-    problem: "Exact-matching a label, synonym or notation with a plain literal. Every literal in these graphs is xsd:string; Virtuoso does not unify the two forms, so the query returns zero rows with no error."
+  - title: "COUNT(*) over a subClassOf* expansion joined to data (DAG double-counting)"
+    problem: "Treating a hierarchy expansion as a set. These are DAGs: a multi-parent term is returned once per path, so every joined data row is multiplied by that term's path count. The result looks plausible and is wrong — and because the distortion is uneven, it changes rankings, not just totals."
     wrong_sparql: |
-      ?t oboInOwl:hasExactSynonym "Epileptic seizure"          # 0 rows, silently
+      # 111,591 "annotations" — inflated 48%; ranks Intellectual disability (4,984) above Seizure
+      SELECT ?label (COUNT(*) AS ?n) WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ; rdfs:label ?label . }
+        GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term } }
+      GROUP BY ?label ORDER BY DESC(?n)
     correct_sparql: |
-      ?t oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string   # HP_0001250
-    explanation: "Verified 2026-07-16. VALUES blocks are the highest-miss spot because the typing requirement is not visually cued there."
+      # 75,562 true distinct annotations; Seizure (2,979) correctly first
+      SELECT ?label (COUNT(DISTINCT ?annotation) AS ?n) WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ; rdfs:label ?label . }
+        GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term } }
+      GROUP BY ?label ORDER BY DESC(?n)
+    explanation: "Verified 2026-07-16. The HP_0000707 expansion is 4,767 path rows over 2,825 distinct terms. Two-parent terms inflate exactly 2x (Intellectual disability 4,984 -> 2,492; Microcephaly 3,624 -> 1,812) while single-parent terms are untouched (Seizure 2,979 -> 2,979) — which is precisely why the ranking breaks."
 
   - title: "Skipping Schema Check Before Text Search — and trusting OLS4's rank for an exact name"
     problem: "Reaching for bif:contains to find a term by name. rdfs:label / hasExactSynonym are controlled xsd:string fields, so an exact match is both cheaper and deterministic. NOTE the counter-intuitive part: OLS4:searchClasses is ALSO the wrong tool for an exact name here."
@@ -604,38 +909,36 @@ anti_patterns:
       relevance ranking buries the exact match. Use OLS4 for fuzzy/exploratory lookup,
       definitions and ancestors; use the pinned exact-match above when you know the name.
 
-  - title: "Filtering Labels By LANG = en"
-    problem: "Assuming ontology labels are English-tagged. They are xsd:string with NO tag; only imported RO_/BFO_ properties are @en, and they are ~1% of labels."
-    wrong_sparql: |
-      ?t rdfs:label ?l . FILTER(LANG(?l) = "en")     # drops ~99% of labels
-    correct_sparql: |
-      ?t rdfs:label ?l . FILTER(LANG(?l) IN ("", "en"))
-    explanation: "Verified 2026-07-16: CL has 21,356 untagged labels vs 287 @en. The IN form also excludes PubCaseFinder's @ja HP labels."
-
 common_errors:
+  - error: "Lookup returns zero rows although the term certainly exists"
+    causes:
+      - "obo namespace assumed for EFO / SIO / EDAM / MEO / FMA — the IRI does not exist (the #1 cause)"
+      - "Plain literal used where xsd:string is stored (labels, synonyms, notation, IDs)"
+      - "A predicate hard-coded from the obo family that the target ontology does not have (skos:notation on FMA, IAO_0000115 on EDAM/SIO/FMA)"
+      - "FILTER(LANG(?label) = \"en\") — drops ~99% of labels, which carry no language tag"
+    solutions:
+      - "Build the IRI from schema_info.iri_namespaces; FMA is lowercase with no underscore, EDAM has no EDAM_ prefix"
+      - "Annotate every exact-match literal ^^xsd:string"
+      - "Check cross_references.predicate_by_ontology before assuming a predicate"
+      - "Use FILTER(LANG(?label) IN (\"\", \"en\"))"
+
+  - error: "Counts are too high, or a ranking looks subtly wrong"
+    causes:
+      - "COUNT(*) over a subClassOf* expansion — DAG path multiplicity multiplies each joined row"
+      - "Unpinned GRAPH, so all 37 graphs' copies of a predicate matched"
+      - "Union of <ontology/pro> and <ontology/pro-reasoned>, which double-counts asserted + entailed"
+      - "An owl:Class total mistaken for the ontology's native size (EFO is 20% native, CL 19%)"
+    solutions:
+      - "COUNT(DISTINCT ?entity) over any subClassOf* expansion — always"
+      - "Pin the owning graph in every pattern"
+      - "Pick /pro OR /pro-reasoned deliberately, never both"
+      - "Read data_statistics.by_class, which separates total from native"
+
   - error: "Label lookup returns an obsolete term, or two contradictory labels"
     causes:
-      - "No owl:deprecated filter — 10,058 labelled GO classes are obsolete"
+      - "No owl:deprecated filter — 10,058 labelled GO classes and 4,930 native EFO classes are obsolete"
       - "Unpinned GRAPH, so a foreign graph's copy of the label won (e.g. xco's 'has_component' for RO_0002211)"
     solutions:
       - "Add FILTER NOT EXISTS { ?t owl:deprecated true }"
-      - "Pin the owning graph via the prefix map in architectural_notes.schema_design"
+      - "Pin the owning graph via iri_namespaces + architectural_notes.schema_design"
       - "Run query example 7 to detect collisions before trusting a resolution"
-
-  - error: "Exact match returns zero rows although the value is visibly present"
-    causes:
-      - "Plain literal used where xsd:string is stored (labels, synonyms, notation, IDs)"
-      - "IAO_0100001 assumed to be an IRI when the row stores an xsd:string CURIE (or vice versa)"
-    solutions:
-      - "Annotate every exact-match literal ^^xsd:string"
-      - "Normalize IAO_0100001 with IF(isIRI(?o), ?o, IRI(CONCAT(...))) — see query example 5"
-
-  - error: "Query times out at 60s"
-    causes:
-      - "Aggregating over an unbound ?g across all 37 graphs"
-      - "UNION of a predicate across 3+ graphs"
-      - "Property path inside FILTER NOT EXISTS (Virtuoso: 'transitive start not given')"
-    solutions:
-      - "Bind ?g with VALUES, or pin a single GRAPH"
-      - "Split into per-graph queries"
-      - "Restructure the path as a subquery + MINUS"

--- a/togo_mcp/data/mie/ontology.yaml
+++ b/togo_mcp/data/mie/ontology.yaml
@@ -1,0 +1,641 @@
+schema_info:
+  title: Ontology Graphs (RDF Portal primary endpoint)
+  description: |
+    A cross-ontology TERM-RESOLUTION and HIERARCHY-EXPANSION surface, not a data source.
+    The primary endpoint hosts 37 named graphs under http://rdfportal.org/ontology/ carrying
+    ~785,551 owl:Class definitions — HP, UBERON, CL, SO, ECO, EFO, PRO, FMA, CLO, EDAM, SIO,
+    PO, XCO, CMO, MEO, MMO, UO — plus the GO/MONDO/taxonomy graphs and the glycordf/orth/piero
+    schema vocabularies. Use this entry to (1) resolve an opaque OBO IRI (SO_0000704,
+    RO_0002211) to a label/definition/synonym set, and (2) expand a term to its subsumption
+    subtree and JOIN that subtree against data co-located on the same endpoint — the one thing
+    OLS4 cannot do. For deep single-ontology work on GO, MONDO, or taxonomy use their own MIE
+    files (go, mondo, taxonomy); this entry covers the ~20 ontologies that have none.
+  keywords:
+    - ontology
+    - controlled vocabulary
+    - term lookup
+    - label resolution
+    - iri resolution
+    - subsumption hierarchy
+    - subclass expansion
+    - phenotype
+    - anatomy
+    - cell type
+    - evidence code
+    - sequence feature type
+    - synonym
+    - obsolete term
+    - obo
+  categories:
+    - ontology
+  endpoint: https://rdfportal.org/primary/sparql
+  base_uri: http://purl.obolibrary.org/obo/
+  graphs:
+    # --- Substantive ontologies WITHOUT their own MIE (this entry's primary scope) ---
+    - http://rdfportal.org/ontology/pro            # PRotein Ontology — 365,852 classes (asserted)
+    - http://rdfportal.org/ontology/pro-reasoned   # PRO inference closure — 13.8M triples (see critical_warnings)
+    - http://rdfportal.org/ontology/fma            # Foundational Model of Anatomy 5.0.0 — 104,721
+    - http://rdfportal.org/ontology/efo            # Experimental Factor Ontology 3.90.0 — 93,358
+    - http://rdfportal.org/ontology/clo            # Cell Line Ontology 2.1.188 — 43,327
+    - http://rdfportal.org/ontology/uberon         # Uberon anatomy — 27,295
+    - http://rdfportal.org/ontology/hp             # Human Phenotype Ontology 2026-06-06 — 23,829
+    - http://rdfportal.org/ontology/cl             # Cell Ontology 2026-06-08 — 19,167
+    - http://rdfportal.org/ontology/cmo            # Clinical Measurement Ontology 2026-05-30 — 4,149
+    - http://rdfportal.org/ontology/edam           # EDAM 1.26-unstable — 3,524
+    - http://rdfportal.org/ontology/so             # Sequence Ontology — 2,747
+    - http://rdfportal.org/ontology/meo            # Metagenome/Environment Ontology 1.0 — 2,390
+    - http://rdfportal.org/ontology/eco            # Evidence & Conclusion Ontology — 2,304
+    - http://rdfportal.org/ontology/po             # Plant Ontology — 2,027
+    - http://rdfportal.org/ontology/xco            # Experimental Condition Ontology 2026-06-06 — 1,839
+    - http://rdfportal.org/ontology/sio            # Semanticscience Integrated Ontology 1.61 — 1,585
+    - http://rdfportal.org/ontology/mmo            # Measurement Method Ontology — 851
+    - http://rdfportal.org/ontology/uo             # Units of measurement 2026-01-16 — 574
+    # --- Schema vocabularies (predicates you USE, not terms you look up) ---
+    - http://rdfportal.org/ontology/glycordf       # GlycoRDF schema behind GlyCosmos — 136
+    - http://rdfportal.org/ontology/piero          # Reaction/enzyme partial ontology — 35
+    - http://rdfportal.org/ontology/orth           # Orthology Ontology 2.0 (OMA instantiates it) — 34
+    # --- Have their OWN MIE file: use go / mondo / taxonomy instead for deep work ---
+    - http://rdfportal.org/ontology/go             # Gene Ontology 2026-05-19 — 51,967 (MIE: go)
+    - http://rdfportal.org/ontology/mondo          # MONDO simple 2026-06-02 — 33,840 (MIE: mondo)
+    - http://rdfportal.org/ontology/taxonomy       # NCBI taxonomy DATA, 41.3M triples (MIE: taxonomy)
+    # --- Utility / W3C vocabularies (tiny; loaded for term resolution only) ---
+    - http://rdfportal.org/ontology/nucleotide     # DDBJ sequence-feature vocabulary — 14,238 triples
+    - http://rdfportal.org/ontology/qudt           # 3,276 triples
+    - http://rdfportal.org/ontology/prov-o         # 1,146 triples
+    - http://rdfportal.org/ontology/dcterms        # 700 triples
+    - http://rdfportal.org/ontology/foaf           # 631 triples
+    - http://rdfportal.org/ontology/owl            # 450 triples
+    - http://rdfportal.org/ontology/pav            # 344 triples
+    - http://rdfportal.org/ontology/skos           # 252 triples
+    - http://rdfportal.org/ontology/faldo          # 235 triples
+    - http://rdfportal.org/ontology/void           # 208 triples
+    - http://rdfportal.org/ontology/rdf            # 127 triples
+    - http://rdfportal.org/ontology/dcelements     # 107 triples
+    - http://rdfportal.org/ontology/rdfs           # 87 triples
+  co_hosted_graphs:
+    - "http://rdfportal.org/ontology/* (all 37) — EVERY ontology graph re-declares the upper-ontology
+       properties and many foreign classes. rdfs:label on IAO_0000115 appears in 15 graphs,
+       BFO_0000050 in 10, RO_0002211 in 7. An unscoped lookup returns one row PER GRAPH."
+    - "http://rdfportal.org/ontology/uberon, /cl, /po, /efo, /clo, /pro — assert rdfs:subClassOf
+       edges on GO_/other foreign terms. Unscoped subtree expansion inherits them and returns a
+       DIFFERENT answer set, not merely inflated rows. See critical_warnings #2."
+    - "https://pubcasefinder.dbcls.jp/rdf — 379,263 oa:hasBody annotations over 10,392 HP terms.
+       The richest join target on this endpoint; also carries Japanese (@ja) HP labels."
+    - "http://rdfportal.org/dataset/open-tggates — cites UBERON, but only 2 terms (liver 20,415 /
+       kidney 4,149). No hierarchy value."
+    - "http://rdfportal.org/dataset/hgnc — cites SO_0000704 ('gene') on 44,997 genes: a single flat
+       type tag, not a discriminative axis."
+  kw_search_tools:
+    - OLS4:searchClasses
+  version:
+    mie_version: "1.0"
+    mie_created: "2026-07-16"
+    data_version: "Per-graph; see graphs list. Snapshot verified 2026-07-16."
+    update_frequency: "Per upstream ontology release (OBO ontologies typically monthly)"
+  access:
+    backend: "Virtuoso"
+
+critical_warnings: |
+  - xsd:STRING EXACT-MATCH TRAP (the #1 silent failure): every literal here is stored as
+    xsd:string. A plain-literal match returns ZERO rows with no error.
+    WRONG:   ?t oboInOwl:hasExactSynonym "Epileptic seizure"        -> 0 rows
+    CORRECT: ?t oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string -> HP_0001250
+    Applies to rdfs:label, skos:notation, oboInOwl:hasExactSynonym, oboInOwl:id,
+    oboInOwl:hasOBONamespace, IAO_0000115. VALUES blocks are the highest-miss spot.
+  - GRAPH-PINNING IS MANDATORY FOR HIERARCHY EXPANSION — and COUNT(DISTINCT) does NOT fix it.
+    Foreign graphs assert rdfs:subClassOf on terms they do not own. Measured on GO_0006915
+    (apoptotic process): unscoped `?c rdfs:subClassOf* GO_0006915` -> 1,537 rows / 77 distinct
+    terms; pinned to GRAPH <ontology/go> -> 104 rows / 72 distinct terms. The 5 extra terms are
+    NOT duplicates: e.g. GO_0003276's ONLY subClassOf edge lives in <ontology/uberon>, not in
+    <ontology/go> at all. The ANSWER SET differs, so DISTINCT masks nothing. Always pin the
+    owning graph.
+  - OBSOLETE TERMS CARRY LABELS AND RESOLVE SILENTLY. owl:deprecated true"^^xsd:boolean marks
+    13,704 GO / 4,019 HP / 1,390 UBERON classes. Of these, 10,058 GO / 574 HP / 1,098 UBERON /
+    214 CL / 211 SO are ALSO labelled — so 21% of labelled GO classes are obsolete and a naive
+    label lookup returns them as if current. Add `FILTER NOT EXISTS { ?t owl:deprecated true }`
+    unless you specifically want obsolete terms.
+  - NEVER FILTER(LANG(?label) = "en"). Each ontology's OWN terms are xsd:string with NO language
+    tag; only the imported RO_/BFO_ upper-ontology properties are @en-tagged, and they are ~1%
+    of labels (287 of 21,643 in CL; 250 of 28,764 in UBERON). LANG="en" therefore drops ~99% of
+    labels silently. Use FILTER(LANG(?label) IN ("", "en")) — which also excludes PubCaseFinder's
+    Japanese (@ja) HP labels.
+  - CONFLICTING LABELS ACROSS GRAPHS — take the OWNING graph's, never "the first row" (row order
+    is arbitrary without ORDER BY). RO_0002211 is "regulates" in go/cl/clo/efo/po/uberon but
+    "has_component" in <ontology/xco> — flatly wrong. <ontology/uberon> additionally carries the
+    variant "regulates (processual)". IAO_0000115 is "definition" in all 15 graphs that declare
+    it, but <ontology/clo> carries BOTH "definition" AND "textual definition" — so a single graph
+    can yield two labels for one IRI. Pin the owner via the prefix map in
+    architectural_notes.schema_design, and expect to pick among several rows even then.
+  - RO_/BFO_ PREDICATES HAVE NO HOME GRAPH — there is no <ontology/ro> or <ontology/bfo>. They
+    resolve only because OBO import closures embed them, so EVERY hit is second-hand. Prefer the
+    <ontology/go> copy; expect benign variants ("part of"/"part_of", "regulates"/"regulates
+    (processual)"); treat a lone dissenter as noise.
+  - IAO_0100001 ("term replaced by") IS POLYMORPHIC WITHIN THE SAME GRAPH: <ontology/go> stores
+    3,646 IRI objects AND 2,211 xsd:string CURIE literals ("GO:0039502"); <ontology/hp> 3,961 IRI
+    + 494 literal; <ontology/uberon> 536 IRI only. Assuming either form silently drops the other
+    (38% of GO's mappings if you assume IRI). Normalize both — see query example 5.
+  - <ontology/pro-reasoned> IS THE MATERIALIZED INFERENCE CLOSURE of <ontology/pro> (13.8M vs
+    PRO's asserted graph). Querying the union of both double-counts. Pick one deliberately:
+    /pro for asserted axioms, /pro-reasoned for entailed ones.
+  - <ontology/taxonomy> IS NOT A SCHEMA — it holds 41.3M triples of NCBI taxonomy DATA and is what
+    the registered `taxonomy` database points at. Do not treat it as a lightweight vocabulary.
+  - LABEL COVERAGE IS NOT 100%. In HP every unlabelled class is deprecated (3,445 of 3,445), but
+    that rule does NOT generalize: <ontology/cl> has 189 ACTIVE classes with no rdfs:label and
+    <ontology/uberon> has 45. Use OPTIONAL for rdfs:label when enumerating, or you will silently
+    drop active terms.
+  - <http://purl.jp/bio/11/goa> IS A SCHEMA STUB (owl:ObjectProperty declarations only), NOT GO
+    annotation data. It contains no GO_ term references — do not try to join to it.
+
+shape_expressions: |
+  PREFIX obo: <http://purl.obolibrary.org/obo/>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+  # One shape describes an OBO class in ANY of the ontology graphs — the schema is uniform
+  # across hp/go/uberon/cl/so/eco/... Counts below are from <ontology/hp> (23,829 classes)
+  # unless noted; the same predicates and datatypes were confirmed in go/uberon/cl.
+  <OboClassShape> {
+    a [ owl:Class ] ;                                  # 23,829 in hp — always present
+    skos:notation xsd:string ;                         # 23,829 (100%) — the CURIE, e.g. "HP:0001250"
+    rdfs:subClassOf (IRI OR BNODE) * ;                 # POLYMORPHIC, and the mix varies BY GRAPH:
+                                                       #   hp:     24,330 — ALL IRI, no bnodes
+                                                       #   go:     66,148 IRI + 16,215 bnode(owl:Restriction)
+                                                       #   uberon: 36,670 IRI + 43,981 bnode — 54% BNODE,
+                                                       #           incl. 428 bnodes typed owl:Class
+                                                       #   Filter isIRI(?parent) when walking; see below.
+    rdfs:label xsd:string ? ;                          # 20,384 (85.5%) — ABSENT on 3,445 deprecated hp
+                                                       #   classes; in cl/uberon some ACTIVE classes
+                                                       #   also lack it (189 / 45). NO lang tag.
+    oboInOwl:id xsd:string ? ;                         # 20,384 — duplicates skos:notation
+    oboInOwl:hasOBONamespace xsd:string ? ;            # 20,384 — e.g. "human_phenotype"
+    oboInOwl:hasExactSynonym xsd:string * ;            # 23,386 triples — MUST match ^^xsd:string
+    oboInOwl:hasRelatedSynonym xsd:string * ;          # 1,489
+    oboInOwl:hasBroadSynonym xsd:string * ;            # 556
+    oboInOwl:hasNarrowSynonym xsd:string * ;           # 541
+    oboInOwl:hasDbXref xsd:string * ;                  # 18,056 triples / 11,478 classes (48.2%) —
+                                                       #   CURIE STRINGS, not IRIs. Also present on
+                                                       #   non-class axiom nodes: anchor on owl:Class.
+    oboInOwl:hasAlternativeId xsd:string * ;           # 3,961 — merged-in obsolete CURIEs
+    oboInOwl:inSubset IRI * ;                          # 845 — e.g. slim membership (VERIFIED IRI)
+    oboInOwl:consider xsd:string * ;                   # 85 — suggested replacement for an obsolete
+                                                       #   term. A CURIE LITERAL, not an IRI —
+                                                       #   same trap as IAO_0100001/hasDbXref.
+    obo:IAO_0000115 xsd:string ? ;                     # 17,344 — "definition" (VERIFIED label, 14 graphs)
+    obo:IAO_0100001 (IRI OR xsd:string) ? ;            # "term replaced by" — POLYMORPHIC, see warnings
+    obo:IAO_0000231 IRI ? ;                            # 3,961 — "has obsolescence reason"
+    obo:IAO_0000233 xsd:anyURI ? ;                     # 1,461 — "term tracker item" (a LITERAL, not IRI)
+    owl:deprecated xsd:boolean ? ;                     # 4,019 in hp — only ever true^^xsd:boolean
+    rdfs:comment xsd:string ? ;                        # 4,685
+    owl:incompatibleWith IRI * ;                       # 2
+  }
+  # NOT documented (bioportal export artifact, no query value):
+  #   <http://data.bioontology.org/metadata/treeView>  # 24,330 in hp — BioPortal UI hint
+  # obo:terms_date / terms_creator / terms_contributor (13,387 / 11,270 / 6,520 in hp) are
+  # provenance literals; excluded deliberately — no retrieval use case.
+
+sample_rdf_entries:
+  rdf_prefixes: |
+    @prefix obo: <http://purl.obolibrary.org/obo/> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+    @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+  entries:
+    - title: "Active HP term — the canonical resolution target"
+      description: >
+        HP_0001250 in GRAPH <http://rdfportal.org/ontology/hp>. Every literal is xsd:string with
+        no language tag: an exact match MUST carry ^^xsd:string.
+      rdf: |
+        obo:HP_0001250 a owl:Class ;
+            rdfs:label "Seizure"^^xsd:string ;
+            skos:notation "HP:0001250"^^xsd:string ;
+            oboInOwl:id "HP:0001250"^^xsd:string ;
+            oboInOwl:hasOBONamespace "human_phenotype"^^xsd:string ;
+            oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string , "Seizures"^^xsd:string ;
+            oboInOwl:hasAlternativeId "HP:0001275"^^xsd:string ;
+            obo:IAO_0000115 "A seizure is an intermittent abnormality of nervous system physiology characterized by a transient occurrence of signs and/or symptoms due to abnormal excessive or synchronous neuronal activity in the brain."^^xsd:string ;
+            rdfs:subClassOf obo:HP_0012638 .
+    - title: "Obsolete GO term — labelled, and its replacement is a CURIE LITERAL"
+      description: >
+        GO_0039501 in GRAPH <http://rdfportal.org/ontology/go>. It is deprecated yet still carries
+        rdfs:label, so an unfiltered lookup returns it as if current. IAO_0100001 here is an
+        xsd:string CURIE — NOT an IRI — so `?replacement rdfs:label ?l` joins to nothing.
+      rdf: |
+        obo:GO_0039501 a owl:Class ;
+            owl:deprecated true ;
+            rdfs:label "obsolete suppression by virus of host type I interferon production"^^xsd:string ;
+            skos:notation "GO:0039501"^^xsd:string ;
+            oboInOwl:hasOBONamespace "biological_process"^^xsd:string ;
+            obo:IAO_0100001 "GO:0039502"^^xsd:string ;
+            obo:IAO_0000233 "https://github.com/geneontology/go-ontology/issues/29194"^^xsd:anyURI ;
+            rdfs:comment "This term was obsoleted because it represents the same process as symbiont-mediated suppression of host type I interferon-mediated signaling pathway ; GO:0039502."^^xsd:string .
+    - title: "Cross-graph label collision — the same IRI, two contradictory labels"
+      description: >
+        RO_0002211 has no home graph (there is no <ontology/ro>). Six graphs agree on "regulates";
+        <ontology/xco> says "has_component". Both triples below are real and simultaneously
+        retrievable — which one an unpinned query returns is arbitrary.
+      rdf: |
+        # GRAPH <http://rdfportal.org/ontology/go>
+        obo:RO_0002211 rdfs:label "regulates"^^xsd:string .
+
+        # GRAPH <http://rdfportal.org/ontology/xco>   <-- WRONG, but present
+        obo:RO_0002211 rdfs:label "has_component"^^xsd:string .
+
+sparql_query_examples:
+  - title: "Resolve a batch of opaque OBO IRIs to labels (owner-graph pinned)"
+    description: >
+      The flagship pattern. VALUES pairs each IRI with its OWNING graph, which sidesteps the
+      cross-graph label collision entirely and resolves classes AND properties in one round trip.
+    question: "What do SO_0000704, UBERON_0002107, CL_0000236, HP_0001250, ECO_0000269 and GO_0006915 mean?"
+    complexity: basic
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+      SELECT ?iri ?label ?obsolete
+      WHERE {
+        VALUES (?iri ?g) {
+          (<http://purl.obolibrary.org/obo/HP_0001250>     <http://rdfportal.org/ontology/hp>)
+          (<http://purl.obolibrary.org/obo/SO_0000704>     <http://rdfportal.org/ontology/so>)
+          (<http://purl.obolibrary.org/obo/UBERON_0002107> <http://rdfportal.org/ontology/uberon>)
+          (<http://purl.obolibrary.org/obo/GO_0006915>     <http://rdfportal.org/ontology/go>)
+          (<http://purl.obolibrary.org/obo/CL_0000236>     <http://rdfportal.org/ontology/cl>)
+          (<http://purl.obolibrary.org/obo/ECO_0000269>    <http://rdfportal.org/ontology/eco>)
+        }
+        GRAPH ?g {
+          ?iri rdfs:label ?label .
+          OPTIONAL { ?iri owl:deprecated ?dep }
+        }
+        FILTER(LANG(?label) IN ("", "en"))
+        BIND(COALESCE(?dep, false) AS ?obsolete)
+      }
+    # Verified 2026-07-16: 6 rows, exactly one label each — gene / liver / B cell / Seizure /
+    # experimental evidence used in manual assertion / apoptotic process. All obsolete=false.
+
+  - title: "Full term record — label, CURIE, definition and synonyms"
+    description: >
+      Everything an agent needs to confirm it has the right term before building a query on it.
+      skos:notation carries the CURIE (100% coverage); IAO_0000115 is the definition.
+    question: "What is HP:0001250 — its CURIE, definition and exact synonyms?"
+    complexity: basic
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+      PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+      SELECT ?label ?curie ?definition
+             (GROUP_CONCAT(DISTINCT ?syn; separator=" | ") AS ?synonyms)
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          <http://purl.obolibrary.org/obo/HP_0001250> rdfs:label ?label ;
+              skos:notation ?curie ;
+              obo:IAO_0000115 ?definition .
+          OPTIONAL { <http://purl.obolibrary.org/obo/HP_0001250> oboInOwl:hasExactSynonym ?syn }
+        }
+      }
+      GROUP BY ?label ?curie ?definition
+    # Verified 2026-07-16: Seizure / HP:0001250 / full definition / "Epileptic seizure | Seizures".
+
+  - title: "Expand a term to its active subsumption subtree (graph-pinned)"
+    description: >
+      The core hierarchy operation. Pinning <ontology/hp> keeps foreign subClassOf edges out;
+      the owl:deprecated filter keeps obsolete terms out. Both are mandatory — see warnings.
+    question: "How many active HP terms are descendants of 'Abnormality of the nervous system'?"
+    complexity: intermediate
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+      SELECT (COUNT(DISTINCT ?term) AS ?activeDescendants)
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ;
+                rdfs:label ?label .
+          FILTER NOT EXISTS { ?term owl:deprecated true }
+        }
+      }
+    # Verified 2026-07-16: 2,825 active descendants.
+
+  - title: "Find a term by its exact synonym (structured, no text search)"
+    description: >
+      Synonyms are a controlled field, so an exact match beats any text search. The ^^xsd:string
+      annotation is REQUIRED — the plain-literal form returns zero rows silently.
+    question: "Which HP term has the exact synonym 'Epileptic seizure'?"
+    complexity: intermediate
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+      SELECT ?term ?curie ?label
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          ?term oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string ;
+                rdfs:label ?label ;
+                skos:notation ?curie .
+        }
+      }
+    # Verified 2026-07-16: HP_0001250 / HP:0001250 / Seizure. Without ^^xsd:string: 0 rows.
+
+  - title: "Map obsolete terms to their replacements (handles the polymorphic object)"
+    description: >
+      IAO_0100001 stores its object as an IRI in some rows and an xsd:string CURIE in others,
+      within the same graph. The BIND normalizes the CURIE form to an IRI so both join.
+    question: "Which GO terms are obsolete, and what replaced them?"
+    complexity: intermediate
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX obo: <http://purl.obolibrary.org/obo/>
+
+      SELECT ?obsolete ?oldLabel ?replacementIRI ?newLabel
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/go> {
+          ?obsolete owl:deprecated true ;
+                    rdfs:label ?oldLabel ;
+                    obo:IAO_0100001 ?rawReplacement .
+        }
+        BIND(IF(isIRI(?rawReplacement),
+                ?rawReplacement,
+                IRI(CONCAT("http://purl.obolibrary.org/obo/",
+                           REPLACE(STR(?rawReplacement), ":", "_")))
+             ) AS ?replacementIRI)
+        GRAPH <http://rdfportal.org/ontology/go> { ?replacementIRI rdfs:label ?newLabel }
+      }
+      ORDER BY ?obsolete
+      LIMIT 6
+    # Verified 2026-07-16: e.g. GO_0000003 "obsolete reproduction" -> GO_0022414
+    # "reproductive process". Resolves rows of BOTH object forms.
+
+  - title: "Subtree expansion JOINED to co-located annotation data"
+    description: >
+      The capability OLS4 cannot provide: expand HP to a 2,825-term subtree and join it to
+      PubCaseFinder's 379,263 phenotype annotations in ONE query, with no 1,546-IRI VALUES block.
+      Both graphs are pinned.
+    question: "Which nervous-system phenotypes are most frequently annotated in PubCaseFinder?"
+    complexity: advanced
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX oa: <http://www.w3.org/ns/oa#>
+
+      SELECT ?label (COUNT(*) AS ?annotations)
+      WHERE {
+        GRAPH <http://rdfportal.org/ontology/hp> {
+          ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> ;
+                rdfs:label ?label .
+          FILTER NOT EXISTS { ?term owl:deprecated true }
+        }
+        GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term }
+      }
+      GROUP BY ?label
+      ORDER BY DESC(?annotations)
+      LIMIT 10
+    # Verified 2026-07-16: Intellectual disability 4,984 / Microcephaly 3,624 / Seizure 2,979 /
+    # Dandy-Walker malformation 2,232 / Global developmental delay 2,134 ...
+
+  - title: "Detect cross-graph label collisions before trusting a resolution"
+    description: >
+      The diagnostic for critical_warning #5. Compare on STR(?label), NOT on ?label — the latter
+      counts "Seizure"^^xsd:string and "Seizure"@en as distinct and reports false collisions.
+    question: "Which of these IRIs are labelled inconsistently across the ontology graphs?"
+    complexity: advanced
+    sparql: |
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?iri (COUNT(DISTINCT ?g) AS ?graphs) (COUNT(DISTINCT ?lex) AS ?distinctLabels)
+             (GROUP_CONCAT(DISTINCT CONCAT(?gs, "=", ?lex); separator=" | ") AS ?variants)
+      WHERE {
+        VALUES ?iri {
+          <http://purl.obolibrary.org/obo/RO_0002211>
+          <http://purl.obolibrary.org/obo/BFO_0000050>
+          <http://purl.obolibrary.org/obo/IAO_0000115>
+          <http://purl.obolibrary.org/obo/HP_0001250>
+        }
+        GRAPH ?g { ?iri rdfs:label ?label }
+        FILTER(LANG(?label) IN ("", "en"))
+        BIND(STR(?label) AS ?lex)
+        BIND(REPLACE(STR(?g), "http://rdfportal.org/ontology/", "") AS ?gs)
+      }
+      GROUP BY ?iri
+      HAVING (COUNT(DISTINCT ?lex) > 1)
+      ORDER BY DESC(?distinctLabels)
+    # Verified 2026-07-16: RO_0002211 (7 graphs, 3 labels — xco="has_component" is wrong);
+    # BFO_0000050 (10 graphs, "part of"/"part_of"); IAO_0000115 (15 graphs, clo="textual
+    # definition"). HP_0001250 correctly EXCLUDED — both its graphs agree on "Seizure".
+
+cross_database_queries:
+  shared_endpoint: primary
+  co_located_databases: [go, mondo, taxonomy, mesh, nando, hgnc, bacdive, mediadive, brenda, jpostdb, massbank, nbrc, mogplus, hco, mco]
+  examples:
+    - title: "HP subtree x PubCaseFinder phenotype annotations"
+      description: |
+        Linking strategy:
+        - ontology/hp: rdfs:subClassOf* expands the term to its subtree (IRI-keyed)
+        - pubcasefinder: oa:hasBody points at the SAME obo HP_ IRIs — direct IRI match, no bridging
+        - Both graphs pinned; deprecated terms excluded
+        This is the only rich ontology-to-data join on the endpoint (10,392 distinct HP terms).
+      databases_used: [ontology, pubcasefinder]
+      complexity: advanced
+      sparql: |
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX owl: <http://www.w3.org/2002/07/owl#>
+        PREFIX oa: <http://www.w3.org/ns/oa#>
+
+        SELECT (COUNT(DISTINCT ?term) AS ?termsUsed) (COUNT(*) AS ?annotations)
+        WHERE {
+          GRAPH <http://rdfportal.org/ontology/hp> {
+            ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/HP_0000707> .
+            FILTER NOT EXISTS { ?term owl:deprecated true }
+          }
+          GRAPH <https://pubcasefinder.dbcls.jp/rdf> { ?annotation oa:hasBody ?term }
+        }
+      notes: |
+        - Linking via: obo HP_ IRIs, identical on both sides (no namespace translation)
+        - Verified 2026-07-16: 1,546 terms / 111,591 annotations
+        - PubCaseFinder is NOT a registered TogoMCP database; query it via this entry
+  notes: |
+    Most ontology graphs here are INERT — joined to nothing on this endpoint. PRO (365,852
+    classes), FMA, EFO and CLO have no data consumer; their only inbound references come from
+    other ontology graphs. The measured ontology-to-data links are: HP <- pubcasefinder
+    (10,392 terms, rich); ECO <- glycosmos glycogenes (1,121 refs, 1 term); UBERON <-
+    open-tggates (2 terms only); SO <- hgnc (1 term only); CL <- refex/fantom5 (14 refs).
+    Only the HP link supports hierarchy-aware querying. Do not assume a graph's size implies
+    it is queryable against data.
+
+cross_references:
+  - pattern: oboInOwl:hasDbXref
+    description: |
+      Cross-references to external vocabularies, stored as xsd:string CURIEs — NOT as IRIs.
+      Multi-valued: 18,056 triples over 11,478 of 23,829 hp classes (48.2%). NOTE the predicate
+      also hangs off non-class nodes (axiom reifications): unanchored it has 32,301 distinct
+      subjects, MORE than the 23,829 classes — so always anchor on `?s a owl:Class` before
+      computing coverage. Because the value is a literal CURIE it cannot be joined directly to an
+      IRI-keyed database; parse the prefix and mint the target IRI, or route through TogoID.
+  - pattern: skos:notation
+    description: |
+      The term's own CURIE ("HP:0001250"), xsd:string, on 23,829 of 23,829 hp classes (100%) —
+      the most reliable identifier field here, and more complete than rdfs:label (85.5%). Use it
+      to render an IRI as the ID form a user recognizes.
+  - pattern: rdfs:subClassOf
+    description: |
+      The subsumption backbone. Objects are IRIs for named parents and BNODEs for owl:Restriction
+      axioms — but the mix varies sharply by graph: hp is 100% IRI (24,330, no bnodes at all),
+      whereas uberon is 54% BNODE (43,981 bnode vs 36,670 IRI) and go is ~20% (16,215 vs 66,148).
+      Filter isIRI(?parent) when walking the hierarchy or the restriction axioms pollute the
+      result — harmless in hp, dominant in uberon. MUST also be graph-pinned; see
+      critical_warnings #2.
+
+architectural_notes:
+  query_strategy:
+    - "FIRST: read this MIE; check whether the target ontology has its OWN MIE (go, mondo, taxonomy) — use that for deep single-ontology work"
+    - "Many IRIs to resolve -> the owner-pinned VALUES batch (query example 1), one round trip"
+    - "One IRI you must genuinely understand (definition, synonyms, ancestors) -> OLS4 fetch / getAncestors / getDescendants — per-ontology authoritative, so no cross-graph collision"
+    - "EXACT term name -> the pinned rdfs:label \"X\"^^xsd:string match, NOT OLS4:searchClasses. VERIFIED: searchClasses('seizure', hp) buries the exact term HP_0001250 below rank 20 of 364 behind its own narrower subtypes. OLS4 search is for FUZZY/exploratory lookup only."
+    - "Hierarchy + a join against data -> SPARQL here; OLS4 cannot join (it would need a 1,546-IRI VALUES block)"
+    - "ALWAYS pin the owning GRAPH; ALWAYS annotate exact-match literals ^^xsd:string"
+    - "Priority: Specific IRIs > owner-pinned label lookup > subtree expansion > text search (never needed here)"
+  schema_design:
+    - "IRI prefix -> owning graph (the pin map): HP_ -> ontology/hp; GO_ -> ontology/go; UBERON_ -> ontology/uberon; CL_ -> ontology/cl; CLO_ -> ontology/clo; SO_ -> ontology/so; ECO_ -> ontology/eco; EFO_ -> ontology/efo; MONDO_ -> ontology/mondo; PR_ -> ontology/pro; FMA_ -> ontology/fma; PO_ -> ontology/po; XCO_ -> ontology/xco; CMO_ -> ontology/cmo; MMO_ -> ontology/mmo; UO_ -> ontology/uo. RO_/BFO_/IAO_ have NO home graph — prefer the ontology/go copy."
+    - "The class schema is uniform across all OBO graphs (owl:Class + skos:notation + rdfs:label + oboInOwl:* + IAO_*), so one shape serves every ontology — only the counts differ."
+    - "Every graph is a self-contained import closure. That is WHY the upper-ontology properties are re-declared 7-15 times and why pinning is mandatory rather than merely tidy."
+  performance:
+    - "Pin the GRAPH in every pattern — it is a correctness requirement AND the main performance lever (unscoped GO_0006915 expansion: 1,537 rows vs 104 pinned)."
+    - "Property paths (rdfs:subClassOf*) fail inside FILTER NOT EXISTS on Virtuoso with 'transitive start not given' — restructure as a subquery + MINUS instead."
+    - "Aggregates over unbound ?g across all 37 graphs time out at 60s. Bind ?g via VALUES."
+    - "A UNION of one predicate across 3+ graphs also times out; split into per-graph queries."
+  data_integration:
+    - "The only rich ontology-to-data join on this endpoint is HP <-> pubcasefinder (379,263 annotations, 10,392 terms)."
+    - "oboInOwl:hasDbXref values are CURIE literals, not IRIs — not directly joinable; use TogoID for external ID mapping."
+  data_quality:
+    - "Obsolete terms are retained in-graph and mostly still labelled (10,058 labelled obsolete GO terms) — filter owl:deprecated deliberately."
+    - "Label coverage: 100% of ACTIVE terms in hp/go/so, but cl has 189 and uberon 45 active classes with no label. Use OPTIONAL when enumerating."
+    - "Foreign graphs assert subClassOf edges on terms they do not own (GO_0003276's only edge is in ontology/uberon) — an unpinned expansion silently changes the answer set."
+    - "One label disagreement is a genuine upstream error, not a variant: xco labels RO_0002211 'has_component' where six graphs say 'regulates'."
+  text_search_justification:
+    - "Number of the 7 example queries that use text search: 0"
+    - "Text search is never justified here: every term carries skos:notation (100%), rdfs:label and hasExactSynonym as controlled xsd:string fields, so an exact pinned match answers a known name deterministically."
+    - "For a name you only know approximately, OLS4:searchClasses is the fallback — but VERIFIED caveat: it ranks by relevance, not exactness, and buries an exact match whose name is a substring of its descendants' names (searchClasses('seizure', hp): HP_0001250 absent from the top 20 of 364). Always try the exact ^^xsd:string match first."
+
+data_statistics:
+  total_entities: 785551
+  verified_date: "2026-07-16"
+  verification_method: "COUNT(DISTINCT ?c) of owl:Class per graph (isIRI-filtered), summed over the 22 substantive ontology graphs"
+  graphs_total: 37
+  by_class:
+    pro: 365852
+    fma: 104721
+    efo: 93358
+    go: 51967
+    clo: 43327
+    mondo: 33840
+    uberon: 27295
+    hp: 23829
+    cl: 19167
+    cmo: 4149
+    edam: 3524
+    so: 2747
+    meo: 2390
+    eco: 2304
+    po: 2027
+    xco: 1839
+    sio: 1585
+    mmo: 851
+    uo: 574
+    glycordf: 136
+    piero: 35
+    orth: 34
+  coverage:
+    hp_skos_notation: "100%"
+    hp_rdfs_label: "85.5%"
+    calculation: "20,384 labelled / 23,829 hp classes; the 3,445 unlabelled are all deprecated"
+    hp_deprecated: "16.9%"
+    go_labelled_but_obsolete: "20.8%"
+    go_obsolete_calculation: "10,058 labelled-obsolete / 48,321 labelled go classes"
+
+anti_patterns:
+  - title: "Unpinned Hierarchy Expansion (changes the ANSWER SET, not just the row count)"
+    problem: "Expanding a subtree without a GRAPH clause on a 37-graph endpoint. Foreign ontologies assert subClassOf edges on terms they do not own, so the union returns terms the owning ontology does not place in that subtree. COUNT(DISTINCT) does NOT repair this."
+    wrong_sparql: |
+      # 1,537 rows / 77 distinct terms — 5 of them pulled in by uberon's edges
+      SELECT (COUNT(DISTINCT ?c) AS ?n) WHERE {
+        ?c rdfs:subClassOf* <http://purl.obolibrary.org/obo/GO_0006915> .
+      }
+    correct_sparql: |
+      # 104 rows / 72 distinct terms — GO's own hierarchy
+      SELECT (COUNT(DISTINCT ?c) AS ?n) WHERE {
+        GRAPH <http://rdfportal.org/ontology/go> {
+          ?c rdfs:subClassOf* <http://purl.obolibrary.org/obo/GO_0006915> .
+        }
+      }
+    explanation: "Verified 2026-07-16. GO_0003276's ONLY subClassOf edge lives in <ontology/uberon>, so the union makes it an apoptosis descendant while GO itself does not. Pin the owning graph."
+
+  - title: "Plain Literal Where xsd:string Is Stored"
+    problem: "Exact-matching a label, synonym or notation with a plain literal. Every literal in these graphs is xsd:string; Virtuoso does not unify the two forms, so the query returns zero rows with no error."
+    wrong_sparql: |
+      ?t oboInOwl:hasExactSynonym "Epileptic seizure"          # 0 rows, silently
+    correct_sparql: |
+      ?t oboInOwl:hasExactSynonym "Epileptic seizure"^^xsd:string   # HP_0001250
+    explanation: "Verified 2026-07-16. VALUES blocks are the highest-miss spot because the typing requirement is not visually cued there."
+
+  - title: "Skipping Schema Check Before Text Search — and trusting OLS4's rank for an exact name"
+    problem: "Reaching for bif:contains to find a term by name. rdfs:label / hasExactSynonym are controlled xsd:string fields, so an exact match is both cheaper and deterministic. NOTE the counter-intuitive part: OLS4:searchClasses is ALSO the wrong tool for an exact name here."
+    wrong_sparql: |
+      ?label bif:contains "'seizure'"
+    correct_sparql: |
+      # Exact name -> pinned, typed, deterministic:
+      GRAPH <http://rdfportal.org/ontology/hp> {
+        ?term rdfs:label "Seizure"^^xsd:string ;
+              skos:notation ?curie .
+        FILTER NOT EXISTS { ?term owl:deprecated true }
+      }
+      # -> exactly HP_0001250 / HP:0001250
+    explanation: >
+      Verified 2026-07-16. OLS4:searchClasses("seizure", ontologyId="hp") returns 364 hits and
+      does NOT surface HP_0001250 ("Seizure") in the top 20 — every high-ranked hit is a NARROWER
+      subtype (Bilateral tonic-clonic seizure with focal onset, Focal impaired awareness
+      seizure, ...). When a term's name is a substring of its own descendants' names, OLS4's
+      relevance ranking buries the exact match. Use OLS4 for fuzzy/exploratory lookup,
+      definitions and ancestors; use the pinned exact-match above when you know the name.
+
+  - title: "Filtering Labels By LANG = en"
+    problem: "Assuming ontology labels are English-tagged. They are xsd:string with NO tag; only imported RO_/BFO_ properties are @en, and they are ~1% of labels."
+    wrong_sparql: |
+      ?t rdfs:label ?l . FILTER(LANG(?l) = "en")     # drops ~99% of labels
+    correct_sparql: |
+      ?t rdfs:label ?l . FILTER(LANG(?l) IN ("", "en"))
+    explanation: "Verified 2026-07-16: CL has 21,356 untagged labels vs 287 @en. The IN form also excludes PubCaseFinder's @ja HP labels."
+
+common_errors:
+  - error: "Label lookup returns an obsolete term, or two contradictory labels"
+    causes:
+      - "No owl:deprecated filter — 10,058 labelled GO classes are obsolete"
+      - "Unpinned GRAPH, so a foreign graph's copy of the label won (e.g. xco's 'has_component' for RO_0002211)"
+    solutions:
+      - "Add FILTER NOT EXISTS { ?t owl:deprecated true }"
+      - "Pin the owning graph via the prefix map in architectural_notes.schema_design"
+      - "Run query example 7 to detect collisions before trusting a resolution"
+
+  - error: "Exact match returns zero rows although the value is visibly present"
+    causes:
+      - "Plain literal used where xsd:string is stored (labels, synonyms, notation, IDs)"
+      - "IAO_0100001 assumed to be an IRI when the row stores an xsd:string CURIE (or vice versa)"
+    solutions:
+      - "Annotate every exact-match literal ^^xsd:string"
+      - "Normalize IAO_0100001 with IF(isIRI(?o), ?o, IRI(CONCAT(...))) — see query example 5"
+
+  - error: "Query times out at 60s"
+    causes:
+      - "Aggregating over an unbound ?g across all 37 graphs"
+      - "UNION of a predicate across 3+ graphs"
+      - "Property path inside FILTER NOT EXISTS (Virtuoso: 'transitive start not given')"
+    solutions:
+      - "Bind ?g with VALUES, or pin a single GRAPH"
+      - "Split into per-graph queries"
+      - "Restructure the path as a subquery + MINUS"

--- a/togo_mcp/data/resources/endpoints.csv
+++ b/togo_mcp/data/resources/endpoints.csv
@@ -34,3 +34,4 @@ mogplus,https://rdfportal.org/primary/sparql,primary,sparql
 hco,https://rdfportal.org/primary/sparql,primary,sparql
 mco,https://rdfportal.org/primary/sparql,primary,sparql
 togovar,https://grch38.togovar.org/sparql,togovar,togovar_search_(gene|disease)
+ontology,https://rdfportal.org/primary/sparql,primary,OLS4:searchClasses

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release 1.6.0

**MINOR** per the agent-pragmatic policy in `CLAUDE.md` — adds a database; old calls are unaffected. No Python or packaging changes; the tool-surface delta is one `endpoints.csv` row plus its MIE file.

### New database: `ontology`
A cross-ontology term-resolution and hierarchy-expansion surface over the 37 ontology graphs on the RDF Portal primary endpoint (785,551 classes) — HP, UBERON, CL, SO, ECO, EFO, PRO, FMA and ~14 others that have no MIE of their own. Listed on the intro page and README.

### MIE corrections (all re-verified against live endpoints 2026-07-16)

- **`ontology` v2.0** — the v1.0 file assumed a single obo namespace, so batch resolution returned **0 rows, silently**, for EFO/SIO/EDAM/MEO/FMA. Adds per-ontology IRI namespaces, a per-ontology predicate map + `FmaClassShape` (FMA has no `skos:notation`/`oboInOwl:*`/`IAO_0000115`), the `part_of` partonomy (UBERON brain: `subClassOf*` returns 5 taxon variants and **zero** body parts vs 72 real parts), and `COUNT(DISTINCT)` over DAG expansions (PubCaseFinder: 111,591 reported vs 75,562 true, which also **reordered** the top 10).
- **`chembl` v3.4** — the typing warning was **inverted**: it told callers to append `^^xsd:string`, the one form that returns 0 rows. ChEMBL stores plain literals.
- **`nando` v2.2** — the `skos:closeMatch` "other targets" category did not exist; 2,150 was a distinct-disease count mislabelled as a triple count. Replaced with the real many-to-many warning.
- **`glycosmos` v4.2** — verified lectin-name grounding layer.

### Root cause behind two of the above

`DATATYPE()` returns `xsd:string` for a plain literal **and** an `xsd:string`-typed one (RDF 1.1 treats them as one value), but Virtuoso matches **terms**, so the two never unify. Deriving the match form from a `DATATYPE()` probe is therefore unsound — and produced the wrong guidance in both `ontology.yaml` and `chembl.yaml`. The `mie-generator` skill now settles the form with a per-form `ASK` instead. `nbrc.yaml` and `rhea.yaml` had already documented this correctly; that knowledge is now in the generator so it stops recurring.

### Verification
- 220/220 tests pass
- All example queries, RDF samples and statistics in the touched MIE files re-run against live endpoints
- `uv.lock` synced with the version bump so `serverInfo.version` reports 1.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)