### PR TITLE
findings: correct four figures that don't reconcile with the raw results

### DIFF
--- a/benchmark/ablation/FINDINGS.md
+++ b/benchmark/ablation/FINDINGS.md
@@ -258,8 +258,14 @@ corpus — so the agent keeps every other tool (run_sparql, NCBI, PubChem, searc
 loses only the MIE. Run as a first-class `run_ablation.py` condition
 (`--conditions no_mie --base-config benchmark/scripts/config_no_mie.yaml`; a guard
 refuses a base config that still allows get_MIE_file) on the local server, so it pairs
-against the group sweep's baseline. Validity: **0** get_MIE_file executions server-side
-(13 attempts, all blocked — the model still reflexively reaches for it ~7% of questions).
+against the group sweep's baseline. Validity: **0** get_MIE_file executions server-side —
+the block is client-side (`disallowed_tools`), so attempts never reach the server and
+`no_mie-server.log` correctly contains no `get_MIE_file` at all. The attempt rate comes from
+`tools_used` in `no_mie-answers-v{1,2,3}.csv`: **16 attempts across 13 of the 120 cells
+(10.8%), touching 10 of the 40 questions (25%)** — the model still reflexively reaches for it.
+*(Corrected 2026-07-26: this line previously read "13 attempts … ~7% of questions". 13 is the
+count of **cells** that attempted at least once, not of attempts, and 13/120 is 10.8%, not 7%.
+Recomputed directly from the answer CSVs; no downstream number depends on it.)*
 
 **Result: significant.** baseline − no_mie on the judge score:
 

--- a/benchmark/redesign/README.md
+++ b/benchmark/redesign/README.md
@@ -8,10 +8,11 @@ the argument and `togo_mcp/data/docs/MIE_v3_spec.md` is the contract.*
 
 ## Why
 
-The 2026-07 MIE ablation sweeps established that the current v2.3 format carries heavy,
-*orthogonal* redundancy — the same predicate-level fact restated up to three ways (ShEx
-shape in `shape_expressions`, sample triple in `sample_rdf_entries`, worked query in
-`sparql_query_examples`; the `cross_references` list is a loose fourth for xref predicates).
+The 2026-07 MIE ablation sweeps established that the current v2.3 format documents the same
+fact up to three times over, each time in a different **form** — a predicate stated as a
+declarative constraint (ShEx shape in `shape_expressions`), shown as a concrete instance
+(sample triple in `sample_rdf_entries`), and used as an executable step (worked query in
+`sparql_query_examples`); the `cross_references` list is a loose fourth for xref predicates.
 `schema_info` is *not* a restatement — it's the metadata header, kept in v3 as `discovery`
 + `header`. The ablation findings:
 

--- a/benchmark/redesign/release/FINDINGS.md
+++ b/benchmark/redesign/release/FINDINGS.md
@@ -134,8 +134,13 @@ q033), not a corpus defect. No regression signature on clean cells.
   +0.350. **95% CI [−0.14, +0.82] — crosses 0**, so this is genuine *equivalence* (delta indistinguishable
   from zero), NOT a proven improvement. The mild positive tilt should not be over-claimed. Key point: the
   CI lower bound (−0.14) sits well inside the −0.5 non-regression margin ⇒ v3 demonstrably does not regress.
-- Both PASS the "flat within ±0.5" bar; n=100 will tighten the interval.
-- **Refusal contamination is corpus-wide** (balanced across arms): fully-refused questions so far =
+- Both PASS the **−0.5 non-regression** bar; n=100 will tighten the interval. (Stated once, since
+  the wording drifts elsewhere in this file: the operative test is one-sided — the CI **lower**
+  bound must sit inside −0.5. It is not a two-sided ±0.5 equivalence test; the final n=100 upper
+  bound is +0.68, so a TOST against ±0.5 would *not* pass. Every verdict here tests the lower
+  bound only, which is the correct test for a compression change that must not regress.)
+- **Refusal contamination is corpus-wide** (looked balanced across arms at this point; the final
+  n=100 count is 21 v2 vs 17 v3 — see the corrected data-quality caveat): fully-refused questions so far =
   q032, q034, q044, q071. NB **q071's canary "bad question" (identical 420-char answers) was the
   refusal message** — not a real v3/v2 difference. These are excluded from the clean verdict; effective
   n is reduced but the equivalence conclusion is unchanged.
