### PR TITLE
Release 2.0.2 — 2.0.1's proxy fix was inert in production (rootless podman, not Docker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,17 +24,22 @@ TZ=Asia/Tokyo
 # TOGOMCP_ALLOWED_HOSTS_TEST=vs94,vs94:8001
 
 # Optional: which peer addresses may set X-Forwarded-Proto / X-Forwarded-For
-# (comma-separated; accepts addresses and CIDR). uvicorn trusts only 127.0.0.1
-# by default, but the container is published as a host port so the reverse proxy
-# arrives via the Docker bridge gateway — without this, X-Forwarded-Proto is
-# discarded and the app emits http:// redirects behind https://.
-# The default (127.0.0.1,::1,172.16.0.0/12) covers loopback + the standard Docker
-# bridge range; set these ONLY if the proxy is on a different subnet (e.g. Docker
-# configured onto 10.0.0.0/8, or a proxy on another host). Avoid "*": the peer
-# address is recorded in the tool-call log, so trusting every source would let
-# anyone reaching port 8000 directly forge the IP that gets logged.
-# TOGOMCP_FORWARDED_ALLOW_IPS=10.0.0.0/8
-# TOGOMCP_FORWARDED_ALLOW_IPS_TEST=10.0.0.0/8
+# (comma-separated; accepts addresses and CIDR). uvicorn trusts only 127.0.0.1 by
+# default, but the container is published as a host port so the reverse proxy never
+# arrives as loopback — without this, X-Forwarded-Proto is discarded and the app
+# emits http:// redirects behind https://. The failure is SILENT: the header is
+# dropped, not rejected.
+# The default covers every runtime we deploy on — 127.0.0.1,::1 plus 10.0.2.0/24
+# (rootless podman + slirp4netns, the vs94 production path), 10.88.0.0/16 (rootful
+# podman) and 172.16.0.0/12 (docker/compose) — so you should not normally need to
+# set this. Set it only for a proxy on some other subnet.
+# NOTE on "*": on the rootless-slirp4netns path the rootlesskit port handler SNATs
+# every client to 10.0.2.100, so the peer recorded in the tool-call log is already
+# constant and a tight list buys nothing there; the real protection is that only the
+# proxy can reach the published port. It still matters on rootful/compose, where the
+# peer is the true client — so keep the default unless you have a reason.
+# TOGOMCP_FORWARDED_ALLOW_IPS=192.168.10.0/24
+# TOGOMCP_FORWARDED_ALLOW_IPS_TEST=192.168.10.0/24
 
 # Optional: enable tool-call logging (JSONL, one record per MCP tool call).
 # Unset/empty = disabled (default). The compose.yaml bind-mounts ./logs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 _Nothing yet._
 
+## [2.0.2] - 2026-07-29
+
+### Fixed
+
+- **The 2.0.1 proxy fix did not work in production — two reasons, both mine.** It shipped, deployed,
+  and the `https://` → `http://` redirect downgrade persisted unchanged.
+  1. **Wrong address range.** `forwarded_allow_ips` defaulted to `172.16.0.0/12`, derived from
+     `compose.yaml`. But Compose is not the production path — `scripts/deploy.sh` is, and it runs
+     **rootless podman with slirp4netns** on vs94, where the rootlesskit port handler SNATs every
+     inbound connection to the container's own slirp address `10.0.2.100`. Not in the list, so
+     uvicorn kept discarding `X-Forwarded-Proto`. The default now covers all three runtimes we
+     deploy on: `10.0.2.0/24` (rootless podman), `10.88.0.0/16` (rootful podman), `172.16.0.0/12`
+     (docker/compose).
+  2. **The documented override could not reach the container.** `deploy.sh` forwards a fixed list of
+     env vars and `TOGOMCP_FORWARDED_ALLOW_IPS` was not in it, so setting it in `.env` did nothing.
+     Now forwarded, per-service, like every other knob.
+  Both failures were silent — an untrusted `X-Forwarded-*` header is dropped, not rejected — and both
+  came from treating `compose.yaml` as the deployment. Regression tests now assert the default trusts
+  a slirp4netns peer and that `deploy.sh` forwards the override.
+- **Corrected the rationale for not using `*`.** 2.0.1 argued a tight list protects the hashed peer
+  IP in the tool-call log from forgery. On the rootless-slirp4netns path that field is *already*
+  constant — every client arrives as `10.0.2.100` — so the tight list buys nothing there and the real
+  protection is that only the proxy can reach the published port. The argument still holds on the
+  rootful/compose paths, where the peer is the true client.
+
 ## [2.0.1] - 2026-07-29
 
 <!-- whatsnew: 2026-07 | Published in <em>Database</em> — <a href="https://doi.org/10.1093/database/baag042" target="_blank" rel="noopener">2026:baag042</a>. -->
@@ -527,7 +552,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/dbcls/togomcp/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/dbcls/togomcp/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/dbcls/togomcp/compare/v1.7.1...v2.0.0
 [1.7.1]: https://github.com/dbcls/togomcp/compare/v1.7.0...v1.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.0.1"
