### PR TITLE
intro: add Site Policy link to the footer

### DIFF
--- a/togo_mcp/data/docs/make_intro.md
+++ b/togo_mcp/data/docs/make_intro.md
@@ -109,6 +109,14 @@ The footer should include the following
     </div>
 ```
 - Also add the link to each item.
+- Below the organisation block, include a row of footer links (`.footer-links`):
+  * [DBCLS Home](https://dbcls.rois.ac.jp/en/)
+  * [TogoMCP Home](https://togomcp.rdfportal.org/)
+  * [RDF Portal](https://rdfportal.org)
+  * [TogoID](https://togoid.dbcls.jp)
+  * [GitHub](https://github.com/dbcls/togomcp)
+  * [Contact](https://dbcls.rois.ac.jp/contact-en.html)
+  * [Site Policy](https://bsi.nig.ac.jp/policy)
 - Make sure all the links are alive and correct.
 
 **IMPORTANT!**

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -1365,6 +1365,7 @@
     <a href="https://togoid.dbcls.jp" target="_blank" rel="noopener">TogoID</a>
     <a href="https://github.com/dbcls/togomcp" target="_blank" rel="noopener">GitHub</a>
     <a href="https://dbcls.rois.ac.jp/contact-en.html" target="_blank" rel="noopener">Contact</a>
+    <a href="https://bsi.nig.ac.jp/policy" target="_blank" rel="noopener">Site Policy</a>
   </div>
   <div class="footer-copy">
     &copy; Database Center for Life Science (DBCLS), Research Organization of Information and Systems (ROIS)


### PR DESCRIPTION
Adds a **Site Policy** link (`https://bsi.nig.ac.jp/policy`) to the footer of the public landing page (`togomcp-intro.html`), next to Contact.

- The BSI/NIG policy explicitly covers APIs, MCP servers, and AI-Agent access, so it's the relevant site policy for this page.
- Placed in the footer links row (governance/legal link — not the content nav). URL verified live.
- Recorded the footer-links row (incl. Site Policy) in `make_intro.md` so a future regeneration keeps it.

Docs-only — no version bump, not a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)