@@ -201,7 +206,10 @@ couple pts on one run — noise).
    - Stable across the whole ladder: 50 +0.34 → 75 +0.29 → 85 +0.30 → **100 +0.29**; CI monotonically
      tightening [−0.14,+0.82] → [−0.09,+0.68].
 
-2. **Factoid correctness — UP (the aggregation-recipe claim, confirmed).** By question type (clean judge score):
+2. **Factoid judge score — UP (the aggregation-recipe claim, confirmed).** Note the metric: this
+   criterion is scored on the **judge score by question type**, not on the binary `grade_exact`
+   correctness grader (which is a separate, less powerful axis — see the ablation FINDINGS).
+   By question type (clean judge score):
    - **factoid Δ +1.01** (v3 17.18 vs v2 16.18) — the biggest gain, exactly the query-construction/aggregation
      questions the v3 format targets with executable worked examples.
    - yes_no +0.54, list +0.18, choice +0.16 — all positive. summary **−0.42** (the only soft type;
@@ -219,25 +227,44 @@ couple pts on one run — noise).
 - q055 (OMA deep-rooting): both arms misroot at Eukaryota vs LUCA; v3 more consistently.
 
 ## Data-quality caveat (does not change the verdict)
-Spurious AUP content-policy refusals contaminated ~5% of cells (balanced across arms once aggregated).
-4 questions fully unmeasurable (both arms refused): q032, q034, q044, q071. All excluded from the clean
-verdict; the equivalence conclusion holds on the 96 measurable questions.
+Spurious AUP content-policy refusals contaminated **6.3% of cells** — v2 21/300 (7.0%), v3 17/300
+(5.7%), so mildly v2-heavy rather than exactly balanced, in the direction that *understates* v3.
+13 questions were touched by at least one refusal; per-question counts (v2/v3 of 3 runs each):
+q034 3/3, q044 3/3, q071 2/3, q032 3/2, q033 1/2, q050 2/1, q008 2/0, q018 2/0, q057 1/1,
+q015 1/0, q059 1/0, q028 0/1, q079 0/1.
+
+4 questions are unmeasurable and excluded from the clean verdict: **q034 and q044** were refused
+on all 3 runs in *both* arms; **q032** (v2 3/3) and **q071** (v3 3/3) were fully refused in one
+arm, which leaves the pair with no comparable cell. The equivalence conclusion holds on the 96
+measurable questions.
+
+*(Corrected 2026-07-26: this previously read "~5% of cells (balanced across arms once aggregated).
+4 questions fully unmeasurable (both arms refused)". The rate is 6.3% not ~5%, the split is
+21-vs-17 not balanced, and only 2 of the 4 dropped questions were refused by both arms on every
+replicate. Recounted directly from the per-batch answer CSVs. No verdict changes: the imbalance
+runs against v3, and all four questions were excluded either way.)*
 
 ## CALL: GO for step 6 (release).
-Equivalence proven (judge score flat within −0.5, tilting mildly positive), factoid correctness UP, bytes
+Equivalence proven (judge score non-regressing against −0.5, tilting mildly positive), factoid judge score UP, bytes
 DOWN 29–65%. The redesign delivers the deterministic token win at no measured quality cost — and a real
 gain on factoid/aggregation questions. Proceed to the MAJOR release: flip the served corpus to v3, ship
 the build-time Usage-Guide catalog generator FIRST, then retire the discovery trio (find_databases/
 list_databases/list_categories) + rewrite the workflow prompt.
 
-## Measured runtime cost/time @ n=100 (clean cells: v2=279 / v3=282)
+## Measured runtime cost/time @ n=100 (clean cells: v2=279 / v3=282, of **300** each)
+
+Denominator note (verified 2026-07-26 by re-counting `results_rel_{canary,batch1..5}/*-answers-v*.csv`):
+300 = 100 questions × 3 replicates, i.e. *all* cells, not the 96-usable subset. The drops are
+**v2: 21 refusals + 0 invalid** and **v3: 17 refusals + 1 invalid** (the q061 r1 timeout) — which
+reconciles exactly with 279 and 282. Note this makes the refusal rate **7.0% (v2) / 5.7% (v3),
+6.3% combined** — see the corrected caveat below.
 
 The deterministic win, MEASURED at runtime (not just file bytes). Per question, v3 vs v2:
 
 | metric (per Q) | v2 | v3 | Δ | % |
 |---|---|---|---|---|
 | total input tokens | 73,059 | 61,790 | −11,269 | **−15.4%** |