+version = "2.0.2"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,7 +46,8 @@ PROD_CONFIRM_PHRASE="togomcp.rdfportal.org"
 
 # Vars forwarded to each container. Per-service vars take their _TEST variant on
 # the test container (mirrors compose.yaml); shared vars are identical for both.
-TOGOMCP_PERSERVICE_VARS=(TOGOMCP_ALLOWED_HOSTS TOGOMCP_QUERY_LOG TOGOMCP_LOG_QUERY_TEXT \
+TOGOMCP_PERSERVICE_VARS=(TOGOMCP_ALLOWED_HOSTS TOGOMCP_FORWARDED_ALLOW_IPS \
+                         TOGOMCP_QUERY_LOG TOGOMCP_LOG_QUERY_TEXT \
                          TOGOMCP_STATS_USER TOGOMCP_STATS_PASSWORD TOGOMCP_LOG_HASH_SALT)
 TOGOMCP_SHARED_VARS=(NCBI_API_KEY)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -490,15 +490,41 @@ class TestForwardedAllowIps:
 
         return ip in _TrustedHosts(spec)
 
-    def test_default_trusts_docker_bridge_and_loopback(self, monkeypatch) -> None:
+    def test_default_trusts_every_container_runtime_we_deploy_on(self, monkeypatch) -> None:
+        """The peer address depends on the runtime, and getting it wrong fails
+        SILENTLY (the header is dropped, not rejected). 2.0.1 shipped with only the
+        Docker range and did nothing in production, which is rootless podman +
+        slirp4netns: the rootlesskit port handler SNATs every inbound connection to
+        the container's own slirp address, 10.0.2.100."""
         from togo_mcp.main import _forwarded_allow_ips
 
         monkeypatch.delenv("TOGOMCP_FORWARDED_ALLOW_IPS", raising=False)
         spec = _forwarded_allow_ips()
-        # Docker allocates compose networks across 172.16.0.0/12, so the gateway
-        # address is not predictable — the whole range has to be covered.
-        for ip in ("172.17.0.1", "172.18.0.1", "172.31.255.254", "127.0.0.1", "::1"):
-            assert self._trusts(spec, ip), f"{ip} must be trusted by default"
+        cases = [
+            ("10.0.2.100", "rootless podman + slirp4netns — the production path"),
+            ("10.88.0.1", "rootful podman default bridge"),
+            ("172.17.0.1", "docker default bridge"),
+            ("172.18.0.1", "docker compose project network"),
+            ("172.31.255.254", "top of the docker bridge range"),
+            ("127.0.0.1", "loopback"),
+            ("::1", "loopback v6"),
+        ]
+        for ip, why in cases:
+            assert self._trusts(spec, ip), f"{ip} must be trusted by default ({why})"
+
+    def test_deploy_script_forwards_the_override(self) -> None:
+        """compose.yaml is NOT the production deploy path — scripts/deploy.sh is, and
+        it forwards a FIXED list of env vars. 2.0.1 documented the override in
+        .env.example while deploy.sh silently dropped it, so it was inert in prod."""
+        from pathlib import Path
+
+        deploy = Path(__file__).resolve().parents[1] / "scripts" / "deploy.sh"
+        body = deploy.read_text(encoding="utf-8")
+        block = body.split("TOGOMCP_PERSERVICE_VARS=(", 1)[1].split(")", 1)[0]
+        assert "TOGOMCP_FORWARDED_ALLOW_IPS" in block, (
+            "deploy.sh must forward TOGOMCP_FORWARDED_ALLOW_IPS or the documented "
+            "override cannot reach the container"
+        )
 
     def test_default_does_not_trust_the_public_internet(self, monkeypatch) -> None:
         """Not '*': server.py records the peer address in the tool-call log, so a

--- a/togo_mcp/main.py
+++ b/togo_mcp/main.py
@@ -21,18 +21,26 @@ def _allowed_hosts() -> list[str]:
 
 # Which peer addresses may set X-Forwarded-Proto/-For. uvicorn parses those headers
 # by default but trusts only 127.0.0.1 unless told otherwise, and the container is
-# published as a host port, so the proxy arrives via the Docker bridge gateway
-# (172.16.0.0/12) — never loopback. Left at the default, uvicorn discards
-# X-Forwarded-Proto, sees scheme=http, and emits absolute redirects that downgrade
-# https:// to http:// (e.g. the /mcp/ -> /mcp trailing-slash 307).
+# published as a host port, so the proxy NEVER arrives as loopback. Left at the
+# default, uvicorn discards X-Forwarded-Proto, sees scheme=http, and emits absolute
+# redirects that downgrade https:// to http:// (the /mcp/ -> /mcp 307).
 #
-# Deliberately NOT "*": server.py logs the peer address (hashed via _hash_ip), so
-# trusting X-Forwarded-For from anywhere would let anyone able to reach port 8000
-# directly forge the IP we record. Keep this to the networks the proxy actually
-# arrives from. Override via TOGOMCP_FORWARDED_ALLOW_IPS (comma-separated; accepts
-# addresses and CIDR) if the proxy sits on a different subnet — e.g. Docker
-# configured onto 10.0.0.0/8, or a proxy on another host in the LAN.
-_DEFAULT_FORWARDED_ALLOW_IPS = "127.0.0.1,::1,172.16.0.0/12"
+# The address depends on the container runtime, which is why this list is wide:
+#   10.0.2.0/24    rootless podman + slirp4netns (the production path on vs94:
+#                  `deploy.sh` -> rootless `podman run -p`). The rootlesskit port
+#                  handler SNATs every inbound connection to the container's own
+#                  slirp address, 10.0.2.100.
+#   10.88.0.0/16   rootful podman default bridge.
+#   172.16.0.0/12  Docker/Compose bridge range (compose.yaml).
+# Getting this wrong is silent: the header is dropped, not rejected.
+#
+# NOTE on why this is not just "*": server.py records the peer address (hashed) in
+# the tool-call log. On the rootless-slirp4netns path that field is ALREADY constant
+# — every client arrives as 10.0.2.100 — so there the tight list buys nothing over
+# "*", and the real protection is that only the proxy can reach the published port.
+# It still matters on the rootful/Compose paths, where the peer is the true client.
+# Override via TOGOMCP_FORWARDED_ALLOW_IPS (comma-separated; addresses and CIDR).
+_DEFAULT_FORWARDED_ALLOW_IPS = "127.0.0.1,::1,10.0.2.0/24,10.88.0.0/16,172.16.0.0/12"
 
 def _forwarded_allow_ips() -> str:
     return os.environ.get("TOGOMCP_FORWARDED_ALLOW_IPS", "").strip() or _DEFAULT_FORWARDED_ALLOW_IPS

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
**Release 2.0.2** — PATCH. Fixes a fix: 2.0.1's proxy change shipped, deployed, and did nothing.

## What happened

2.0.1 went out and both vhosts confirmed `serverInfo.version: 2.0.1`. The symptom it targeted was unchanged:

```
POST https://togomcp.rdfportal.org/mcp/
-> 307  location: http://togomcp.rdfportal.org/mcp
```

Two defects, both from treating `compose.yaml` as the deployment when `scripts/deploy.sh` is.

**1. Wrong address range.** `forwarded_allow_ips` defaulted to `172.16.0.0/12` — Docker's bridge range, read off `compose.yaml`. Production is **rootless podman + slirp4netns** (podman 4.9.3, `NetworkMode=slirp4netns`, empty `NetworkSettings.Gateway`), where the rootlesskit port handler SNATs every inbound connection to the container's own slirp address `10.0.2.100`. Not in the list → uvicorn kept discarding `X-Forwarded-Proto`.

Default now covers all three runtimes: `10.0.2.0/24` (rootless podman), `10.88.0.0/16` (rootful podman), `172.16.0.0/12` (docker/compose).

**2. The documented override could not reach the container.** `deploy.sh` forwards a fixed list of env vars; `TOGOMCP_FORWARDED_ALLOW_IPS` wasn't in it. The knob documented in `.env.example` was inert on the real deploy path. Now forwarded per-service.

Both failures are **silent by construction** — an untrusted `X-Forwarded-*` header is dropped, not rejected — which is why 2.0.1 looked correct and tested green.

## Also corrected: the rationale against `*`

2.0.1 argued a tight list protects the hashed peer IP in the tool-call log from forgery. On the rootless-slirp4netns path that field is **already constant** (every client arrives as `10.0.2.100`), so a tight list buys nothing there and the real protection is that only the proxy can reach the published port. The argument still holds on rootful/compose, where the peer is the true client — so the default stays tight.

## Tests

The 2.0.1 suite passed while the fix did nothing: it asserted the Docker range, encoding the wrong assumption rather than catching it. Now asserts a slirp4netns peer is trusted, and that `deploy.sh` forwards the override. 230 pass.

## What this unblocks

Deploying to test finally makes the `/mcp/` redirect a real test for #175, which it wasn't before — our side was swallowing the header regardless of what the proxy sent:

- `location: https://` → the proxy does send `X-Forwarded-Proto`; #175 can be closed with no proxy work.
- `location: http://` → confirmed the proxy isn't sending it; #175 goes to the edge admin with a clean diagnosis.

## Release checklist

- [x] `pyproject.toml` + `uv.lock` bumped in one commit (`e913ff8`)
- [x] Dated `## [2.0.2] - 2026-07-29` heading, `[Unreleased]` emptied, compare link
- [x] 230 tests pass; catalog + whatsnew drift guards green
- [ ] Tag the merge: `git tag v2.0.2 <merge-sha> && git push origin v2.0.2`
- [ ] Deploy, then run the #175 diagnostic above

_(`8bdd9f2` is an empty commit — the bump landed in `e913ff8` alongside the fix, satisfying the same-commit rule. Left rather than force-push a shared branch.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
