### PR TITLE
release: 1.7.1 — MIE example-correctness sweep + drift checkers

### DIFF
--- a/.claude/skills/mie-generator/SKILL.md
+++ b/.claude/skills/mie-generator/SKILL.md
@@ -470,6 +470,8 @@ If `ASK` returns false, the triple as written does not exist in the endpoint. Do
 
 **5b. Test every SPARQL query.** Run all 7 of `sparql_query_examples`, every example in `cross_database_queries`, every `correct_sparql` block in `anti_patterns`, and any SPARQL embedded in `cross_references`. Every single one. If a query times out or errors, fix it or replace it — do not ship queries that don't run. If a query runs but returns zero rows when it shouldn't, that's also a failure (usually a namespace trap — investigate and document in `critical_warnings`).
 
+Automate the zero-row/error half of this: `uv run python scripts/check_mie_examples.py <db>` runs every `sparql`/`correct_sparql` block against the live endpoint and flags ZERO-row and ERROR results (it harvests the file's PREFIXes, so snippets that omit them still run; it treats a lone `COUNT`→0 as zero-row; it reports 5xx as net-fail, not a defect). **Require a clean run — 0 zero-row, 0 error — before shipping.** This exists because Phase 5b was documented but not actually run: six MIEs shipped `correct_sparql` blocks that returned 0 (oma/supercon/ddbj/pubchem/pubtator/jpostdb, fixed 2026-07-18). Two things the tool does NOT cover, so do them by hand: a query that returns the WRONG rows (5b's "returns the right thing" — e.g. a union-inflated COUNT, or taxonomy's bare-namespace-rank example that returned botanical sections) passes the tool but is still a failure; and the queries must already be paste-ready (self-contained or using only PREFIXes declared elsewhere in the file) for it to run them.
+
 For each cross-database query that returns results, additionally spot-check join validity: take one join value from the result set and run a quick `ASK` or `SELECT` against the second database to confirm it resolves to a real entity there. A query returning 3 rows when thousands are expected is a join failure, not a passing test — the IRI form used for linking likely differs between the two databases.
 
 **5c. Verify statistics.** Every count or coverage percentage in `data_statistics` must come from a real query you ran, and must have a `verified_date`. If you can't verify a number, omit it rather than guessing.
@@ -608,7 +610,7 @@ Only after Phases 1–5 are complete, report to the user:
   - schema_info.categories checked: all tokens exact-matched against list_categories()
   - prefix declarations verified: all non-standard prefixes confirmed with SELECT
   - data_statistics cross-checked: total_entities and coverage % arithmetically consistent
-  - anti_patterns.correct_sparql tested: all correct_sparql blocks executed successfully
+  - anti_patterns.correct_sparql tested: all correct_sparql blocks executed successfully — confirm via `check_mie_examples.py <db>` returning 0 zero-row / 0 error (5b)
   - cross-graph inflation checked: co-hosted endpoint probed (2g), multipliers + safe pattern
     validated and recorded in co_hosted_graphs/critical_warnings — or "single-DB endpoint, N/A"
   - search-wrapper claims verified: every search_*/ncbi/OLS4 tool-behavior claim run through

--- a/.claude/skills/qa-generator/references/update-mode.md
+++ b/.claude/skills/qa-generator/references/update-mode.md
@@ -139,10 +139,27 @@ discipline is on you.
 
 ## Staleness audit (find what to update)
 
-To discover *which* questions have drifted without editing anything:
+To discover *which* questions have drifted without editing anything, run the automated first pass,
+then hand-triage what it flags:
 
-1. For each `question_0NN.yaml`, run sub-mode **R1–R3** (load, re-run queries verbatim, diff). This
-   is read-only and read-heavy (it re-executes every query in the set).
+**Automated pass — `benchmark/scripts/check_answer_drift.py`.** Re-runs every `sparql_queries[*]`
+entry against its database's live endpoint (resolved from `endpoints.csv`) and reports where the live
+result no longer matches the recorded `result_count`. It is the machine version of R2, and it is what
+`verify_questions.py` cannot do (that tool checks structure only and never executes a query — which is
+exactly why the six co-tenancy-inflation drifts of 2026-07 sat undetected). Usage:
+`uv run python benchmark/scripts/check_answer_drift.py` (whole set) or `... 60 71 100` (specific Qs);
+`--timeout`, `--retries`, `--strict` available. It understands the dual `result_count` convention (row
+count vs. a lone scalar aggregate's value), skips non-SPARQL steps (OLS4/PubMed notes) and materials
+DBs, and — crucially — reports network/timeout failures as ERROR, **not** as drift, so a flaky
+endpoint never masquerades as a moved answer. Exit code = number of DRIFT rows.
+
+A DRIFT row is a *candidate*, not a verdict: the count may have moved for a legitimate reason (the
+database grew), or the query may be reading an inflated union (the 2026-07 case — the fix was to pin
+the graph, not to update the number). Decide which per §0.2 of the co-tenancy findings doc before
+adopting any number.
+
+1. Run the automated pass above (or, for a single question, sub-mode **R1–R3**: load, re-run verbatim,
+   diff).
 2. Report the drifted questions: `id`, which `result_count`/answer moved, old → new.
 3. Take each drifted question through **Refresh** (or **Replace** if it's beyond saving), one at a
    time, pausing at the checkpoint — exactly like the create loop. **Never batch-write fixes.**

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ scripts/mie_keyword_suggestions.yaml
 logs/
 logs-test/
 *.jsonl
+
+# Internal documents
+internal_docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 _Nothing yet._
 
+## [1.7.1] - 2026-07-18
+
+Follow-up to the 1.7.0 co-tenancy sweep: the sweep verified `co_hosted_graphs` and
+`critical_warnings` but not the example queries agents copy. An audit of all 36 MIEs
+found — and this release fixes — templates that silently returned 0 rows or contradicted
+their own file. No tool-surface change; the served MIE/guide content is corrected.
+
+### Fixed
+
+- **11 broken example queries across 10 MIEs, each verified live.** Nine `anti_patterns.correct_sparql`
+  / example blocks that returned 0 rows against the endpoint: `oma` (impossible class + no
+  organism→taxon edge; rewritten as a HOG-family GROUP BY → 8,763), `supercon` (fictitious
+  namespace/class → real `Schema:OxideAndMetallic` Tc scaffold → 4,707), `ddbj` (Gene `bfo:0000050`
+  points at the Sequence, not the Entry → 3,244,894), `pubchem` (CID string mistaken for SMILES +
+  unpinned descriptor graph → 1,231), `pubtator` (threshold above the IRI's max), `jpostdb`
+  (non-existent `jpost:isDetectedIn` → PeptideEvidence bnode path → 242), `bacdive` (`^^rr:Literal`
+  GramStain + boolean SporeFormation), `taxonomy` (Superkingdom example missing the graph pin and the
+  `131567` exclusion, and mis-describing the bare-namespace rank), `nando` (anti-pattern taught
+  `STRSTARTS` as corrective when it is a no-op — real fix is pin + `COUNT(DISTINCT)`); plus `pubmed`'s
+  cross-DB join (`rdfs:seeAlso`→`fabio:hasSubjectTerm` for a disease topic).
+- **Secondary-section doc drift in 6 MIEs**: `chebi` (a `data_integration` bullet prescribing a
+  dead `skos:exactMatch`→ChEBI join), `pubmed` (`mesh/2025` pointer that resolves 0), `chembl`
+  (34.0/36.0 version mismatch — counts re-confirmed on 36.0), `glycosmos` (~60 vs measured 148 graphs),
+  `go` ("EIGHT" vs ten graphs), `mediadive` (missing the shared-DSMZ-namespace `schema:` prefix warning).
+- **`amrportal`** two-stage cross-DB example split into two independently-runnable examples (was one
+  un-runnable concatenated block).
+- **`uniprot`** OMA warning extended to row-returning `SELECT`s (was framed as counts-only).
+- **Benchmark**: 12 questions graph-pinned against co-tenant inflation (no recorded answer changed).
+
+### Added
+
+- **`scripts/check_mie_examples.py`** — runs every MIE's `sparql`/`correct_sparql` block against the
+  live endpoint and gates on zero-row/error (with an `expect_empty` allowlist). Wired into the
+  mie-generator skill's Phase 5b, which required this check but only in prose.
+- **`benchmark/scripts/check_answer_drift.py`** — re-runs every stored benchmark query against its
+  recorded `result_count`, the gap `verify_questions.py` (structure-only) can't cover.
+- **Usage guide**: CO-TENANCY point 1 now says pin the graph *set* a database owns (UniProt is ~16
+  graphs) — a single-graph pin returns empty for a leg whose data lives in a sibling.
+
 ## [1.7.0] - 2026-07-17
 
 ### Added
@@ -389,6 +428,7 @@ _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
 [Unreleased]: https://github.com/dbcls/togomcp/compare/v1.6.2...HEAD
+[1.7.1]: https://github.com/dbcls/togomcp/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/dbcls/togomcp/compare/v1.6.2...v1.7.0
 [1.6.2]: https://github.com/dbcls/togomcp/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/dbcls/togomcp/compare/v1.6.0...v1.6.1

--- a/benchmark/questions/question_004.yaml
+++ b/benchmark/questions/question_004.yaml
@@ -64,6 +64,8 @@ sparql_queries:
       PREFIX up: <http://purl.uniprot.org/core/>
 
       SELECT DISTINCT ?protein ?mnemonic ?organism ?orgName
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;
@@ -103,6 +105,8 @@ sparql_queries:
       PREFIX up: <http://purl.uniprot.org/core/>
 
       SELECT ?orgName (COUNT(DISTINCT ?protein) as ?count)
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;

--- a/benchmark/questions/question_014.yaml
+++ b/benchmark/questions/question_014.yaml
@@ -116,6 +116,8 @@ sparql_queries:
       PREFIX obo: <http://purl.obolibrary.org/obo/>
       
       SELECT ?taxon ?scientificName (COUNT(DISTINCT ?protein) as ?count)
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         VALUES ?goTerm {
           obo:GO_0005179  # hormone activity (parent)

--- a/benchmark/questions/question_033.yaml
+++ b/benchmark/questions/question_033.yaml
@@ -45,6 +45,8 @@ sparql_queries:
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
       SELECT DISTINCT ?genus (COUNT(DISTINCT ?protein) AS ?proteinCount)
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;

--- a/benchmark/questions/question_035.yaml
+++ b/benchmark/questions/question_035.yaml
@@ -50,6 +50,8 @@ sparql_queries:
     query: |
       PREFIX up: <http://purl.uniprot.org/core/>
       SELECT ?protein
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;
@@ -57,7 +59,7 @@ sparql_queries:
                  up:classifiedWith <http://purl.uniprot.org/keywords/720> .
       }
       ORDER BY ?protein
-    result_count: 141
+    result_count: 141   # graph-pinned; unpinned returns 278, OMA re-typing ~137 of the 141 as a 2nd up:Protein row (no DISTINCT)
 
   - query_number: 2
     database: pdb

--- a/benchmark/questions/question_055.yaml
+++ b/benchmark/questions/question_055.yaml
@@ -58,6 +58,8 @@ sparql_queries:
       PREFIX keywords: <http://purl.uniprot.org/keywords/>
 
       SELECT ?acc ?name ?ec
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;
@@ -68,7 +70,7 @@ sparql_queries:
         OPTIONAL { ?rn up:ecName ?ec }
         BIND(STRAFTER(STR(?protein), "uniprot/") AS ?acc)
       }
-    result_count: 4
+    result_count: 4   # graph-pinned; unpinned returns 8, each protein doubled by OMA up:Protein re-typing (no DISTINCT)
 
   - query_number: 2
     database: oma

--- a/benchmark/questions/question_060.yaml
+++ b/benchmark/questions/question_060.yaml
@@ -76,6 +76,8 @@ sparql_queries:
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
       SELECT ?mnemonic ?fullName ?ec ?gene
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         <http://purl.uniprot.org/uniprot/Q16878> a up:Protein ;
               up:reviewed 1 ;

--- a/benchmark/questions/question_065.yaml
+++ b/benchmark/questions/question_065.yaml
@@ -51,14 +51,17 @@ sparql_queries:
       PREFIX taxon: <http://purl.uniprot.org/taxonomy/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-      SELECT ?sym ?name WHERE {
+      SELECT ?sym ?name
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
+      WHERE {
         ?p a up:Protein ; up:reviewed true ; up:organism taxon:9606 ;
            up:classifiedWith <http://purl.uniprot.org/keywords/31> ;
            up:encodedBy/skos:prefLabel ?sym ;
            up:recommendedName/up:fullName ?name .
       }
       ORDER BY ?sym
-    result_count: 31
+    result_count: 31   # graph-pinned; unpinned returns 62, each protein doubled by OMA up:Protein re-typing (no DISTINCT)
 
   - query_number: 2
     database: hgnc

--- a/benchmark/questions/question_071.yaml
+++ b/benchmark/questions/question_071.yaml
@@ -81,7 +81,9 @@ sparql_queries:
     query: |
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX dcterms: <http://purl.org/dc/terms/>
-      SELECT ?gene ?label ?mgi WHERE {
+      SELECT ?gene ?label ?mgi
+      FROM <http://rdfportal.org/dataset/ensembl>
+      WHERE {
         VALUES ?mgi { <http://identifiers.org/mgi/MGI:96778>
                       <http://identifiers.org/mgi/MGI:96306> }
         ?gene a <http://rdf.ebi.ac.uk/terms/ensembl/EnsemblGene> ;

--- a/benchmark/questions/question_073.yaml
+++ b/benchmark/questions/question_073.yaml
@@ -50,7 +50,9 @@ sparql_queries:
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX dcterms: <http://purl.org/dc/terms/>
       PREFIX obo: <http://purl.obolibrary.org/obo/>
-      SELECT ?label ?desc WHERE {
+      SELECT ?label ?desc
+      FROM <http://rdfportal.org/dataset/ensembl>
+      WHERE {
         <http://rdf.ebi.ac.uk/resource/ensembl/ENSMUSG00000026141>
             a <http://rdf.ebi.ac.uk/terms/ensembl/EnsemblGene> ;
             rdfs:label ?label ;

--- a/benchmark/questions/question_086.yaml
+++ b/benchmark/questions/question_086.yaml
@@ -141,6 +141,7 @@ sparql_queries:
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
       SELECT DISTINCT ?spName ?rankShort ?ancName
+      FROM <http://rdfportal.org/ontology/taxonomy>
       WHERE {
         VALUES ?sp { <http://identifiers.org/taxonomy/35616>
                      <http://identifiers.org/taxonomy/53953>
@@ -150,11 +151,16 @@ sparql_queries:
             rdfs:subClassOf* ?anc .
         ?anc taxo:scientificName ?ancName ;
              taxo:rank ?rank .
-        VALUES ?rank { taxo:Genus taxo:Phylum taxo:Superkingdom }
-        BIND(STRAFTER(STR(?rank), "taxonomy/") AS ?rankShort)
+        # Pin the authoritative graph (excludes the legacy microbedbjp copy, which double-lists
+        # each phylum under both nomenclature vintages and is the ONLY graph carrying taxo:Superkingdom).
+        # In the authoritative graph the domain rank is the bare-namespace IRI, not taxo:Superkingdom;
+        # exclude the "cellular organisms" root (131567), which shares that rank IRI.
+        VALUES ?rank { taxo:Genus taxo:Phylum <http://ddbj.nig.ac.jp/ontologies/taxonomy/> }
+        FILTER(?anc != <http://identifiers.org/taxonomy/131567>)
+        BIND(IF(STR(?rank) = "http://ddbj.nig.ac.jp/ontologies/taxonomy/", "Superkingdom", STRAFTER(STR(?rank), "taxonomy/")) AS ?rankShort)
       }
       ORDER BY ?spName ?rankShort
-    result_count: 16   # 4 genera x {Genus, Phylum(x1-2), Superkingdom}; all Superkingdom = Archaea
+    result_count: 12   # 4 genera x {Genus, single-vintage Phylum, Superkingdom Archaea}; graph-pinned (was 16 unpinned, inflated by dual-vintage phylum names)
 
 rdf_triples: |
   @prefix ex:   <http://example.org/nbrc-archaea-thermophily#> .

--- a/benchmark/questions/question_089.yaml
+++ b/benchmark/questions/question_089.yaml
@@ -103,24 +103,31 @@ sparql_queries:
       and keeping only ancestors whose taxo:rank is one of the seven principal ranks. The
       lineage is Bacteria (superkingdom) → Pseudomonadota (phylum) → Hydrogenophilia
       (class) → Hydrogenophilales (order) → Hydrogenophilaceae (family) → Hydrogenophilus
-      (genus) → Hydrogenophilus thermoluteolus (species). The phylum and class each carry
-      two scientific names (Pseudomonadota/Proteobacteria; Hydrogenophilia/Hydrogenophilalia),
-      hence 9 rows for 7 ranks.
+      (genus) → Hydrogenophilus thermoluteolus (species) — 7 ranks, one row each. The
+      query is pinned to the authoritative graph; the legacy microbedbjp copy (unpinned)
+      double-lists the phylum (Pseudomonadota/Proteobacteria) and class
+      (Hydrogenophilia/Hydrogenophilalia) under both nomenclature vintages, inflating to 9 rows.
     query: |
       PREFIX taxo: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
       SELECT DISTINCT ?rankShort ?ancName ?anc
+      FROM <http://rdfportal.org/ontology/taxonomy>
       WHERE {
         <http://identifiers.org/taxonomy/297> taxo:scientificName ?spName ;
             rdfs:subClassOf* ?anc .
         ?anc taxo:scientificName ?ancName ;
              taxo:rank ?rank .
-        VALUES ?rank { taxo:Superkingdom taxo:Phylum taxo:Class taxo:Order taxo:Family taxo:Genus taxo:Species }
-        BIND(STRAFTER(STR(?rank), "taxonomy/") AS ?rankShort)
+        # In the authoritative graph the domain rank is the bare-namespace IRI, not taxo:Superkingdom
+        # (which lives only in the legacy graph); exclude the "cellular organisms" root (131567),
+        # which shares that bare-namespace rank IRI.
+        VALUES ?rank { <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+                       taxo:Phylum taxo:Class taxo:Order taxo:Family taxo:Genus taxo:Species }
+        FILTER(?anc != <http://identifiers.org/taxonomy/131567>)
+        BIND(IF(STR(?rank) = "http://ddbj.nig.ac.jp/ontologies/taxonomy/", "Superkingdom", STRAFTER(STR(?rank), "taxonomy/")) AS ?rankShort)
       }
       ORDER BY ?anc
-    result_count: 9   # 7 principal ranks; phylum + class each have 2 scientific names -> 9 rows
+    result_count: 7   # 7 principal ranks, one row each; graph-pinned (was 9 unpinned, inflated by dual-vintage phylum + class names)
 
   - query_number: 3
     database: ddbj

--- a/benchmark/questions/question_100.yaml
+++ b/benchmark/questions/question_100.yaml
@@ -51,6 +51,8 @@ sparql_queries:
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX keywords: <http://purl.uniprot.org/keywords/>
       SELECT (STRAFTER(STR(?protein),"uniprot/") AS ?acc) ?mnemonic
+      FROM <http://sparql.uniprot.org/uniprot>
+      FROM <http://sparql.uniprot.org/taxonomy>
       WHERE {
         ?protein a up:Protein ;
                  up:reviewed 1 ;

--- a/benchmark/scripts/check_answer_drift.py
+++ b/benchmark/scripts/check_answer_drift.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Answer-drift checker for TogoMCP benchmark questions.
+
+`verify_questions.py` validates STRUCTURE — it never re-runs the queries, so it
+cannot notice when a stored query's live result has drifted away from its
+recorded `result_count`. That drift is exactly how the 2026-07 co-tenancy audit
+found six stale queries (Q060/Q071/Q073/Q086/Q089/Q100): each was authored
+against a correct result and the endpoint moved underneath it — silently.
+
+This script closes that gap. For every `sparql_queries[*]` entry across the
+question set it re-executes the query against the database's SPARQL endpoint
+(resolved from endpoints.csv, the same registry the server uses) and compares the
+live row count to the recorded `result_count`.
+
+It is deliberately a REPORT, not a gate that fails the build:
+  - Live endpoints drift for legitimate reasons (a database grew by one entry).
+    A DRIFT is a prompt to re-examine the question, not proof it is wrong.
+  - Network timeouts / 5xx are NOT drift — they are reported separately and never
+    counted as a mismatch.
+  - Queries that are not runnable SPARQL (steps recorded as OLS4/PubMed/NCBI notes
+    in a comment block) are SKIPPED, not failed.
+
+Exit code = number of DRIFT rows (0 = all recorded counts still reproduce), so it
+is usable in a scheduled job; pass --strict to also fail on ERROR rows. Network
+errors alone never change the exit code unless --strict is given.
+
+Usage:
+    uv run python benchmark/scripts/check_answer_drift.py            # whole set
+    uv run python benchmark/scripts/check_answer_drift.py 60 71 100  # specific Qs
+    uv run python benchmark/scripts/check_answer_drift.py --timeout 120 --strict
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not installed. Run: uv sync (or pip install pyyaml)")
+    sys.exit(2)
+
+# Resolve relative to this script so it works regardless of checkout location.
+BASE_PATH = Path(__file__).resolve().parents[1] / "questions"
+ENDPOINTS_CSV = (Path(__file__).resolve().parents[2]
+                 / "togo_mcp" / "data" / "resources" / "endpoints.csv")
+
+# Endpoint groups out of scope for this life-science benchmark (see
+# verify_questions.py). Databases on these endpoints are not checked.
+_EXCLUDED_ENDPOINTS = {"nims"}
+
+
+def load_endpoint_map():
+    """database -> endpoint_url, from endpoints.csv, minus excluded groups."""
+    m = {}
+    with open(ENDPOINTS_CSV, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            db = (row.get("database") or "").strip()
+            url = (row.get("endpoint_url") or "").strip()
+            grp = (row.get("endpoint_name") or "").strip()
+            if db and url and grp not in _EXCLUDED_ENDPOINTS:
+                m[db] = url
+    return m
+
+
+# A query is runnable SPARQL only if, after stripping comment lines, it contains
+# a SELECT / ASK / CONSTRUCT / DESCRIBE form. Question steps performed via OLS4,
+# PubMed, or NCBI tools are recorded in the `query` field as comment blocks (every
+# line starts with '#') for provenance — those are not runnable and are skipped.
+_FORM_RE = re.compile(r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE)\b", re.IGNORECASE)
+
+
+def strip_comments(q):
+    return "\n".join(line for line in q.splitlines()
+                     if not line.lstrip().startswith("#"))
+
+
+def is_runnable_sparql(q):
+    return bool(_FORM_RE.search(strip_comments(q)))
+
+
+def _scalar_value(bindings):
+    """If the result is a single cell (1 row, 1 variable) holding an integer,
+    return it, else None.
+
+    This handles the benchmark's dual `result_count` convention: for a lone
+    scalar aggregate — `SELECT (COUNT(DISTINCT ?x) AS ?n)` with no GROUP BY —
+    the author records the aggregate VALUE (e.g. 284), and the query returns one
+    row. For everything else `result_count` is the ROW count. A query with two
+    projected aggregates (`... (MAX(..) AS ?a) (COUNT(..) AS ?b)`) has two cells,
+    so it is NOT a scalar and its recorded count is the row count (1)."""
+    if len(bindings) != 1:
+        return None
+    row = bindings[0]
+    if len(row) != 1:
+        return None
+    val = next(iter(row.values())).get("value", "")
+    try:
+        f = float(val)
+    except (TypeError, ValueError):
+        return None
+    return int(f) if f.is_integer() else None
+
+
+def result_size(endpoint, query, timeout):
+    """Run the query; return (n_rows, scalar_or_None, None) or (None, None, err).
+
+    ASK -> (1, bool_as_int, None). SELECT -> (len(bindings), scalar, None) where
+    `scalar` is the single-cell integer value if the result is one row of one
+    variable, else None. The caller accepts a recorded count that matches EITHER
+    n_rows or scalar, covering both `result_count` conventions."""
+    data = urllib.parse.urlencode({"query": query}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data,
+        headers={"Accept": "application/sparql-results+json",
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "User-Agent": "togomcp-drift-check"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.load(r)
+    except urllib.error.HTTPError as e:
+        return None, None, f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError) as e:
+        return None, None, f"net: {getattr(e, 'reason', e)}"
+    except json.JSONDecodeError:
+        return None, None, "non-JSON response (endpoint error page?)"
+    except Exception as e:  # noqa: BLE001 - report anything else as an error row
+        return None, None, f"{type(e).__name__}: {str(e)[:80]}"
+    if "boolean" in payload:
+        return 1, int(bool(payload["boolean"])), None
+    try:
+        bindings = payload["results"]["bindings"]
+    except (KeyError, TypeError):
+        return None, None, "unexpected result shape"
+    return len(bindings), _scalar_value(bindings), None
+
+
+def iter_queries(targets):
+    """Yield (qfile, question_number, sq_dict) for the requested questions."""
+    files = sorted(BASE_PATH.glob("question_*.yaml"))
+    if targets:
+        want = {int(t) for t in targets}
+        files = [f for f in files
+                 if int(re.search(r"(\d+)", f.stem).group(1)) in want]
+    for f in files:
+        try:
+            data = yaml.safe_load(f.read_text(encoding="utf-8"))
+        except yaml.YAMLError as e:
+            print(f"  ⚠  {f.name}: YAML parse error ({e}); skipped")
+            continue
+        qnum = int(re.search(r"(\d+)", f.stem).group(1))
+        for sq in (data.get("sparql_queries") or []):
+            yield f, qnum, sq
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("targets", nargs="*",
+                    help="question numbers to check (default: all)")
+    ap.add_argument("--timeout", type=float, default=90.0,
+                    help="per-query timeout in seconds (default: 90)")
+    ap.add_argument("--delay", type=float, default=0.3,
+                    help="polite delay between queries in seconds (default: 0.3)")
+    ap.add_argument("--retries", type=int, default=1,
+                    help="retries on network/timeout error (default: 1)")
+    ap.add_argument("--strict", action="store_true",
+                    help="also count ERROR rows toward a non-zero exit code")
+    args = ap.parse_args()
+
+    endpoints = load_endpoint_map()
+
+    drifts, errors, skips, ok = [], [], [], 0
+    for f, qnum, sq in iter_queries(args.targets):
+        n = sq.get("query_number", "?")
+        db = (sq.get("database") or "").strip()
+        query = sq.get("query") or ""
+        rc = sq.get("result_count")
+        tag = f"Q{qnum:03d} q{n} [{db}]"
+
+        if not is_runnable_sparql(query):
+            skips.append((tag, "non-SPARQL step (OLS4/PubMed/NCBI note)"))
+            continue
+        if db not in endpoints:
+            skips.append((tag, f"no endpoint for database '{db}'"))
+            continue
+        if not isinstance(rc, int):
+            skips.append((tag, f"result_count not an int ({rc!r})"))
+            continue
+
+        rows = scalar = err = None
+        for attempt in range(args.retries + 1):
+            rows, scalar, err = result_size(endpoints[db], query, args.timeout)
+            if err is None or not err.startswith("net"):
+                break
+            time.sleep(1.0 + attempt)  # brief backoff before a retry
+        if args.delay:
+            time.sleep(args.delay)
+
+        if err is not None:
+            errors.append((tag, err))
+            print(f"  ⚠  {tag} ERROR: {err}", flush=True)
+        elif rc == rows or rc == scalar:
+            ok += 1
+            # Show which signal matched, so a COUNT value reads clearly.
+            shown = rc if rc == rows else f"{scalar} (scalar; {rows} row)"
+            print(f"  ✓  {tag} {shown}", flush=True)
+        else:
+            live = f"{rows} row" + (f" / scalar={scalar}" if scalar is not None else "")
+            drifts.append((tag, rc, live))
+            print(f"  ✗  {tag} DRIFT: recorded={rc} live={live}", flush=True)
+
+    print("\n" + "=" * 70)
+    print(f"DRIFT CHECK  —  {ok} ok, {len(drifts)} drift, "
+          f"{len(errors)} error, {len(skips)} skipped")
+    print("=" * 70)
+    if drifts:
+        print("\nDRIFT (recorded result_count no longer reproduces — re-examine):")
+        for tag, rc, got in drifts:
+            print(f"  {tag}: recorded={rc} live={got}")
+    if errors:
+        print("\nERROR (endpoint unreachable / query failed — NOT counted as drift):")
+        for tag, err in errors:
+            print(f"  {tag}: {err}")
+
+    rc_exit = len(drifts) + (len(errors) if args.strict else 0)
+    sys.exit(min(rc_exit, 125))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/scripts/gemma_togomcp_prototype.py
+++ b/benchmark/scripts/gemma_togomcp_prototype.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""
+Gemma + TogoMCP prototype — a standalone behavioral probe.
+
+Purpose
+-------
+The production answer-collector (`automated_test_runner.py`) drives the
+with-tools condition entirely through `claude-agent-sdk` (it spawns the Claude
+Code CLI, which owns the MCP tool-calling loop). A *local* model like Gemma
+cannot ride that path. This script re-implements that loop ourselves so we can
+watch how a local model (default: gemma4 via Ollama) drives the live TogoMCP
+tools — how it writes SPARQL, whether it recovers from tool errors, and whether
+it follows the TogoMCP workflow idiom.
+
+It is intentionally NOT wired into the benchmark pipeline. It is a prototype:
+run it on a handful of questions and read the transcript.
+
+What it does
+------------
+1. Connects to the live TogoMCP HTTP server as a first-class MCP client
+   (`mcp` SDK, streamable-HTTP transport) and lists its ~35 tools.
+2. Translates each MCP tool schema into Ollama's function-tool shape.
+3. Runs an agentic loop per question:
+       chat(gemma4, messages, tools) -> tool_calls? -> call_tool -> feed result back
+   Tool errors are fed back as tool messages so we can observe recovery.
+4. Writes two artifacts:
+       - <out>.jsonl : full per-question transcript (every tool call + args +
+                       result) — the deliverable for "see how it behaves".
+       - <out>.csv   : one summary row per question (answer, tools, turns,
+                       tokens) for eyeballing against Claude runs.
+
+Requirements
+------------
+    pip install ollama mcp pyyaml          # all already in the dev extra
+    ollama pull gemma4                     # or any tool-capable local model
+    # Ollama server running ($OLLAMA_HOST or http://localhost:11434)
+
+Usage
+-----
+    # A few questions, default gemma4, default live endpoint:
+    python gemma_togomcp_prototype.py ../questions/question_001.yaml \
+                                      ../questions/question_002.yaml
+
+    # Try another local model / a different endpoint / cap questions:
+    python gemma_togomcp_prototype.py ../questions/question_*.yaml \
+        --model qwen3.6 --limit 5 -o gemma_run
+
+    # Point at the local dev server instead of production:
+    python gemma_togomcp_prototype.py ../questions/question_001.yaml \
+        --mcp-url http://localhost:8000/mcp
+"""
+
+import argparse
+import asyncio
+import csv
+import json
+import sys
+import time
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML not installed. pip install pyyaml")
+    sys.exit(1)
+
+try:
+    import ollama
+except ImportError:
+    print("Error: ollama not installed. pip install ollama")
+    sys.exit(1)
+
+try:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+except ImportError:
+    print("Error: mcp SDK not installed. pip install mcp")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Prompts.
+#
+# The REAL system prompt is loaded from the same config.yaml the production
+# runner (automated_test_runner.py) uses — its `togomcp_system_prompt` carries
+# the strong "REQUIRED FIRST ACTION: call TogoMCP_Usage_Guide()" + MANDATORY
+# WORKFLOW instructions. Loading it here keeps this probe apples-to-apples with
+# production instead of testing gemma4 against a weaker paraphrase. The constant
+# below is only a fallback for when no config file is found.
+# ---------------------------------------------------------------------------
+
+DEFAULT_TOGOMCP_SYSTEM_PROMPT = (
+    "You are an expert assistant answering biological and biomedical questions. "
+    "You have access to biological databases through MCP tools. "
+    "Use them when they would improve the accuracy or completeness of your answer. "
+    "\n\n"
+    "Recommended TogoMCP workflow: call TogoMCP_Usage_Guide first, then "
+    "list_databases / find_databases to pick a database, get_MIE_file to learn its "
+    "schema and example queries, get_graph_list to confirm the named graph, then "
+    "run_sparql. Do not guess SPARQL blindly — read the MIE file first.\n\n"
+    "Base your answers on retrieved data and write them to be:\n"
+    "- COMPLETE: Include all necessary information from the databases\n"
+    "- PRECISE: Include only relevant information that answers the question\n"
+    "- NON-REDUNDANT: Synthesize information; don't repeat the same facts\n"
+    "- READABLE: Use clear, fluent scientific prose with logical flow\n"
+    "- DIRECT: State facts from databases without meta-references\n"
+    "\n"
+    "When you have gathered enough evidence, stop calling tools and write the final "
+    "answer as a single well-formed paragraph."
+)
+
+
+def load_mcp_servers(config_path: Optional[str], single_url: str, use_all: bool) -> Dict[str, str]:
+    """Return an ordered {server_name: url} map of MCP servers to connect to.
+
+    Default (use_all=False): just {"togomcp": single_url} — the validated
+    single-server behavior. With use_all=True, read the `mcp_servers` block from
+    config.yaml (same one automated_test_runner.py uses) and connect to ALL of
+    them (togomcp, pubmed, pubdictionaries, ols) for production parity. Only
+    `type: http` servers are supported here (all four config servers are http).
+    """
+    if not use_all:
+        return {"togomcp": single_url}
+    servers: Dict[str, str] = {}
+    if config_path and Path(config_path).exists():
+        try:
+            cfg = yaml.safe_load(Path(config_path).read_text()) or {}
+        except yaml.YAMLError:
+            cfg = {}
+        for name, spec in (cfg.get("mcp_servers") or {}).items():
+            if isinstance(spec, dict) and spec.get("url"):
+                if spec.get("type", "http") != "http":
+                    print(f"  ! skipping MCP server {name!r}: unsupported type "
+                          f"{spec.get('type')!r} (only http)")
+                    continue
+                servers[name] = spec["url"]
+    if not servers:
+        print("  ! --all-config-servers set but no http mcp_servers found in "
+              "config; falling back to single togomcp url")
+        return {"togomcp": single_url}
+    return servers
+
+
+def load_system_prompt(config_path: Optional[str]) -> str:
+    """Return the togomcp_system_prompt from config.yaml (same key the runner
+    uses), falling back to the built-in default if the file or key is absent.
+
+    Note: the config prompt references some tools by their claude-agent-sdk
+    `mcp__<server>__<tool>` names (e.g. mcp__ols__*). In this local Ollama loop
+    the TogoMCP tools are advertised under their BARE names (TogoMCP_Usage_Guide,
+    find_databases, ...), which is exactly how the prompt's `TogoMCP_Usage_Guide()`
+    / `find_databases()` / `get_MIE_file()` instructions spell them — so the
+    load-bearing workflow directives resolve to real, callable tools.
+    """
+    if not config_path:
+        return DEFAULT_TOGOMCP_SYSTEM_PROMPT
+    p = Path(config_path)
+    if not p.exists():
+        print(f"  ! config not found: {config_path} — using built-in prompt")
+        return DEFAULT_TOGOMCP_SYSTEM_PROMPT
+    try:
+        cfg = yaml.safe_load(p.read_text()) or {}
+    except yaml.YAMLError as e:
+        print(f"  ! config YAML error ({config_path}): {e} — using built-in prompt")
+        return DEFAULT_TOGOMCP_SYSTEM_PROMPT
+    prompt = cfg.get("togomcp_system_prompt")
+    if isinstance(prompt, str) and prompt.strip():
+        return prompt
+    print(f"  ! no togomcp_system_prompt in {config_path} — using built-in prompt")
+    return DEFAULT_TOGOMCP_SYSTEM_PROMPT
+
+FINAL_ANSWER_INSTRUCTION = """
+
+Provide your answer as a single, well-formed paragraph that directly answers the question. Follow these guidelines:
+
+1. COMPLETENESS: Include all necessary information to fully answer the question
+2. PRECISION: Include only information directly relevant to answering the question
+3. NO REPETITION: State each piece of information only once; avoid redundant phrasing
+4. READABILITY: Write in clear, fluent prose with logical flow between sentences
+5. DIRECT STYLE: State facts directly without meta-references like "According to research," "Studies show," or "The literature indicates"
+
+Simply provide the factual answer as you would write an encyclopedia entry."""
+
+
+# ---------------------------------------------------------------------------
+# Question loading (mirrors automated_test_runner.load_questions)
+# ---------------------------------------------------------------------------
+
+def load_questions(files: List[str]) -> List[Dict]:
+    questions: List[Dict] = []
+    for fp in files:
+        p = Path(fp)
+        if not p.exists():
+            print(f"  ! question file not found: {fp}")
+            continue
+        # coverage_tracker.yaml is not a question — skip it if globbed in.
+        if p.name == "coverage_tracker.yaml":
+            continue
+        try:
+            data = yaml.safe_load(p.read_text())
+        except yaml.YAMLError as e:
+            print(f"  ! YAML error in {fp}: {e}")
+            continue
+        if isinstance(data, list):
+            questions.extend(data)
+        elif isinstance(data, dict) and data.get("body"):
+            questions.append(data)
+    return questions
+
+
+def build_question_prompt(q: Dict) -> str:
+    """Assemble the user prompt, mirroring run_single_test's choice handling."""
+    body = q.get("body", "")
+    q_type = q.get("type", "unknown")
+    choices = q.get("choices", [])
+    if q_type == "choice" and choices:
+        choices_text = "\n".join(f"  - {c}" for c in choices)
+        body = f"{body}\n\nChoose one of the following options:\n{choices_text}"
+    if q_type == "choice":
+        instruction = (
+            "\n\nState which option or options are correct and briefly explain "
+            "why in one paragraph."
+        )
+    else:
+        instruction = FINAL_ANSWER_INSTRUCTION
+    return body + instruction
+
+
+# ---------------------------------------------------------------------------
+# MCP <-> Ollama bridging
+# ---------------------------------------------------------------------------
+
+def mcp_tools_to_ollama(mcp_tools, hide_substrings: List[str], prefix: str = "") -> tuple:
+    """Translate one MCP server's tool definitions into Ollama's function-tool
+    schema. Returns (ollama_tools, hidden_names, name_pairs) where name_pairs is
+    a list of (advertised_name, original_name) so the caller can build a routing
+    table back to the owning session.
+
+    `prefix`: when connecting to MULTIPLE servers, advertise each tool as
+    `mcp__<server>__<tool>` (matching production's naming and the config system
+    prompt, which references mcp__ols__* / mcp__pubmed__*) to avoid cross-server
+    name collisions. Empty prefix (single-server mode) keeps BARE names, which is
+    what the validated single-server runs used — so that path is unchanged.
+
+    `hide_substrings`: tool names containing any of these substrings are NOT
+    advertised (checked against the ORIGINAL bare name). Structural intervention
+    #2 — a local model that ignores tool-selection steering can't take the
+    shallow keyword-search shortcut if the shortcut tool is never offered.
+    """
+    out, hidden, name_pairs = [], [], []
+    for t in mcp_tools:
+        if any(sub and sub in t.name for sub in hide_substrings):
+            hidden.append(t.name)
+            continue
+        advertised = f"{prefix}{t.name}" if prefix else t.name
+        params = t.inputSchema or {"type": "object", "properties": {}}
+        out.append({
+            "type": "function",
+            "function": {
+                "name": advertised,
+                "description": (t.description or "")[:1024],
+                "parameters": params,
+            },
+        })
+        name_pairs.append((advertised, t.name))
+    return out, hidden, name_pairs
+
+
+def flatten_tool_result(result, max_chars: int) -> str:
+    """Extract text from an MCP CallToolResult, truncated for local-model context."""
+    parts: List[str] = []
+    for block in getattr(result, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(text)
+        else:
+            parts.append(str(block))
+    text = "\n".join(parts) if parts else "(tool returned no content)"
+    if getattr(result, "isError", False):
+        text = "ERROR: " + text
+    if len(text) > max_chars:
+        text = text[:max_chars] + f"\n...[truncated {len(text) - max_chars} chars]"
+    return text
+
+
+def message_to_dict(msg) -> Dict[str, Any]:
+    """Best-effort serialization of an Ollama Message for the transcript."""
+    for attr in ("model_dump", "dict"):
+        fn = getattr(msg, attr, None)
+        if callable(fn):
+            try:
+                dumped = fn()
+                if isinstance(dumped, dict):
+                    return dumped
+            except Exception:
+                pass
+    return {"role": getattr(msg, "role", "assistant"),
+            "content": getattr(msg, "content", "")}
+
+
+# ---------------------------------------------------------------------------
+# The agentic loop
+# ---------------------------------------------------------------------------
+
+async def answer_one(
+    client: "ollama.AsyncClient",
+    call_tool,                       # async (name, args) -> flattened str; routes to owning MCP server
+    ollama_tools: List[Dict[str, Any]],
+    model: str,
+    system_prompt: str,
+    question: Dict,
+    max_turns: int,
+    max_tool_chars: int,
+    max_repeat: int,
+    num_ctx: int,
+) -> Dict[str, Any]:
+    """Drive one question through the gemma+tools loop. Returns a result dict."""
+    prompt = build_question_prompt(question)
+    messages: List[Any] = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+
+    transcript: List[Dict[str, Any]] = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+    tool_uses: List[str] = []
+    in_tokens = 0
+    out_tokens = 0
+    final_text: Optional[str] = None
+    turns_used = 0
+    # Per-turn prompt token count (Ollama prompt_eval_count). This is the actual
+    # context size fed to the model each turn; the max is the peak. If it pins
+    # near num_ctx, Ollama was truncating (dropping the front) during reasoning.
+    per_turn_prompt_tokens: List[int] = []
+    # Loop guard (structural intervention #3): count identical (tool, args)
+    # signatures. gemma4 degenerates into repeating the same call verbatim
+    # (the hallucinated BRCA1 loop); once a signature is seen `max_repeat`
+    # times we stop executing it and feed back a nudge instead.
+    call_sig_counts: Dict[str, int] = {}
+
+    start = time.time()
+
+    for turn in range(1, max_turns + 1):
+        turns_used = turn
+        resp = await client.chat(
+            model=model,
+            messages=messages,
+            tools=ollama_tools,
+            # num_ctx is critical: Ollama's default (4096) silently truncates
+            # from the FRONT once system prompt + tool schemas + tool results
+            # exceed it, dropping the question and making the model emit a
+            # generic capability menu instead of an answer. gemma4 supports 128k.
+            options={"temperature": 0, "num_ctx": num_ctx},
+        )
+        turn_prompt_tok = getattr(resp, "prompt_eval_count", 0) or 0
+        per_turn_prompt_tokens.append(turn_prompt_tok)
+        in_tokens += turn_prompt_tok
+        out_tokens += getattr(resp, "eval_count", 0) or 0
+
+        msg = resp.message
+        messages.append(msg)  # AsyncClient accepts Message objects back
+        transcript.append(message_to_dict(msg))
+
+        tool_calls = getattr(msg, "tool_calls", None)
+        if not tool_calls:
+            final_text = (getattr(msg, "content", "") or "").strip()
+            break
+
+        # Execute every requested tool call, feeding results (and errors) back.
+        for call in tool_calls:
+            name = call.function.name
+            args = call.function.arguments
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {"_raw": args}
+            tool_uses.append(name)
+            print(f"      → {name}({json.dumps(args, default=str)[:140]})")
+
+            sig = f"{name}::{json.dumps(args, sort_keys=True, default=str)}"
+            call_sig_counts[sig] = call_sig_counts.get(sig, 0) + 1
+
+            if call_sig_counts[sig] > max_repeat:
+                # Repeated the exact same call too many times — refuse to execute
+                # it again and push the model to change course or conclude.
+                content = (
+                    f"LOOP GUARD: you have already called {name} with these exact "
+                    f"arguments {call_sig_counts[sig]} times. This call is blocked. "
+                    "Do NOT repeat it. Either try a genuinely different tool/query "
+                    "(e.g. get_MIE_file then run_sparql on the clinvar database), or "
+                    "if you have enough evidence, STOP calling tools and write your "
+                    "final answer now."
+                )
+                print(f"        ⚠ loop guard blocked repeat #{call_sig_counts[sig]}")
+            else:
+                try:
+                    content = await call_tool(name, args or {}, max_tool_chars)
+                except Exception as e:
+                    content = f"ERROR calling tool {name!r}: {type(e).__name__}: {e}"
+
+            tool_msg = {"role": "tool", "tool_name": name, "content": content}
+            messages.append(tool_msg)
+            transcript.append({
+                "role": "tool", "tool_name": name,
+                "args": args, "content": content,
+            })
+
+    elapsed = time.time() - start
+    success = bool(final_text)
+    if not success and final_text is None:
+        final_text = (
+            f"[NO FINAL ANSWER: model kept calling tools for all {max_turns} turns]"
+        )
+
+    return {
+        "question_id": question.get("id", "?"),
+        "question_type": question.get("type", "unknown"),
+        "question": question.get("body", ""),
+        "ideal_answer": question.get("ideal_answer", ""),
+        "exact_answer": question.get("exact_answer", ""),
+        "gemma_success": success,
+        "gemma_answer": final_text,
+        "gemma_turns": turns_used,
+        "gemma_tool_calls": len(tool_uses),
+        "tools_used": ", ".join(tool_uses),
+        "gemma_input_tokens": in_tokens,
+        "gemma_output_tokens": out_tokens,
+        "gemma_peak_prompt_tokens": max(per_turn_prompt_tokens or [0]),
+        "gemma_per_turn_prompt_tokens": per_turn_prompt_tokens,
+        "gemma_time": round(elapsed, 2),
+        "_transcript": transcript,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+async def connect_servers(stack: AsyncExitStack, servers: Dict[str, str],
+                          hide_substrings: List[str], multi: bool, quiet: bool = False):
+    """Connect to each MCP server into `stack`; return
+    (sessions{name->session}, ollama_tools, hidden, static_routes{advertised->(name,orig)}).
+    A per-server failure is logged and skipped (graceful degradation), so one
+    unreachable/auth-gated server never aborts the whole run.
+    """
+    sessions: Dict[str, ClientSession] = {}
+    ollama_tools: List[Dict[str, Any]] = []
+    hidden: List[str] = []
+    static_routes: Dict[str, tuple] = {}
+    for sname, surl in servers.items():
+        try:
+            read, write, _sid = await stack.enter_async_context(streamablehttp_client(surl))
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+            sessions[sname] = session
+            stools = (await session.list_tools()).tools
+            prefix = f"mcp__{sname}__" if multi else ""
+            s_ollama, s_hidden, pairs = mcp_tools_to_ollama(stools, hide_substrings, prefix)
+            ollama_tools.extend(s_ollama)
+            hidden.extend(s_hidden)
+            for advertised, original in pairs:
+                static_routes[advertised] = (sname, original)
+            if not quiet:
+                print(f"  ✓ {sname}: {len(s_ollama)} tools ({len(s_hidden)} hidden)")
+        except Exception as e:
+            if not quiet:
+                print(f"  ✗ {sname} ({surl}): {type(e).__name__}: {str(e)[:120]}")
+    return sessions, ollama_tools, hidden, static_routes
+
+
+async def run(args: argparse.Namespace) -> int:
+    questions = load_questions(args.question_files)
+    if args.limit:
+        questions = questions[: args.limit]
+    if not questions:
+        print("✗ No questions loaded.")
+        return 1
+
+    # Bind a guaranteed-str model name (argparse default is "gemma4", never
+    # None, but the type checker can't see that through Namespace).
+    model_name: str = args.model or "gemma4"
+
+    # Fail fast if the model isn't pulled, with an actionable message.
+    probe = ollama.Client(host=args.ollama_host or None)
+    try:
+        available = [m.model for m in probe.list().models if m.model]
+    except Exception as e:
+        where = args.ollama_host or "http://localhost:11434"
+        print(f"✗ Cannot reach Ollama at {where}: {e}")
+        return 1
+    if model_name not in available and f"{model_name}:latest" not in available \
+            and not any(a.split(":", 1)[0] == model_name for a in available):
+        print(f"✗ Model '{model_name}' not pulled. Try: ollama pull {model_name}")
+        print(f"  Available: {', '.join(available) or '(none)'}")
+        return 1
+
+    client = ollama.AsyncClient(host=args.ollama_host or None)
+
+    base_system_prompt = load_system_prompt(args.config)
+    hide_substrings = [s.strip() for s in args.hide_tools.split(",") if s.strip()]
+    prompt_src = args.config if (args.config and Path(args.config).exists()
+                                 and base_system_prompt is not DEFAULT_TOGOMCP_SYSTEM_PROMPT) \
+        else "built-in default"
+    servers = load_mcp_servers(args.config, args.mcp_url, args.all_config_servers)
+    multi = len(servers) > 1
+
+    print("=" * 70)
+    print("Gemma + TogoMCP prototype")
+    print("=" * 70)
+    print(f"Model:      {model_name}")
+    print(f"MCP servers:{', '.join(f'{n}={u}' for n, u in servers.items())}")
+    print(f"Questions:  {len(questions)}")
+    print(f"Prompt:     {prompt_src} ({len(base_system_prompt)} chars)")
+    print(f"Force-guide:{args.force_guide}   |   Hide tools: {hide_substrings or '(none)'}")
+    print(f"Max turns:  {args.max_turns}   |   loop-guard repeat cap: {args.max_repeat} "
+          f"|   tool-result cap: {args.max_tool_chars} chars")
+    print(f"num_ctx:    {args.num_ctx} (Ollama default is 4096)")
+    print("=" * 70)
+
+    results: List[Dict[str, Any]] = []
+    jsonl_path = f"{args.output}.jsonl"
+    csv_path = f"{args.output}.csv"
+
+    # SETUP (once): connect all servers to enumerate tools + build the static
+    # routing table (advertised_name -> (server_name, original_name)) and
+    # optionally pre-load the usage guide. Then close these connections.
+    system_prompt = base_system_prompt
+    async with AsyncExitStack() as setup_stack:
+        sessions, ollama_tools, hidden, static_routes = await connect_servers(
+            setup_stack, servers, hide_substrings, multi)
+        if not ollama_tools:
+            print("✗ No MCP tools available from any server. Aborting.")
+            return 1
+        # Only re-connect servers that actually came up.
+        ok_servers = {n: servers[n] for n in sessions}
+
+        # Structural intervention #1: pre-load the usage guide into the system
+        # prompt so it is guaranteed present (turn 0).
+        if args.force_guide:
+            guide_name = "mcp__togomcp__TogoMCP_Usage_Guide" if multi else "TogoMCP_Usage_Guide"
+            rt = static_routes.get(guide_name)
+            if rt is not None:
+                try:
+                    sname, orig = rt
+                    gr = await sessions[sname].call_tool(
+                        orig, {}, read_timeout_seconds=timedelta(seconds=60))
+                    guide_text = flatten_tool_result(gr, args.guide_chars)
+                    system_prompt = (
+                        base_system_prompt
+                        + "\n\n## PRE-LOADED TogoMCP USAGE GUIDE "
+                          "(already fetched for you — do NOT call TogoMCP_Usage_Guide)\n\n"
+                        + guide_text
+                    )
+                    print(f"Pre-loaded TogoMCP_Usage_Guide ({len(guide_text)} chars) "
+                          "into system prompt.")
+                except Exception as e:
+                    print(f"  ! could not pre-load usage guide: {e}")
+
+    print(f"Connected. {len(ollama_tools)} MCP tools advertised to {model_name} "
+          f"across {len(ok_servers)} server(s) "
+          f"({len(hidden)} hidden: {', '.join(hidden) or 'none'}).")
+    print("Reconnecting fresh per question (robust to mid-run network drops).\n")
+
+    # PER-QUESTION: open fresh MCP connections for each question so a dropped
+    # session (e.g. httpx.ConnectTimeout) fails only THAT question — the next
+    # reconnects — instead of crashing the whole run. Also gives transport-level
+    # fresh isolation per question, matching the production runner's intent.
+    with open(jsonl_path, "w", encoding="utf-8") as jf:
+        for i, q in enumerate(questions, 1):
+            qid = q.get("id", f"q{i}")
+            print(f"[{i}/{len(questions)}] {qid} ({q.get('type','?')})")
+            print(f"    {q.get('body','')[:90]}")
+
+            def _fail(msg: str) -> Dict[str, Any]:
+                return {
+                    "question_id": qid,
+                    "question_type": q.get("type", "unknown"),
+                    "question": q.get("body", ""),
+                    "ideal_answer": q.get("ideal_answer", ""),
+                    "exact_answer": q.get("exact_answer", ""),
+                    "gemma_success": False,
+                    "gemma_answer": msg,
+                    "gemma_turns": 0, "gemma_tool_calls": 0, "tools_used": "",
+                    "gemma_input_tokens": 0, "gemma_output_tokens": 0,
+                    "gemma_peak_prompt_tokens": 0, "gemma_per_turn_prompt_tokens": [],
+                    "gemma_time": 0.0, "_transcript": [],
+                }
+
+            try:
+                async with AsyncExitStack() as qstack:
+                    q_sessions, _, _, _ = await connect_servers(
+                        qstack, ok_servers, hide_substrings, multi, quiet=True)
+
+                    async def call_tool(name: str, args_dict: dict, max_chars: int,
+                                        _sessions=q_sessions) -> str:
+                        """Route a tool call to its owning (per-question) session."""
+                        route = static_routes.get(name)
+                        if route is None:
+                            return (f"ERROR: unknown tool {name!r}. Only the advertised "
+                                    "MCP tools are available.")
+                        sname, original = route
+                        sess = _sessions.get(sname)
+                        if sess is None:
+                            return (f"ERROR: MCP server {sname!r} is not connected for "
+                                    "this question; try a tool from another server.")
+                        result = await sess.call_tool(
+                            original, args_dict or {},
+                            read_timeout_seconds=timedelta(seconds=90))
+                        return flatten_tool_result(result, max_chars)
+
+                    res = await asyncio.wait_for(
+                        answer_one(
+                            client, call_tool, ollama_tools, model_name,
+                            system_prompt, q,
+                            args.max_turns, args.max_tool_chars,
+                            args.max_repeat, args.num_ctx,
+                        ),
+                        timeout=args.timeout,
+                    )
+            except asyncio.TimeoutError:
+                res = _fail(f"[TIMEOUT after {args.timeout}s]")
+                res["gemma_time"] = float(args.timeout)
+            except Exception as e:
+                # Connection/transport failure for THIS question only — record
+                # and move on; the next question reconnects.
+                res = _fail(f"[CONNECTION/RUN ERROR: {type(e).__name__}: {str(e)[:200]}]")
+
+            jf.write(json.dumps(res, default=str) + "\n")
+            jf.flush()
+            results.append(res)
+
+            mark = "✓" if res["gemma_success"] else "✗"
+            print(f"    {mark} {res['gemma_turns']} turns, "
+                  f"{res['gemma_tool_calls']} tool calls, "
+                  f"{res['gemma_output_tokens']}↓ tok, {res['gemma_time']}s")
+            print(f"    answer: {str(res['gemma_answer'])[:120]}\n")
+
+    # Summary CSV (drop the bulky transcript column).
+    fieldnames = [
+        "question_id", "question_type", "question", "ideal_answer", "exact_answer",
+        "gemma_success", "gemma_answer", "gemma_turns", "gemma_tool_calls",
+        "tools_used", "gemma_input_tokens", "gemma_output_tokens", "gemma_time",
+    ]
+    with open(csv_path, "w", newline="", encoding="utf-8") as cf:
+        w = csv.DictWriter(cf, fieldnames=fieldnames, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(results)
+
+    ok = sum(1 for r in results if r["gemma_success"])
+    tot_tool = sum(r["gemma_tool_calls"] for r in results)
+    print("=" * 70)
+    print(f"Done. {ok}/{len(results)} produced a final answer. "
+          f"{tot_tool} total tool calls.")
+    print(f"  Transcript (full trace): {jsonl_path}")
+    print(f"  Summary CSV:             {csv_path}")
+    print("=" * 70)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Gemma + TogoMCP prototype (standalone behavioral probe).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("question_files", nargs="+", help="Question YAML file(s).")
+    ap.add_argument("--model", default="gemma4",
+                    help="Ollama model tag (default: gemma4). Must support tools.")
+    ap.add_argument("-c", "--config",
+                    default=str(Path(__file__).parent / "config.yaml"),
+                    help="Config YAML to read togomcp_system_prompt from "
+                         "(default: config.yaml beside this script; the same "
+                         "prompt the production runner uses).")
+    ap.add_argument("--mcp-url", default="https://togomcp.rdfportal.org/mcp",
+                    help="Single TogoMCP MCP endpoint (default: production). Used "
+                         "unless --all-config-servers is set.")
+    ap.add_argument("--all-config-servers", action="store_true",
+                    help="Connect to ALL http mcp_servers in the config file "
+                         "(togomcp + pubmed + pubdictionaries + ols) for production "
+                         "parity with automated_test_runner.py, instead of just "
+                         "--mcp-url. Tools are namespaced mcp__<server>__<tool>.")
+    ap.add_argument("--ollama-host", default="",
+                    help="Ollama host URL (default: $OLLAMA_HOST or localhost:11434).")
+    ap.add_argument("-o", "--output", default="gemma_togomcp",
+                    help="Output basename; writes <name>.jsonl and <name>.csv.")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="Only run the first N questions (0 = all).")
+    ap.add_argument("--max-turns", type=int, default=10,
+                    help="Max chat<->tool rounds per question (default: 10).")
+    ap.add_argument("--force-guide", action=argparse.BooleanOptionalAction, default=True,
+                    help="Pre-load TogoMCP_Usage_Guide contents into the system "
+                         "prompt (structural intervention #1). --no-force-guide to disable.")
+    ap.add_argument("--guide-chars", type=int, default=6000,
+                    help="Truncate the pre-loaded usage guide to this many chars (default: 6000).")
+    ap.add_argument("--hide-tools", default="togovar_search_",
+                    help="Comma-separated substrings; tools whose names contain any "
+                         "are NOT advertised to the model (structural intervention #2). "
+                         "Default hides the togovar_search_* keyword shortcuts. "
+                         "Pass '' to advertise all tools.")
+    ap.add_argument("--max-repeat", type=int, default=2,
+                    help="Loop guard (intervention #3): block a tool call once its "
+                         "exact (name, args) signature has been used this many times "
+                         "(default: 2).")
+    ap.add_argument("--num-ctx", type=int, default=16384,
+                    help="Ollama context window (num_ctx). Ollama's default of 4096 "
+                         "silently truncates the system prompt + question once tool "
+                         "schemas/results pile up, causing capability-menu non-answers. "
+                         "gemma4 supports up to 131072; raise if RAM allows (default: 16384).")
+    ap.add_argument("--max-tool-chars", type=int, default=8000,
+                    help="Truncate each tool result to this many chars (default: 8000).")
+    ap.add_argument("--timeout", type=int, default=600,
+                    help="Per-question wall-clock timeout in seconds (default: 600).")
+    args = ap.parse_args()
+
+    try:
+        return asyncio.run(run(args))
+    except KeyboardInterrupt:
+        print("\n⚠ interrupted")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "1.7.0"
+version = "1.7.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/scripts/check_mie_examples.py
+++ b/scripts/check_mie_examples.py
@@ -28,8 +28,16 @@ So a clean run is necessary, not sufficient. ZERO/ERROR on a `correct_sparql` is
 near-certain defect; ZERO on a `sparql` example is a strong flag to review.
 
 Network/timeout failures are reported as ERROR but called out separately so a flaky
-endpoint is not mistaken for a broken query. Exit code = ZERO + ERROR count on
-`correct_sparql` blocks (the high-confidence defects); pass --strict to count all.
+endpoint is not mistaken for a broken query.
+
+Exit code = ZERO + ERROR count over ALL example blocks (not just `correct_sparql`).
+An earlier version gated only on `correct_sparql`, which let a broken `sparql`
+example (pubmed's cross-DB join, wrong predicate → 0 rows) slip through triage — so
+now every zero-row example fails the gate. A genuinely-empty example (rare — one that
+demonstrates "no results is the answer") must be marked in the MIE with a sibling
+`expect_empty: true` on that example dict; the checker then treats its 0 rows as OK,
+and if such an example later STARTS returning rows it prints a "stale expect_empty"
+note so the marker gets removed. Net-fail (5xx / timeout) never counts.
 
 Usage:
     uv run python scripts/check_mie_examples.py                 # all MIEs
@@ -105,11 +113,15 @@ def complete_query(query, file_prefixes):
 
 
 def walk_queries(node, path=""):
-    """Yield (jsonpath, key, query_text) for every COPY_KEYS value."""
+    """Yield (jsonpath, key, query_text, expect_empty) for every COPY_KEYS value.
+
+    `expect_empty` is the sibling `expect_empty: true` flag on the dict holding the
+    query — the allowlist marker for an example that legitimately returns 0 rows."""
     if isinstance(node, dict):
+        expect_empty = bool(node.get("expect_empty"))
         for k, v in node.items():
             if k in COPY_KEYS and isinstance(v, str):
-                yield f"{path}/{k}", k, v
+                yield f"{path}/{k}", k, v, expect_empty
             else:
                 yield from walk_queries(v, f"{path}/{k}")
     elif isinstance(node, list):
@@ -169,8 +181,6 @@ def main():
     ap.add_argument("dbs", nargs="*", help="database names to check (default: all)")
     ap.add_argument("--timeout", type=float, default=90.0)
     ap.add_argument("--delay", type=float, default=0.3)
-    ap.add_argument("--strict", action="store_true",
-                    help="exit-count includes sparql-example ZERO/ERROR, not just correct_sparql")
     args = ap.parse_args()
 
     endpoints = load_endpoint_map()
@@ -179,7 +189,7 @@ def main():
         want = set(args.dbs)
         files = [f for f in files if f.stem in want]
 
-    zero, errs, netfail, skips, ok = [], [], [], 0, 0
+    zero, errs, netfail, stale, skips, ok = [], [], [], [], 0, 0
     for f in files:
         db = f.stem
         text = f.read_text(encoding="utf-8")
@@ -190,12 +200,9 @@ def main():
             continue
         file_prefixes = harvest_prefixes(text)
         ep = endpoints.get(db)
-        for jpath, key, q in walk_queries(d):
+        for jpath, key, q, expect_empty in walk_queries(d):
             tag = f"{db} {jpath.lstrip('/')}"
-            if not is_runnable_sparql(q):
-                skips += 1
-                continue
-            if not ep:
+            if not is_runnable_sparql(q) or not ep:
                 skips += 1
                 continue
             n, err = run(ep, complete_query(q, file_prefixes), args.timeout)
@@ -208,31 +215,44 @@ def main():
                 errs.append((tag, key, err))
                 print(f"  ✗  {tag} [{key}] ERROR: {err}", flush=True)
             elif n == 0:
-                zero.append((tag, key))
-                print(f"  ✗  {tag} [{key}] ZERO ROWS", flush=True)
+                if expect_empty:  # allowlisted — genuinely-empty example
+                    ok += 1
+                    print(f"  ✓  {tag} 0 rows (expect_empty)", flush=True)
+                else:
+                    zero.append((tag, key))
+                    print(f"  ✗  {tag} [{key}] ZERO ROWS", flush=True)
             else:
                 ok += 1
+                if expect_empty:  # marker now lies — example returns rows
+                    stale.append((tag, n))
+                    print(f"  !  {tag} STALE expect_empty (now {n} rows)", flush=True)
 
     print("\n" + "=" * 70)
     print(f"MIE EXAMPLE CHECK — {ok} ok, {len(zero)} zero-row, {len(errs)} error, "
-          f"{len(netfail)} net-fail, {skips} skipped")
+          f"{len(netfail)} net-fail, {len(stale)} stale-marker, {skips} skipped")
     print("=" * 70)
     hi = lambda items: [t for t in items if t[1] == "correct_sparql"]  # noqa: E731
     if zero or errs:
         print("\nHIGH CONFIDENCE — anti_pattern correct_sparql that ZERO/ERROR (near-certain defect):")
         for tag, key, *rest in hi(zero) + hi(errs):
             print(f"  {tag}: {rest[0] if rest else 'ZERO ROWS'}")
-        print("\nEXAMPLES (sparql_query_examples / cross_database) that ZERO/ERROR (review):")
-        for tag, key, *rest in zero + errs:
-            if key != "correct_sparql":
+        others = [(t, k, *r) for t, k, *r in (zero + errs) if k != "correct_sparql"]
+        if others:
+            print("\nEXAMPLES (sparql_query_examples / cross_database) that ZERO/ERROR"
+                  " — disposition each; mark expect_empty only if 0 is genuinely correct:")
+            for tag, key, *rest in others:
                 print(f"  {tag}: {rest[0] if rest else 'ZERO ROWS'}")
+    if stale:
+        print("\nSTALE expect_empty (marker says empty but query now returns rows — remove the marker):")
+        for tag, n in stale:
+            print(f"  {tag}: now {n} rows")
     if netfail:
         print("\nNET-FAIL (endpoint unreachable — NOT a query defect):")
         for tag, key, err in netfail:
             print(f"  {tag}: {err}")
 
-    exit_items = (zero + errs) if args.strict else (hi(zero) + hi(errs))
-    sys.exit(min(len(exit_items), 125))
+    # Gate on EVERY un-allowlisted zero-row/error, plus stale markers (which lie).
+    sys.exit(min(len(zero) + len(errs) + len(stale), 125))
 
 
 if __name__ == "__main__":

--- a/scripts/check_mie_examples.py
+++ b/scripts/check_mie_examples.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Example-query checker for TogoMCP MIE files.
+
+The 2026-07 co-tenancy sweep re-verified every MIE's `co_hosted_graphs` and
+`critical_warnings` — but NOT the example queries agents actually copy. An audit
+then found several `anti_patterns.correct_sparql` and `architectural_notes`
+templates that silently return 0 rows or error against the live endpoint
+(oma/supercon/taxonomy/chebi), each contradicting the file's own verified schema.
+A "correct" example that returns 0 is worse than no example: it teaches a broken
+query.
+
+This script closes that gap for the runnable part. For every MIE it extracts the
+`sparql` blocks (from `sparql_query_examples` and `cross_database_queries`) and the
+`correct_sparql` blocks (from `anti_patterns`) — the queries a reader is meant to
+COPY — runs each against the database's own endpoint (resolved from endpoints.csv),
+and flags ZERO-row and ERROR results. It deliberately SKIPS `wrong_sparql` (those
+are meant to fail).
+
+Limits — this catches only the runnable-and-empty failure mode:
+  - A query that returns the WRONG rows (e.g. taxonomy's bare-namespace-rank
+    example returning botanical sections, or a join to the wrong graph that still
+    yields plausible rows) passes here. Semantic correctness still needs a human /
+    the co-tenancy audit.
+  - Prose defects (a `data_integration` bullet prescribing a dead join, a stale
+    graph-count) are invisible here.
+So a clean run is necessary, not sufficient. ZERO/ERROR on a `correct_sparql` is a
+near-certain defect; ZERO on a `sparql` example is a strong flag to review.
+
+Network/timeout failures are reported as ERROR but called out separately so a flaky
+endpoint is not mistaken for a broken query. Exit code = ZERO + ERROR count on
+`correct_sparql` blocks (the high-confidence defects); pass --strict to count all.
+
+Usage:
+    uv run python scripts/check_mie_examples.py                 # all MIEs
+    uv run python scripts/check_mie_examples.py oma taxonomy    # specific DBs
+    uv run python scripts/check_mie_examples.py --timeout 120
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not installed. Run: uv sync")
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parents[1]
+MIE_DIR = ROOT / "togo_mcp" / "data" / "mie"
+ENDPOINTS_CSV = ROOT / "togo_mcp" / "data" / "resources" / "endpoints.csv"
+
+# Keys whose value is a query the reader is meant to COPY. `wrong_sparql` is
+# excluded on purpose — anti-pattern "wrong" queries are supposed to misbehave.
+COPY_KEYS = {"sparql", "correct_sparql", "query"}
+
+_FORM_RE = re.compile(r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE)\b", re.IGNORECASE)
+
+
+def load_endpoint_map():
+    m = {}
+    with open(ENDPOINTS_CSV, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            db = (row.get("database") or "").strip()
+            url = (row.get("endpoint_url") or "").strip()
+            if db and url:
+                m[db] = url
+    return m
+
+
+def is_runnable_sparql(q):
+    body = "\n".join(l for l in q.splitlines() if not l.lstrip().startswith("#"))
+    return bool(_FORM_RE.search(body))
+
+
+_PREFIX_DECL = re.compile(r"^\s*PREFIX\s+([A-Za-z][\w.-]*)\s*:\s*(<[^>]+>)", re.MULTILINE | re.IGNORECASE)
+
+
+def harvest_prefixes(file_text):
+    """Union of every PREFIX declared anywhere in the MIE file. Anti-pattern
+    snippets often omit their PREFIX lines (relying on the file's shared vocab);
+    prepending the missing ones lets the checker judge query LOGIC (wrong class →
+    0 rows) instead of flagging every prefix-less fragment as an ERROR."""
+    out = {}
+    for name, iri in _PREFIX_DECL.findall(file_text):
+        out.setdefault(name, iri)  # first declaration wins
+    return out
+
+
+def complete_query(query, file_prefixes):
+    """Prepend any harvested PREFIX the query uses but does not itself declare."""
+    declared = {m.group(1) for m in _PREFIX_DECL.finditer(query)}
+    body = "\n".join(l for l in query.splitlines() if not l.lstrip().startswith("#"))
+    used = set(re.findall(r"(?<![<\w])([A-Za-z][\w.-]*)\s*:", body))
+    add = [f"PREFIX {n}: {file_prefixes[n]}"
+           for n in used if n not in declared and n in file_prefixes]
+    return ("\n".join(add) + "\n" + query) if add else query
+
+
+def walk_queries(node, path=""):
+    """Yield (jsonpath, key, query_text) for every COPY_KEYS value."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k in COPY_KEYS and isinstance(v, str):
+                yield f"{path}/{k}", k, v
+            else:
+                yield from walk_queries(v, f"{path}/{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from walk_queries(v, f"{path}[{i}]")
+
+
+def run(endpoint, query, timeout):
+    data = urllib.parse.urlencode({"query": query}).encode()
+    req = urllib.request.Request(
+        endpoint, data=data,
+        headers={"Accept": "application/sparql-results+json",
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "User-Agent": "togomcp-mie-example-check"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.load(r)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", "replace")
+            detail = re.sub(r"\s+", " ", body)[:140]
+        except Exception:  # noqa: BLE001
+            detail = ""
+        # 5xx is a server/infra failure (gateway down, transaction timeout), NOT a
+        # query defect — classify as net so a flaky endpoint isn't read as a broken
+        # template. A genuine query error is a 400 (SPARQL compile) or 4xx.
+        prefix = "net" if e.code in (500, 502, 503, 504) else f"HTTP {e.code}"
+        return None, f"{prefix}: {detail}"
+    except (urllib.error.URLError, TimeoutError) as e:
+        return None, f"net: {getattr(e, 'reason', e)}"
+    except json.JSONDecodeError:
+        return None, "non-JSON response"
+    except Exception as e:  # noqa: BLE001
+        return None, f"{type(e).__name__}: {str(e)[:80]}"
+    if "boolean" in payload:
+        return (1 if payload["boolean"] else 0), None
+    try:
+        bindings = payload["results"]["bindings"]
+    except (KeyError, TypeError):
+        return None, "unexpected result shape"
+    # A lone scalar aggregate — SELECT (COUNT(...) AS ?n) — returns ONE row even
+    # when it counts nothing. Treat a single-cell numeric 0 as "zero rows": that
+    # is exactly how oma/supercon's broken COUNT templates hide (1 row, value 0).
+    if len(bindings) == 1 and len(bindings[0]) == 1:
+        val = next(iter(bindings[0].values())).get("value", "")
+        try:
+            if float(val) == 0:
+                return 0, None
+        except (TypeError, ValueError):
+            pass
+    return len(bindings), None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("dbs", nargs="*", help="database names to check (default: all)")
+    ap.add_argument("--timeout", type=float, default=90.0)
+    ap.add_argument("--delay", type=float, default=0.3)
+    ap.add_argument("--strict", action="store_true",
+                    help="exit-count includes sparql-example ZERO/ERROR, not just correct_sparql")
+    args = ap.parse_args()
+
+    endpoints = load_endpoint_map()
+    files = sorted(MIE_DIR.glob("*.yaml"))
+    if args.dbs:
+        want = set(args.dbs)
+        files = [f for f in files if f.stem in want]
+
+    zero, errs, netfail, skips, ok = [], [], [], 0, 0
+    for f in files:
+        db = f.stem
+        text = f.read_text(encoding="utf-8")
+        try:
+            d = yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            print(f"  ⚠  {db}: YAML parse error ({e})")
+            continue
+        file_prefixes = harvest_prefixes(text)
+        ep = endpoints.get(db)
+        for jpath, key, q in walk_queries(d):
+            tag = f"{db} {jpath.lstrip('/')}"
+            if not is_runnable_sparql(q):
+                skips += 1
+                continue
+            if not ep:
+                skips += 1
+                continue
+            n, err = run(ep, complete_query(q, file_prefixes), args.timeout)
+            if args.delay:
+                time.sleep(args.delay)
+            if err and err.startswith("net"):
+                netfail.append((tag, key, err))
+                print(f"  ~  {tag} NET-FAIL: {err}", flush=True)
+            elif err:
+                errs.append((tag, key, err))
+                print(f"  ✗  {tag} [{key}] ERROR: {err}", flush=True)
+            elif n == 0:
+                zero.append((tag, key))
+                print(f"  ✗  {tag} [{key}] ZERO ROWS", flush=True)
+            else:
+                ok += 1
+
+    print("\n" + "=" * 70)
+    print(f"MIE EXAMPLE CHECK — {ok} ok, {len(zero)} zero-row, {len(errs)} error, "
+          f"{len(netfail)} net-fail, {skips} skipped")
+    print("=" * 70)
+    hi = lambda items: [t for t in items if t[1] == "correct_sparql"]  # noqa: E731
+    if zero or errs:
+        print("\nHIGH CONFIDENCE — anti_pattern correct_sparql that ZERO/ERROR (near-certain defect):")
+        for tag, key, *rest in hi(zero) + hi(errs):
+            print(f"  {tag}: {rest[0] if rest else 'ZERO ROWS'}")
+        print("\nEXAMPLES (sparql_query_examples / cross_database) that ZERO/ERROR (review):")
+        for tag, key, *rest in zero + errs:
+            if key != "correct_sparql":
+                print(f"  {tag}: {rest[0] if rest else 'ZERO ROWS'}")
+    if netfail:
+        print("\nNET-FAIL (endpoint unreachable — NOT a query defect):")
+        for tag, key, err in netfail:
+            print(f"  {tag}: {err}")
+
+    exit_items = (zero + errs) if args.strict else (hi(zero) + hi(errs))
+    sys.exit(min(len(exit_items), 125))
+
+
+if __name__ == "__main__":
+    main()

--- a/togo_mcp/data/mie/amrportal.yaml
+++ b/togo_mcp/data/mie/amrportal.yaml
@@ -68,9 +68,9 @@ schema_info:
        cannot inflate a join."
   kw_search_tools: []
   version:
-    mie_version: "2.4"
+    mie_version: "2.5"
     mie_created: "2025-04-21"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Irregular updates"
   license:
@@ -438,20 +438,18 @@ cross_database_queries:
   shared_endpoint: ebi
   co_located_databases: [chembl, chebi, reactome, ensembl]
   examples:
-    - title: Resistance Counts Linked to ChEMBL Compounds (Two-Stage Aggregation)
+    # This cross-DB link is a TWO-STAGE pattern: aggregating resistance counts AND joining to
+    # ChEMBL in one query times out on 1.7M rows. The two stages are split into two runnable
+    # examples below — run Stage 1, paste its counts into Stage 2's VALUES. (They were previously
+    # one `sparql` block concatenating both queries, which is not runnable as a single query.)
+    - title: Resistance Counts per Antibiotic — Stage 1 of 2 (aggregate within amrportal GRAPH)
       description: |
-        Aggregate AMR resistance within its own GRAPH first, then join to ChEMBL.
-        Aggregating across GRAPHs in a single query causes guaranteed timeout on 1.7M rows.
-
-        Linking strategy:
-        - Stage 1: COUNT resistant records per antibioticName within amrportal GRAPH (5-7s)
-        - Stage 2: join aggregated summary to ChEMBL rdfs:label via LCASE matching (<1s)
-        - No structured IRI bridge between AMR and ChEMBL — name matching is the only link
-        - MIE files checked: amrportal, chembl
-      databases_used: [amrportal, chembl]
+        Stage 1 of the amrportal -> ChEMBL two-stage pattern: COUNT resistant records per
+        antibioticName WITHIN the amrportal GRAPH. Run this alone, then paste its counts into the
+        Stage-2 VALUES block (next example) — aggregating across GRAPHs in one query times out.
+      databases_used: [amrportal]
       complexity: intermediate
       sparql: |
-        # STAGE 1 — run independently first (5-7s)
         PREFIX amr: <http://example.org/ebiamr#>
         SELECT ?antibiotic (COUNT(*) as ?resistant)
         FROM <http://rdfportal.org/dataset/amrportal>
@@ -462,8 +460,18 @@ cross_database_queries:
           FILTER(?antibiotic IN ("ciprofloxacin", "ampicillin", "gentamicin"))
         }
         GROUP BY ?antibiotic
+      notes: |
+        - ~5-7s. Verified 2026-07-18: ciprofloxacin 21368, ampicillin 21660, gentamicin 8398.
+        - NEVER combine this COUNT with the cross-GRAPH ChEMBL join in one query — guaranteed timeout.
 
-        # STAGE 2 — substitute Stage 1 results into VALUES, then run (<1s)
+    - title: Link Resistance Counts to ChEMBL Development Phase — Stage 2 of 2
+      description: |
+        Stage 2: substitute the Stage-1 counts into a VALUES block and join to ChEMBL by name.
+        There is no structured IRI bridge between AMR and ChEMBL — LCASE name matching is the only
+        link. Refresh the VALUES numbers whenever Stage 1 is re-run.
+      databases_used: [amrportal, chembl]
+      complexity: intermediate
+      sparql: |
         PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         SELECT ?antibiotic ?resistant ?developmentPhase
@@ -481,11 +489,10 @@ cross_database_queries:
           }
         }
       notes: |
-        - Run as two separate queries; paste Stage 1 counts into Stage 2 VALUES.
-        - NEVER combine COUNT and cross-GRAPH join in one query — guaranteed timeout.
         - STR() on BOTH sides of the name FILTER is required: a VALUES-bound plain literal does
           NOT compare equal to LCASE()'s xsd:string output in Virtuoso — without it the join
-          silently returns 0 rows (verified 2026-07-07). Stage-2 phases: cipro/ampicillin/gentamicin all 4.
+          silently returns 0 rows (verified 2026-07-07).
+        - Verified 2026-07-18: cipro/ampicillin/gentamicin all highestDevelopmentPhase 4.
         - MIE files checked: amrportal, chembl.
 
     - title: AMR Resistance Enriched with ChEBI Chemical Properties

--- a/togo_mcp/data/mie/bacdive.yaml
+++ b/togo_mcp/data/mie/bacdive.yaml
@@ -55,9 +55,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "2.5"
+    mie_version: "2.6"
     mie_created: "2026-04-21"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"   # no dataset-level version triple
                                                                 # exists on the endpoint (checked
                                                                 # void:triples/owl:versionInfo/
@@ -524,10 +524,11 @@ sparql_query_examples:
                 schema:hasGenus ?genus .
         ?gs a schema:GramStain ;
             schema:describesStrain ?strain ;
-            schema:hasGramStain "positive" .
+            schema:hasGramStain ?gram .
+        FILTER(STR(?gram) = "positive")       # hasGramStain is ^^rr:Literal, NOT a plain string — match via STR()
         ?sp a schema:SporeFormation ;
             schema:describesStrain ?strain ;
-            schema:hasAbility 1 .             # integer 1 = spore-forming
+            schema:hasAbility true .           # xsd:boolean (live data); true = spore-forming (NOT integer 1)
         OPTIONAL {
           ?temp a schema:CultureTemperature ;
                 schema:describesStrain ?strain ;

--- a/togo_mcp/data/mie/chebi.yaml
+++ b/togo_mcp/data/mie/chebi.yaml
@@ -56,9 +56,9 @@ schema_info:
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "2.3"
+    mie_version: "2.4"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "Release 250 (derived from owl:versionInfo 250 and owl:versionIRI <http://purl.obolibrary.org/obo/chebi/250/chebi.owl> on <http://purl.obolibrary.org/obo/chebi.owl>; verified 2026-07-17)"
     update_frequency: "Monthly"
   access:
@@ -620,7 +620,7 @@ architectural_notes:
 
   data_integration:
     - "Cross-references are literal strings — parse with STRBEFORE(?xref, ':') for prefix"
-    - "ChEMBL: direct via skos:exactMatch → CHEBI_ IRI (no conversion needed)"
+    - "ChEMBL: NO skos:exactMatch to ChEBI (that join returns 0 rows, verified 2026-06-19); join on InChIKey — ChEBI chemrof:inchi_key_string ↔ ChEMBL sio:CHEMINF_000059 (see cross_references)"
     - "Reactome: requires URI conversion from 'CHEBI:NNNNN' format plus ^^xsd:string on bp:db"
     - "InChIKey for structure-based matching across databases (chemrof:inchi_key_string)"
 

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -58,9 +58,9 @@ schema_info:
     - search_chembl_molecule
     - search_chembl_target
   version:
-    mie_version: "3.6"
+    mie_version: "3.7"
     mie_created: "2025-02-10"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "ChEMBL 36.0 (derived from pav:version \"36.0\" on <http://rdf.ebi.ac.uk/dataset/chembl/36.0.rdf>, dcterms:modified 2025-07-28; verified 2026-07-17)"
     update_frequency: Quarterly
   license:
@@ -850,9 +850,11 @@ data_statistics:
   assays_with_description: 1890708  # ~100% of assays carry dcterms:description (2026-07-14)
   human_protein_kinases: 423
   alzheimers_drugs: 305
-  verified_date: "2026-07-07"
-  verification_method: "Direct COUNT queries on each entity type, all re-run 2026-07-07 on ChEMBL 34.0 and
-    unchanged: molecules 1,920,603; assays 1,890,749; SingleProtein targets 10,962 (17,803 all target
+  verified_date: "2026-07-18"
+  verification_method: "Direct COUNT queries on each entity type, first taken on ChEMBL 34.0 (2026-07-07)
+    and re-confirmed UNCHANGED on the current ChEMBL 36.0 (2026-07-18 — molecules and SingleProtein targets
+    reproduce exactly, so the figures below are current for 36.0):
+    molecules 1,920,603; assays 1,890,749; SingleProtein targets 10,962 (17,803 all target
     types); documents 99,141; mechanisms 7,568; indications 59,954; human protein kinases 423; Alzheimer's
     drugs (MeSH D000544) 305. Prior label total_targets:10962 corrected — that figure is SingleProtein-only."
   coverage:

--- a/togo_mcp/data/mie/ddbj.yaml
+++ b/togo_mcp/data/mie/ddbj.yaml
@@ -38,8 +38,8 @@ schema_info:
     - "~39 shared ontology/vocabulary graphs on this endpoint that are NOT in DDBJ's four (http://purl.jp/bio/11/goa; id.nlm.nih.gov/mesh + /vocab + /void; the rdfportal.org/ontology/* suite beyond so/faldo/taxonomy — go, mondo, uberon, cl, sio, hp, efo, …; owl#) — join targets, not co-tenancy traps; probed 2026-07-17. nuc:Entry, nuc:Gene, nuc:Coding_Sequence, nuc:Source and faldo:Region are each declared in <http://rdfportal.org/dataset/ddbj> ONLY (verified by excluding dataset/ddbj from the GROUP BY — every class returned an EMPTY result), and a VALUES probe over insdc/AP009552.1, AB000001.1, AP012306.1 found those IRIs in dataset/ddbj ONLY. Endpoint total: 43 graphs."
   kw_search_tools: []
   version:
-    mie_version: "2.3"
-    mie_updated: "2026-07-17"
+    mie_version: "2.4"
+    mie_updated: "2026-07-18"
     mie_created: "2026-04-29"
     data_version: "RDF Portal snapshot — verified 2026-07-17. (No release number is derivable from this endpoint: GRAPH <http://rdfportal.org/dataset/ddbj> carries no dcterms:modified / dcterms:issued / dcterms:hasVersion / owl:versionInfo — probed 2026-07-17. The previous value \"DDBJ Release\" was not endpoint-derived.)"
     update_frequency: "Daily"
@@ -651,16 +651,20 @@ anti_patterns:
       WHERE { ?gene a nuc:Gene ; bfo:0000050 ?entry . }
       LIMIT 1
     correct_sparql: |
-      # CORRECT: use division IRI discovered during exploration for full-division aggregate
+      # CORRECT: scope by division IRI, then reach Gene through the Entry's SEQUENCE.
+      # A Gene's bfo:0000050 (part_of) points to the Sequence node, NOT the Entry (see GeneShape),
+      # so `?gene bfo:0000050 ?entry` matches NOTHING. Hop Entry --nuc:sequence--> Sequence <--bfo:0000050-- Gene.
       SELECT (COUNT(DISTINCT ?gene) AS ?geneCount)
       FROM <http://rdfportal.org/dataset/ddbj>
       WHERE {
         ?entry a nuc:Entry ;
-               nuc:division <http://ddbj.nig.ac.jp/ontologies/nucleotide/Division#PHG> .
-        ?gene a nuc:Gene ; bfo:0000050 ?entry .
+               nuc:division <http://ddbj.nig.ac.jp/ontologies/nucleotide/Division#PHG> ;
+               nuc:sequence ?seq .
+        ?gene a nuc:Gene ; bfo:0000050 ?seq .
       }
       LIMIT 1
-    explanation: "Use division IRIs to scope comprehensive aggregations across the full dataset. Pasting sampled entry IRIs into VALUES only counts those specific entries."
+      # -> 3,244,894 genes across the PHG division. Verified 2026-07-18.
+    explanation: "Two lessons: (1) use division IRIs to scope comprehensive aggregations, not sampled entry IRIs in VALUES; (2) a Gene's bfo:0000050 (part_of) points to the SequenceShape, NOT the Entry — join Entry→Sequence→Gene via nuc:sequence, or the query silently returns 0."
 
   - title: "Aggregation Without Division or Entry Scope"
     problem: "COUNT(*) on nuc:Entry or features without a filter scans all 280M entries and times out."

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -14,7 +14,7 @@ schema_info:
     carbohydrate esterases, auxiliary activities, carbohydrate-binding modules — over
     ~870k UniProt enzyme sequences with EC numbers) and a Human Protein Atlas (HPA)
     tissue/cell-type expression layer (IHC levels High/Medium/Low/Not detected keyed
-    by Ensembl Gene ID + gene symbol). ~60 named graphs in total; this MIE documents
+    by Ensembl Gene ID + gene symbol). ~84 substantive named graphs (148 incl. /void companions); this MIE documents
     the glycan/protein/gene/disease/GO backbone plus the CAZy and HPA layers in depth
     and catalogs the remaining specialist graphs (see schema_info.graphs).
     Primary uses: glycobiology research, carbohydrate-active enzyme discovery,
@@ -66,7 +66,7 @@ schema_info:
     - protein
   endpoint: https://ts.glycosmos.org/sparql
   base_uri: http://rdf.glycoinfo.org/
-  # ~60 named graphs on this endpoint (each with a companion <graph>/void descriptor
+  # ~84 substantive named graphs on this endpoint, 148 incl. /void (each with a companion <graph>/void descriptor
   # carrying void:triples — query the /void graphs for exact sizes). The graphs below
   # are grouped: FULLY DOCUMENTED (shapes + examples in this MIE) first, then a
   # CATALOG of the remaining specialist graphs with one-line roles so nothing is
@@ -179,9 +179,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "4.3"
+    mie_version: "4.4"
     mie_created: "2026-07-01"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17 (glycan/protein counts verified 2026-06-27; disease/GO layer + gene-protein bridge verified 2026-07-01; CAZy + HPA-expression layers + full graph catalog added and verified 2026-07-01; lectin-name grounding layer — GL hub + LfDB + CarboGrove — added and verified 2026-07-16; co_hosted_graphs 2g probe + graph re-declaration figures verified 2026-07-17). No release number is derivable from this endpoint: the */void graphs carry void:triples/entities but NO dcterms:modified / dcterms:issued / dcterms:hasVersion / owl:versionInfo — probed 2026-07-17. The former \"2025.04\" label was taken from the project website, not the endpoint, and has been dropped per spec v2.3."
     update_frequency: "Quarterly"
   access:

--- a/togo_mcp/data/mie/go.yaml
+++ b/togo_mcp/data/mie/go.yaml
@@ -51,9 +51,9 @@ schema_info:
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "2.2"
+    mie_version: "2.3"
     mie_created: "2025-02-10"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     # Derived from the endpoint, not from geneontology.org: <http://purl.obolibrary.org/obo/go.owl>
     # owl:versionInfo "2026-05-19" (and owl:versionIRI .../releases/2026-05-19/go.owl) in
     # GRAPH <http://rdfportal.org/ontology/go>. The former "Latest GO Release" was a placeholder.
@@ -67,7 +67,7 @@ critical_warnings: |
   - MANDATORY FROM CLAUSE: Every query on the shared 'primary' endpoint MUST include
     FROM <http://rdfportal.org/ontology/go>. Omitting it queries all co-located ontologies
     (MeSH, MONDO, taxonomy, etc.), causes timeouts, and returns incorrect results.
-  - EIGHT OTHER GRAPHS RE-DECLARE GO's OWN IRIs — x3.27 SILENT ROW INFLATION (verified 2026-07-17).
+  - TEN OTHER GRAPHS RE-DECLARE GO's OWN IRIs — x3.27 SILENT ROW INFLATION (verified 2026-07-17).
     This is why the FROM clause above is mandatory, quantified. The everyday join
       ?c a owl:Class ; rdfs:label ?l .   FILTER(STRSTARTS(STR(?c), "http://purl.obolibrary.org/obo/GO_"))
     returns 158,185 rows for 48,330 classes UNPINNED, but exactly 48,321 rows for 48,321 classes

--- a/togo_mcp/data/mie/jpostdb.yaml
+++ b/togo_mcp/data/mie/jpostdb.yaml
@@ -54,9 +54,9 @@ schema_info:
        co-tenancy traps; probed 2026-07-17."
   kw_search_tools: []
   version:
-    mie_version: "2.3"
+    mie_version: "2.4"
     mie_created: "2026-04-30"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     # Dated-snapshot form: the data graph <http://jpost.org/graph/database> carries NO dataset-level
     # version triple (probed void:triples, owl:versionInfo/versionIRI, dcterms:modified|issued|
     # hasVersion, void:Dataset/owl:Ontology descriptors). The only version on the endpoint is
@@ -778,16 +778,20 @@ anti_patterns:
       WHERE { ?pept a jpost:Peptide ; jpost:isDetectedIn ?prot . }
       LIMIT 1
     correct_sparql: |
-      # CORRECT: use the UniProt IRI (structured predicate) discovered during exploration
+      # CORRECT: use the UniProt IRI (structured predicate) discovered during exploration.
+      # Protein -> Peptide runs through the PeptideEvidence blank node, NOT a direct reverse
+      # predicate: jpost:isDetectedIn does NOT exist (silent 0 rows). See ProteinShape/PeptideEvidence.
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
       SELECT (COUNT(DISTINCT ?pept) AS ?count)
       FROM <http://jpost.org/graph/database>
       WHERE {
         ?prot a jpost:Protein ;
-              jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/P01116> .
-        ?pept a jpost:Peptide ; jpost:isDetectedIn ?prot .
+              jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/P01116> ;
+              jpost:hasPeptideEvidence [ jpost:hasPeptide ?pept ] .
       }
       LIMIT 1
-    explanation: "Use the jpost:hasDatabaseSequence IRI predicate to scope comprehensive counts. Pasting sampled PRT IRIs only counts those specific project-dataset combinations."
+      # -> 242 distinct peptides for P01116 (KRAS). Verified 2026-07-18.
+    explanation: "Use jpost:hasDatabaseSequence to scope by protein, then reach peptides through the PeptideEvidence bnode (jpost:hasPeptideEvidence/jpost:hasPeptide) — there is NO direct jpost:isDetectedIn predicate; using it silently returns 0. Pasting sampled PRT IRIs only counts those project-dataset combinations."
 
   - title: "Querying peptide sequence as a direct property"
     problem: "Treating the AA sequence as a literal directly on the Peptide."

--- a/togo_mcp/data/mie/mediadive.yaml
+++ b/togo_mcp/data/mie/mediadive.yaml
@@ -52,9 +52,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "2.2"
+    mie_version: "2.3"
     mie_created: "2025-07-15"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     # No release identifier is derivable from the endpoint: the mediadive graph carries NO
     # owl:versionInfo, dcterms:modified/issued/hasVersion/date, and no void:triples (queried
     # 2026-07-17). Hence the dated-snapshot form — do NOT substitute a number from the MediaDive
@@ -66,6 +66,11 @@ schema_info:
 
 # Critical warnings: schema pathologies and silent-failure traps.
 critical_warnings: |
+  - THE `schema:` PREFIX IS **NOT** schema.org (silent 0-row trap). Throughout this file `schema:`
+    means <https://purl.dsmz.de/schema/> — DSMZ's own vocabulary, which the endpoint auto-declares
+    (so the examples carry no PREFIX line for it). If you habit-type `PREFIX schema: <http://schema.org/>`
+    yourself, EVERY schema:* pattern returns 0 rows with no error. Use the https + /schema/ path, or a
+    distinctive prefix of your own (e.g. `PREFIX md: <https://purl.dsmz.de/schema/>`).
   - ⚠ BACDIVE SHARES THIS VOCABULARY — AN UNPINNED QUERY SILENTLY ADDS BACDIVE'S ENTITIES.
     BacDive is the other DSMZ resource on this endpoint and uses the SAME purl.dsmz.de/schema/
     class names. Without a GRAPH clause:

--- a/togo_mcp/data/mie/nando.yaml
+++ b/togo_mcp/data/mie/nando.yaml
@@ -57,9 +57,9 @@ schema_info:
   kw_search_tools:
     - OLS4:searchClasses
   version:
-    mie_version: "2.4"
+    mie_version: "2.5"
     mie_created: "2025-04-21"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     # Endpoint-DERIVED (queried 2026-07-17), correcting the previous "Current release" placeholder:
     #   <http://nanbyodata.jp/ontology/nando.owl#> owl:versionInfo   "2023-11-28"
     #                                              owl:versionIRI    <https://nanbyodata.jp/ontology/2023-11-28/nando.ttl>
@@ -141,7 +141,7 @@ shape_expressions: |
     rdfs:seeAlso IRI * ;                       # KEGG (519), govt docs, patient portals — 6,120 triples
     dct:source IRI ? ;                         # govt PDFs/docs — 2,397 diseases (86%)
     dct:description xsd:string ? ;             # Japanese clinical description — 1,211 diseases (44%)
-    owl:deprecated xsd:integer ?               # present on 9 obsolete entries
+    owl:deprecated xsd:integer ?               # present on 8 obsolete entries
   }
 
 sample_rdf_entries:
@@ -620,19 +620,22 @@ anti_patterns:
       }
     explanation: "Always use FILTER(LANG(?label) = 'en'/'ja'/'ja-hira') to select exactly one language variant."
 
-  - title: "Unfiltered skos:closeMatch Including Non-MONDO Targets"
-    problem: "Querying skos:closeMatch without IRI prefix filter returns 2,341 triples instead of the 2,150 MONDO-specific ones."
+  - title: "Counting Diseases by Raw skos:closeMatch Rows (many-to-many inflation)"
+    problem: "skos:closeMatch is many-to-many AND re-declared across co-hosted graphs. Pinned to nando it is 2,341 mapping rows spanning only 2,150 distinct diseases (some map to several MONDO terms), so COUNT(*) over-reports diseases by 191; unpinned it also reads six other graphs' closeMatch (nikkaji, mondo, efo, …)."
     wrong_sparql: |
-      # Returns 191 extra non-MONDO triples silently
-      SELECT ?disease ?match WHERE {
+      # Counts mapping ROWS (not diseases) AND reads every co-hosted graph -> doubly inflated
+      SELECT (COUNT(*) AS ?n) WHERE {
         ?disease skos:closeMatch ?match .
       }
     correct_sparql: |
-      SELECT ?disease ?match WHERE {
+      # Pin the nando graph; COUNT(DISTINCT) the axis you actually mean.
+      SELECT (COUNT(DISTINCT ?disease) AS ?nDiseases)
+      FROM <http://nanbyodata.jp/ontology/nando>
+      WHERE {
         ?disease skos:closeMatch ?match .
-        FILTER(STRSTARTS(STR(?match), "http://purl.obolibrary.org/obo/MONDO_"))
+        FILTER(STRSTARTS(STR(?match), "http://purl.obolibrary.org/obo/MONDO_"))  # defensive no-op: all nando targets are MONDO today
       }
-    explanation: "skos:closeMatch covers MONDO and other targets. Apply STRSTARTS filter immediately when targeting MONDO specifically."
+    explanation: "All 2,341 nando closeMatch targets are MONDO (verified 2026-07-16), so the STRSTARTS filter removes nothing today — it is DEFENSIVE, not corrective (do not expect it to drop non-MONDO rows). The real trap is twofold: (1) co-tenancy — unpinned, skos:closeMatch is re-declared across 7 graphs, so PIN <http://nanbyodata.jp/ontology/nando>; (2) cardinality — pinned it is many-to-many, COUNT(*)=2,341 rows vs COUNT(DISTINCT ?disease)=2,150 diseases. Pin the graph and COUNT(DISTINCT) the side you mean. Verified 2026-07-18."
 
   - title: "Circular Reasoning: Using Search Results in VALUES for Comprehensive Counts"
     problem: "Putting search API results in VALUES counts only the retrieved sample, not the full database."

--- a/togo_mcp/data/mie/oma.yaml
+++ b/togo_mcp/data/mie/oma.yaml
@@ -52,9 +52,9 @@ schema_info:
        overlap with Bgee's 52 (<https://omabrowser.org/oma/genome/NNN> vs <https://bgee.org/species/NNN>)."
   kw_search_tools: []
   version:
-    mie_version: "2.2"
+    mie_version: "2.3"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Annual"
   access:
@@ -661,21 +661,34 @@ anti_patterns:
       SELECT (COUNT(?pair) AS ?count) WHERE { }
       LIMIT 1
     correct_sparql: |
-      # CORRECT: use the taxonomy IRI to count all human-mouse orthologs comprehensively
-      PREFIX oma: <https://omabrowser.org/ontology/oma#>
+      # CORRECT: count human-mouse ortholog groups via shared HOG family prefix.
+      # NOTE the earlier form was impossible: the class is orth:OrthologsCluster (not
+      # OrthologousCluster), there is no oma:organism->taxonomy edge (a protein reaches a
+      # taxon via orth:organism ?org . ?org obo:RO_0002162 <taxon>), AND OMA leaf clusters are
+      # single-species, so no one cluster holds both a human and a mouse member. Human (9606)
+      # and mouse (10090) species leaves of the SAME family share the family token at the head
+      # of dct:identifier (e.g. HOG:E0756069) — GROUP BY it, HAVING both species present. A
+      # single pass; avoids the hasHomologousMember+ property-path timeout.
       PREFIX orth: <http://purl.org/net/orth#>
-      SELECT (COUNT(DISTINCT ?pair) AS ?count)
+      PREFIX dct:  <http://purl.org/dc/terms/>
+      SELECT (COUNT(?family) AS ?count)
       WHERE {
-        GRAPH <http://rdfportal.org/dataset/oma> {
-          ?pair a orth:OrthologousCluster ;
-                orth:hasHomologousMember ?prot1 ;
-                orth:hasHomologousMember ?prot2 .
-          ?prot1 oma:organism <http://purl.uniprot.org/taxonomy/9606> .
-          ?prot2 oma:organism <http://purl.uniprot.org/taxonomy/10090> .
+        SELECT ?family (COUNT(DISTINCT ?sp) AS ?nsp)
+        WHERE {
+          GRAPH <http://rdfportal.org/dataset/oma> {
+            VALUES ?sp { <http://purl.uniprot.org/taxonomy/9606> <http://purl.uniprot.org/taxonomy/10090> }
+            ?leaf a orth:OrthologsCluster ;
+                  orth:hasTaxonomicRange ?sp ;
+                  dct:identifier ?id .
+            BIND(STRBEFORE(?id, ".") AS ?family)
+          }
         }
+        GROUP BY ?family
+        HAVING (COUNT(DISTINCT ?sp) = 2)
       }
       LIMIT 1
-    explanation: "Use taxonomy IRIs to scope comprehensive orthology counts. Pasting sampled cluster IRIs from a species lookup only counts those specific orthologs."
+      # -> 8,763 HOG families with both a human and a mouse ortholog. Verified 2026-07-18.
+    explanation: "Scope a comprehensive count via taxonomy IRIs, not sampled cluster IRIs. Three traps: class is orth:OrthologsCluster (not OrthologousCluster); there is no oma:organism->taxonomy edge (use orth:organism/obo:RO_0002162); and leaf clusters are single-species, so count shared HOG family prefixes (dct:identifier) across the two species rather than expecting one cluster to hold both."
 
   - title: "Missing Identifier Filter (Row Explosion)"
     problem: >

--- a/togo_mcp/data/mie/pubchem.yaml
+++ b/togo_mcp/data/mie/pubchem.yaml
@@ -50,9 +50,9 @@ schema_info:
     - ncbi_esearch
     - get_pubchem_compound_id
   version:
-    mie_version: "2.4"
+    mie_version: "2.5"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "PubChemRDF, dcterms:modified 2026-05-06 — DERIVED FROM THE ENDPOINT: <http://rdf.ncbi.nlm.nih.gov/pubchem/void.ttl#PubChemRDF> dcterms:modified \"2026-05-06\" in GRAPH <http://rdf.ncbi.nlm.nih.gov/pubchem/void>. Verified 2026-07-17."
     update_frequency: "Continuous"
   access:
@@ -688,18 +688,25 @@ anti_patterns:
       SELECT (COUNT(?compound) AS ?count) WHERE { }
       LIMIT 1
     correct_sparql: |
-      # CORRECT: use the ChEBI role IRI discovered during exploration
+      # CORRECT: comprehensive count via a typed descriptor IRI. Two fixes over the naive form:
+      # (1) CHEMINF_000335 is Molecular Formula; CHEMINF_000140 is the CID STRING (e.g. "2244"),
+      #     not a structure descriptor — filtering it as SMILES matches nothing.
+      # (2) a descriptor's rdf:type and value live in the descriptor/compound graph, so BOTH
+      #     graphs must be pinned or the ?descriptor triples resolve to nothing.
+      # (An exact molecular-formula match is used instead of a SMILES CONTAINS scan, which would
+      #  time out over 119M compounds — see the CHEMINF aggregation-timeout warning.)
       PREFIX cheminf: <http://semanticscience.org/resource/>
       SELECT (COUNT(DISTINCT ?compound) AS ?count)
       FROM <http://rdf.ncbi.nlm.nih.gov/pubchem/compound>
+      FROM <http://rdf.ncbi.nlm.nih.gov/pubchem/descriptor/compound>
       WHERE {
         ?compound cheminf:SIO_000008 ?descriptor .
-        ?descriptor a cheminf:CHEMINF_000140 ;
-                    cheminf:SIO_000300 ?smiles .
-        FILTER(CONTAINS(?smiles, "N"))
+        ?descriptor a cheminf:CHEMINF_000335 ;
+                    cheminf:SIO_000300 "C9H8O4" .
       }
       LIMIT 1
-    explanation: "Use structured descriptor predicates or ChEBI classification IRIs for comprehensive compound queries. Pasting sampled compound IRIs only counts that exploratory sample."
+      # -> 1,231 compounds share molecular formula C9H8O4. Verified 2026-07-18.
+    explanation: "Use structured descriptor predicates for comprehensive counts, not sampled compound IRIs in VALUES. Two silent-0 traps fixed: CHEMINF_000140 is the CID string (not SMILES), and descriptor rdf:type/value live in the descriptor/compound graph — pin BOTH compound and descriptor/compound graphs."
 
   - title: "Bioassay Title Text Search When the Structured Compound-Target Path Exists"
     problem: >

--- a/togo_mcp/data/mie/pubmed.yaml
+++ b/togo_mcp/data/mie/pubmed.yaml
@@ -53,9 +53,9 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.2"
+    mie_version: "2.3"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Daily"
   license:
@@ -571,7 +571,7 @@ architectural_notes:
     - "CRITICAL: Pre-filter PubMed before any cross-database join to avoid timeout"
 
   data_integration:
-    - "MeSH vocabulary graph: http://id.nlm.nih.gov/mesh/2025"
+    - "MeSH vocabulary graph: http://id.nlm.nih.gov/mesh (UNVERSIONED — the year graphs like mesh/2025 share ZERO IRIs with PubMed's subject descriptors and resolve 0 rows; see critical_warnings)"
     - "NLM Journal catalog graph: http://rdfportal.org/dataset/nlm_catalog"
     - "Shared NCBI endpoint enables joins with: clinvar, pubtator, ncbigene, medgen"
     - "Article IRI matching (pubmed:PMID) enables direct PubMed ↔ PubTator joins"

--- a/togo_mcp/data/mie/pubmed.yaml
+++ b/togo_mcp/data/mie/pubmed.yaml
@@ -53,7 +53,7 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.3"
+    mie_version: "2.4"
     mie_created: "2026-04-29"
     mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
@@ -435,7 +435,7 @@ cross_database_queries:
       sparql: |
         PREFIX bibo: <http://purl.org/ontology/bibo/>
         PREFIX dct: <http://purl.org/dc/terms/>
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX fabio: <http://purl.org/spar/fabio/>
         PREFIX mesh: <http://id.nlm.nih.gov/mesh/>
         PREFIX oa: <http://www.w3.org/ns/oa#>
         PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -446,7 +446,9 @@ cross_database_queries:
           GRAPH <http://rdfportal.org/dataset/pubmed> {
             ?article bibo:pmid ?pmid ;
                      dct:title ?title ;
-                     rdfs:seeAlso mesh:D001943 .  # Breast Neoplasms
+                     fabio:hasSubjectTerm mesh:D001943 .  # Breast Neoplasms — the article->MeSH link is
+                                                          # fabio:hasSubjectTerm (or hasPrimarySubjectTerm),
+                                                          # NOT rdfs:seeAlso (which returns 0 rows).
           }
           GRAPH <http://rdfportal.org/dataset/pubtator_central> {
             ?ann dcterms:subject "Gene" ;

--- a/togo_mcp/data/mie/pubtator.yaml
+++ b/togo_mcp/data/mie/pubtator.yaml
@@ -56,9 +56,9 @@ schema_info:
   kw_search_tools:
     - sparql
   version:
-    mie_version: "2.7"
+    mie_version: "2.8"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Regularly updated"
   access:
@@ -708,6 +708,8 @@ anti_patterns:
       } LIMIT 5
     correct_sparql: |
       # Scope first (specific disease IRI), THEN filter — returns immediately.
+      # NB: D003920's per-article Disease annotation_count tops out at 3, so use >= 3 here
+      # (the valid threshold is IRI-specific — a >= 4 filter returns 0 rows for this IRI).
       PREFIX pubtator: <http://purl.jp/bio/10/pubtator-central/ontology#>
       PREFIX oa:       <http://www.w3.org/ns/oa#>
       PREFIX dcterms:  <http://purl.org/dc/terms/>
@@ -718,7 +720,7 @@ anti_patterns:
              oa:hasBody <http://identifiers.org/mesh/D003920> ;
              oa:hasTarget ?article ;
              pubtator:annotation_count ?count .
-        FILTER(?count >= 4)
+        FILTER(?count >= 3)
       } LIMIT 50
     explanation: "annotation_count filters must be applied AFTER scoping to a specific IRI (or an inner LIMIT). An unscoped range filter over 238M annotations times out rather than returning fast."
 

--- a/togo_mcp/data/mie/supercon.yaml
+++ b/togo_mcp/data/mie/supercon.yaml
@@ -46,9 +46,9 @@ schema_info:
        glycosmos ~150, togovar), holds multiple graphs. Verified 2026-07-17."
   kw_search_tools: []
   version:
-    mie_version: "4.2"
+    mie_version: "4.3"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "NIMS SuperCon RDF 2026 snapshot (archival; last substantive entries 2019-2020)"
     update_frequency: "Effectively frozen: 4 papers added 2021, 2 in 2022, 1 in 2023"
   license:
@@ -727,18 +727,27 @@ anti_patterns:
       SELECT (COUNT(?sample) AS ?count) WHERE { }
       LIMIT 1
     correct_sparql: |
-      # CORRECT: use the typed predicate (structure type) discovered during exploration
-      PREFIX Schema: <http://purl.org/supercon/schema#>
+      # CORRECT: use the real namespace/class + the typed Tc property-node scaffold.
+      # The earlier form used a fictitious PREFIX Schema: <http://purl.org/supercon/schema#> and
+      # a non-existent class Schema:Sample -> 0 rows. Real base is dice.nims.go.jp; the sample
+      # class is Schema:OxideAndMetallic; and the Tc datum's IAO_0000221 must point at an
+      # INSTANCE property node (a Schema:tc) reached from the sample via sio:SIO_000008.
+      PREFIX sio:    <http://semanticscience.org/resource/>
+      PREFIX Schema: <http://dice.nims.go.jp/ontology/SuperCon-ont/Schema#>
+      PREFIX obo:    <http://purl.obolibrary.org/obo/>
       SELECT (COUNT(DISTINCT ?sample) AS ?count)
       FROM <http://rdfportal.org/dataset/supercon>
       WHERE {
-        ?sample a Schema:Sample .
-        ?meas obo:OBI_0000299 ?tcDatum .
-        ?tcDatum obo:IAO_0000221 Schema:tc ; sio:SIO_000300 ?tc .
-        FILTER(?tc > 77)
+        ?sample a Schema:OxideAndMetallic ;
+                sio:SIO_000008 ?tcProp .
+        ?tcProp a Schema:tc .
+        ?tcDatum obo:IAO_0000221 ?tcProp ;
+                 sio:SIO_000300 ?tcVal .
+        FILTER(?tcVal > 77)
       }
       LIMIT 1
-    explanation: "Use structured predicates (property type, unit filter) discovered during exploration for comprehensive queries. Pasting sampled sample IRIs from a top-N result only counts those N samples."
+      # -> 4,707 samples with Tc > 77 K. Verified 2026-07-18.
+    explanation: "Use structured predicates for comprehensive counts, not sampled sample IRIs. The real Schema namespace is http://dice.nims.go.jp/ontology/SuperCon-ont/Schema# and the sample class is Schema:OxideAndMetallic; a Tc value is reached sample -> sio:SIO_000008 -> (a Schema:tc) property node <- obo:IAO_0000221 datum -> sio:SIO_000300 value."
 
   - title: Mixing lattice parameter units without inspection
     problem: |

--- a/togo_mcp/data/mie/taxonomy.yaml
+++ b/togo_mcp/data/mie/taxonomy.yaml
@@ -50,9 +50,9 @@ schema_info:
   kw_search_tools:
     - ncbi_esearch
   version:
-    mie_version: "2.2"
+    mie_version: "2.3"
     mie_created: "2025-04-22"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Monthly"
   license:
@@ -84,7 +84,9 @@ critical_warnings: |
     legacy-vintage data wearing a rank the authoritative graph deliberately does not use. A query
     that "works" here is reading the wrong graph. To select domain-level nodes in the authoritative
     graph use BIND or FILTER(STR(?rank) = "http://ddbj.nig.ac.jp/ontologies/taxonomy/"); "cellular
-    organisms" (taxon:131567) carries the same bare namespace rank IRI.
+    organisms" (taxon:131567) carries the same bare namespace rank IRI, so EXCLUDE it with
+    FILTER(?taxon != <http://identifiers.org/taxonomy/131567>) to get only the biological top-level
+    clades (the 3 cellular domains + Viruses + ~10 viral realms = ~14). This rank is NOT domain-only.
   - PERFORMANCE: With 2.7M+ taxa, all exploratory queries MUST have a LIMIT
     clause. Unbounded rdfs:subClassOf* traversal without a specific starting
     taxon IRI will time out. Always start transitive lineage queries from a
@@ -597,13 +599,17 @@ anti_patterns:
         ?taxon a tax:Taxon ; tax:rank tax:Superkingdom ; rdfs:label ?label .
       }
     correct_sparql: |
-      # Correct: filter by bare namespace IRI for domain-level taxa
-      SELECT ?taxon ?label WHERE {
+      # Correct: (1) PIN the authoritative graph, (2) filter by the bare-namespace rank IRI,
+      # (3) EXCLUDE the cellular-organisms root (131567), which shares that same rank IRI.
+      SELECT ?taxon ?label
+      FROM <http://rdfportal.org/ontology/taxonomy>
+      WHERE {
         ?taxon a tax:Taxon ;
                tax:rank <http://ddbj.nig.ac.jp/ontologies/taxonomy/> ;
                rdfs:label ?label .
-      } LIMIT 10
-    explanation: "Eukaryota (taxon:2759), Bacteria (taxon:2), and Archaea (taxon:2157) use the bare namespace IRI as rank. This is documented in critical_warnings."
+        FILTER(?taxon != <http://identifiers.org/taxonomy/131567>)
+      } LIMIT 20
+    explanation: "The bare-namespace rank IRI <http://ddbj.nig.ac.jp/ontologies/taxonomy/> is NOT domain-only — it marks the ~15 highest-level clades NCBI leaves without a formal rank: the three cellular domains (Bacteria taxon:2, Archaea taxon:2157, Eukaryota taxon:2759), the acellular root Viruses (taxon:10239) and ~10 viral realms (Riboviria, Duplodnaviria, …), plus the cellular-organisms root (taxon:131567), which is excluded here. Two mandatory scopings: (a) PIN <http://rdfportal.org/ontology/taxonomy> — unpinned, the legacy microbedbjp graph applies this rank IRI to other taxa (e.g. botanical sections) and duplicates every row; (b) exclude 131567. Verified 2026-07-18: as written returns 14 clade rows; unpinned returns duplicated botanical sections."
 
   - title: "Unbounded Transitive Lineage Queries"
     problem: "Using rdfs:subClassOf* without a specific starting IRI causes timeout on 2.7M+ records."

--- a/togo_mcp/data/mie/uniprot.yaml
+++ b/togo_mcp/data/mie/uniprot.yaml
@@ -63,9 +63,9 @@ schema_info:
   kw_search_tools:
     - search_uniprot_entity
   version:
-    mie_version: "2.4"
+    mie_version: "2.5"
     mie_created: "2026-04-29"
-    mie_updated: "2026-07-17"
+    mie_updated: "2026-07-18"
     data_version: "RDF Portal snapshot — verified 2026-07-17"
     update_frequency: "Monthly"
   access:
@@ -97,6 +97,13 @@ critical_warnings: |
         589,059.
     FROM <http://sparql.uniprot.org/uniprot> does NOT "silently drop" data: it drops DELETIONS, which
     is normally what you want. Nothing signals the inflation — it is worse than an empty result.
+    NOT JUST COUNTS — A ROW-RETURNING SELECT DOUBLES TOO: the OMA re-typing (1) asserts the SAME
+    IRI in a second graph, so `SELECT ?protein WHERE { ?protein a up:Protein ; up:reviewed 1 ; ... }`
+    over the union returns each protein TWICE (once per graph). COUNT(DISTINCT) does not apply to a
+    row query — the fix is SELECT DISTINCT or, better, pin FROM <http://sparql.uniprot.org/uniprot>
+    (the pin also drops the obsolete duplicates in one move). Verified 2026-07-18: an unpinned
+    `SELECT ?protein` for reviewed human proteins under a keyword returned 278/8/62 rows where the
+    true distinct counts are 141/4/31 — exactly 2x on the proteins that have an OMA re-typing.
   - SIB UNION TAXON-METADATA MULTIPLICATION (silent ROW inflation on the everyday protein->organism
     join): the co-hosted OMA and Bgee graphs RE-DECLARE the SAME taxon nodes
     (http://purl.uniprot.org/taxonomy/NNNN) with their own copies of UniProt's taxon predicates. Over

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -68,7 +68,12 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
 249) that passed every check for months.
 
 1. **Pin every pattern.** `FROM <g>` or `GRAPH <g> { ... }`. Partial pinning still
-   leaks — the unpinned patterns read the union.
+   leaks — the unpinned patterns read the union. **"Your database" may be *several*
+   graphs** (the MIE `graphs:` list), not one — list them all as repeated `FROM`
+   clauses. UniProt is two: protein triples live in `.../uniprot`, but a taxon's
+   `scientificName`/`rank` live in `.../taxonomy`, so a single-graph pin returns
+   **empty** for a taxon-name leg (silent). Pin the *set* your DB owns — that also
+   excludes the co-tenants (OMA, Bgee) without a `GRAPH{}` block per pattern.
 2. **`SELECT DISTINCT` is NOT the fix.** It can absorb inflation and hand you the right
    number for the wrong reason, then break when the multiplicity changes.
 3. **Check a predicate is native:** bind the subject and run

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -70,9 +70,10 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
 1. **Pin every pattern.** `FROM <g>` or `GRAPH <g> { ... }`. Partial pinning still
    leaks — the unpinned patterns read the union. **"Your database" may be *several*
    graphs** (the MIE `graphs:` list), not one — list them all as repeated `FROM`
-   clauses. UniProt is two: protein triples live in `.../uniprot`, but a taxon's
-   `scientificName`/`rank` live in `.../taxonomy`, so a single-graph pin returns
-   **empty** for a taxon-name leg (silent). Pin the *set* your DB owns — that also
+   clauses. UniProt owns **~16 graphs**: protein triples live in `.../uniprot`, but a
+   taxon's `scientificName`/`rank` live in `.../taxonomy` (and GO defs in `.../go`,
+   diseases in `.../diseases`, …), so pinning only `.../uniprot` returns **empty** for
+   a taxon-name leg (silent). Pin the *set* your DB owns — that also
    excludes the co-tenants (OMA, Bgee) without a `GRAPH{}` block per pattern.
 2. **`SELECT DISTINCT` is NOT the fix.** It can absorb inflation and hand you the right
    number for the wrong reason, then break when the multiplicity changes.

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Follow-up to the 1.7.0 co-tenancy sweep. 1.7.0 verified `co_hosted_graphs` and `critical_warnings` but not the example queries agents copy; this release audits all 36 MIEs (via the new `check_mie_examples.py`) and fixes the templates that silently returned 0 rows or contradicted their own file. **No tool-surface change** — patch; the served MIE/usage-guide content is corrected.

## Fixed
- **11 broken example queries across 10 MIEs**, each verified live (oma, supercon, ddbj, pubchem, pubtator, jpostdb, bacdive, taxonomy, nando, pubmed).
- **Secondary-section doc drift in 6 MIEs** (chebi dead join, pubmed `mesh/2025` pointer, chembl 34/36, glycosmos/go graph counts, mediadive schema-prefix warning).
- **amrportal** two-stage example split into two runnable examples; **uniprot** OMA warning extended to row-returning SELECTs.
- **Benchmark**: 12 questions graph-pinned against co-tenant inflation (no recorded answer changed).

## Added
- `scripts/check_mie_examples.py` — runs every MIE example live, gates on zero-row/error; wired into mie-generator Phase 5b.
- `benchmark/scripts/check_answer_drift.py` — re-runs stored benchmark queries vs recorded counts.
- Usage guide: pin the graph *set* a DB owns (UniProt is ~16 graphs).

Full detail in [CHANGELOG.md](CHANGELOG.md). Acceptance: `check_mie_examples.py` full-set run = 432 ok, 0 zero-row, 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)