-|  · cache-read | 71,394 | 59,255 | −12,138 | −17.0% |
+|  · cache-read | 71,394 | 59,255 | −12,139 | −17.0% |
 |  · cache-creation | 1,658 | 2,527 | +869 | +52.4% |
 | output tokens | 656 | 686 | +30 | +4.6% |
 | cost $/Q | 0.52 | 0.44 | −0.08 | **−14.8%** |

--- a/togo_mcp/data/docs/MIE_v3_spec.md
+++ b/togo_mcp/data/docs/MIE_v3_spec.md
@@ -16,10 +16,12 @@ queries it can reuse. v3 is organized by **agent need × recoverability** with t
 **verified, executable worked example as the atomic unit**.
 
 ### 1.2 Why v3 (evidence)
-The 2026-07 ablations found the v2.3 layout carries heavy *orthogonal* redundancy — the
-same predicate-level fact restated up to three ways (ShEx shape in `shape_expressions`,
-sample triple in `sample_rdf_entries`, worked query in `sparql_query_examples`; the
-`cross_references` list adds a loose fourth for xref predicates). (`schema_info` is *not*
+The 2026-07 ablations found the v2.3 layout documents the same fact up to three times over,
+each time in a different **form**: a predicate stated as a declarative constraint (ShEx shape
+in `shape_expressions`), shown as a concrete instance (sample triple in `sample_rdf_entries`),
+and used as an executable step (worked query in `sparql_query_examples`) — with the
+`cross_references` list a loose fourth restatement for xref predicates. Three modes of
+expression, one underlying fact, three separate sections. (`schema_info` is *not*
 one of these — it is the metadata header, and survives into v3 as `discovery` + `header`.)
 Leave-one-in confirmed the value concentrates in the query-construction content: the
 `query` group alone recovers **99%** of the whole-MIE benefit. v3 collapses the


### PR DESCRIPTION
Audited while cross-checking the [mie-redesign manuscript](https://github.com/arkinjo/mie-redesign/pull/3) against these records — the paper's Availability section points readers here as the source of every number it reports, so the two need to agree.

Each correction was **recomputed from the result CSVs** rather than re-derived from the prose, and each is annotated inline with what the text previously said. **No verdict or headline effect changes.**

## `benchmark/ablation/FINDINGS.md`

The `no_mie` validity line — "13 attempts, all blocked — the model still reflexively reaches for it ~7% of questions" — was wrong twice over. Recounted from `tools_used` in `no_mie-answers-v{1,2,3}.csv`:

- **16 attempts across 13 of the 120 cells (10.8%), touching 10 of the 40 questions (25%).**
- 13 was the count of *cells* that attempted at least once, not of attempts; and 13/120 is 10.8%, not 7%.

Also documented why `no_mie-server.log` contains no `get_MIE_file` at all: the block is client-side (`disallowed_tools`), so attempts never reach the server. That absence is expected, not a validity problem — worth recording so the next reader doesn't misread it as one.

## `benchmark/redesign/release/FINDINGS.md`

**Refusal contamination.** Was "~5% of cells (balanced across arms once aggregated)". Recounted from the per-batch answer CSVs: **6.3% overall — v2 21/300 (7.0%) vs v3 17/300 (5.7%)**. Mildly v2-heavy rather than balanced, in the direction that *understates* v3. Per-question counts now listed.

**Unmeasurable questions.** "4 questions fully unmeasurable (both arms refused)" held for only two: q034 and q044 were refused 3/3 in both arms. q032 (v2 3/3) and q071 (v3 3/3) were fully refused in *one* arm, which still leaves the pair with no comparable cell. All four remain excluded either way.

**Runtime-cost denominator.** Was unstated and reads as ambiguous. Clean cells are 279/282 **of 300 per arm** (all cells), not of the 96-usable subset — reconciles exactly with 21 refusals + 0 invalid (v2) and 17 + 1 (v3, the q061 timeout).

**The equivalence bar.** Written as "flat within ±0.5" in one place and as a -0.5 non-regression margin everywhere else. The operative test is one-sided: the n=100 CI upper bound is +0.68, so a TOST against ±0.5 would **not** pass. Now stated explicitly once, with the reasoning.

**Criterion 2** relabelled "factoid judge score" — it is scored on the judge score by question type, not on the binary `grade_exact` axis, which is a separate and less powerful measure.

**Arithmetic:** cache-read delta -12,138 → -12,139.

## Note

This PR also carries one pre-existing commit on `dev` (f1093da, "docs(mie-v3): sharpen the 'why v3' redundancy rationale") that was already merged-pending before this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)