### PR TITLE
Release 2.1.0 — declare all tools read-only in the MCP protocol

### DIFF
--- a/.claude/skills/intro-page-updater/references/make_intro.md
+++ b/.claude/skills/intro-page-updater/references/make_intro.md
@@ -72,7 +72,7 @@ Read the following webpages carefully and write a concise, accurate setup guide 
 - [Claude Desktop](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
   * Method 1 (for paid plans). Settings -> Connectors -> "Add custom connectors"
   * Method 2. (alternative). Settings -> Developer -> Edit Config (JSON config file)
-- [ChatGPT](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) (Developer Mode; Plus/Pro/Business/Enterprise/Edu accounts)
+- [ChatGPT](https://developers.openai.com/api/docs/guides/developer-mode) (Developer Mode, beta). **Do not state a plan-tier list on the page.** Eligibility and connector capability (read-only vs full read/write) have changed repeatedly during the beta, roll out in stages, and first-party docs, secondary write-ups and user reports disagree at any given moment — a hardcoded list goes stale silently and invites correction. Link to OpenAI's guide for eligibility, and say instead that TogoMCP needs only read access (every tool is a query/search/ID conversion, no writes), which is true on every tier. Note the `help.openai.com` article is Cloudflare-blocked to automated checks, so its liveness cannot be verified from CI or a tool — prefer the `developers.openai.com` guide, which returns 200.
 - [Gemini CLI](https://geminicli.com/docs/tools/mcp-server/#how-to-set-up-your-mcp-server) Note that TogoMCP is provided via **Streamable-HTTP, not SSE**.
 For Gemini CLI, the settings.json should be 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **All 29 tools now declare `readOnlyHint`** (plus `openWorldHint`) in their MCP annotations.
+  TogoMCP has always been read-only — every tool is a query, search or ID conversion, and nothing
+  writes to a database — but that was stated only in prose, and MCP's default for an *unannotated*
+  tool is the unsafe one. OpenAI's ChatGPT developer-mode docs are explicit that "tools without this
+  hint are treated as write actions", so an unannotated read-only server draws a confirmation prompt
+  on **every** call and can be refused outright by a plan that only permits read/search connectors.
+  Claude and other clients use the same hint to decide what may be auto-approved. `destructiveHint`
+  and `idempotentHint` are deliberately left unset — the spec defines both as meaningful only when
+  `readOnlyHint` is false. A test guard fails the build if a new tool omits the annotation, since the
+  failure is otherwise invisible.
 
 ## [2.0.2] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.1.0] - 2026-07-29
+
+<!-- whatsnew: 2026-07-29 | All tools now declare themselves <strong>read-only</strong> in the MCP protocol, so clients such as ChatGPT no longer treat every query as a write action needing confirmation. -->
+
 ### Added
 
 - **All 29 tools now declare `readOnlyHint`** (plus `openWorldHint`) in their MCP annotations.
@@ -25,6 +31,17 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
   and `idempotentHint` are deliberately left unset — the spec defines both as meaningful only when
   `readOnlyHint` is false. A test guard fails the build if a new tool omits the annotation, since the
   failure is otherwise invisible.
+
+### Changed
+
+- **ChatGPT setup guide no longer states a plan-tier list.** The page claimed Developer Mode was
+  available to "Plus, Pro, Business, Enterprise, or Edu". Checking that against sources found three
+  mutually inconsistent accounts — OpenAI's own developer guide says all those tiers with full
+  read+write, secondary write-ups say Plus/Pro are read-only, and user reports exclude Plus
+  entirely — with the authoritative help-center article Cloudflare-blocked to any automated check.
+  Developer Mode is a staged-rollout beta, so the tier matrix is genuinely unstable. The page now
+  links to OpenAI's guide for eligibility and states what settles it regardless: TogoMCP needs only
+  read access, so a plan limited to read/search connectors runs it in full.
 
 ## [2.0.2] - 2026-07-29
 
@@ -563,7 +580,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/dbcls/togomcp/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/dbcls/togomcp/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/dbcls/togomcp/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/dbcls/togomcp/compare/v1.7.1...v2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.0.2"
+version = "2.1.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -80,3 +80,53 @@ def test_every_tool_description_states_what_it_returns(assembled_tools) -> None:
         "move the return/error contract into the body above `Args:`, or into "
         "the decorator `description=` for decorator-driven tools."
     )
+
+
+class TestReadOnlyAnnotations:
+    """Every TogoMCP tool is a query/search/ID conversion — nothing writes. That
+    has to be stated in the protocol, not just in prose: MCP's default for an
+    unannotated tool is the UNSAFE one. OpenAI's ChatGPT developer-mode docs say
+    "tools without this hint are treated as write actions", so an unannotated
+    read-only server draws a confirmation prompt on every call and can be refused
+    outright by a plan that only permits read/search connectors."""
+
+    def test_every_tool_declares_read_only(self) -> None:
+        tools = asyncio.run(self._tools())
+        missing = [
+            t.name
+            for t in tools
+            if getattr(getattr(t, "annotations", None), "readOnlyHint", None) is not True
+        ]
+        assert not missing, (
+            f"tools missing readOnlyHint=True: {missing}. Add "
+            "`annotations=READ_ONLY_TOOL` to the @mcp.tool decorator — without it "
+            "clients treat the tool as a writer."
+        )
+
+    def test_every_tool_declares_open_world(self) -> None:
+        """Each tool reaches an external endpoint (RDF Portal, NCBI, TogoID, …),
+        not a closed local dataset."""
+        tools = asyncio.run(self._tools())
+        missing = [
+            t.name
+            for t in tools
+            if getattr(getattr(t, "annotations", None), "openWorldHint", None) is not True
+        ]
+        assert not missing, f"tools missing openWorldHint=True: {missing}"
+
+    def test_destructive_and_idempotent_hints_stay_unset(self) -> None:
+        """The MCP spec defines both as meaningful only when readOnlyHint is false.
+        Setting them on a read-only tool is noise that implies the opposite."""
+        tools = asyncio.run(self._tools())
+        wrong = [
+            t.name
+            for t in tools
+            for hint in ("destructiveHint", "idempotentHint")
+            if getattr(getattr(t, "annotations", None), hint, None) is not None
+        ]
+        assert not wrong, f"read-only tools must leave destructive/idempotent unset: {wrong}"
+
+    @staticmethod
+    async def _tools():
+        await setup()
+        return await mcp.list_tools()

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -178,7 +178,7 @@ def _rest_fail_msg(subject: str, detail: str, database: str) -> str:
 #####　Database-specific tools ########
 ######################################
 # DB: UniProt
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_uniprot_entity(
     query: str = "",
     limit: int = 20,
@@ -321,7 +321,7 @@ async def search_uniprot_entity(
 
 
 # DB: PubChem
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def get_pubchem_compound_id(compound_name: str) -> str:
     """
     Get a PubChem compound ID (CID) for a compound name.
@@ -344,7 +344,7 @@ async def get_pubchem_compound_id(compound_name: str) -> str:
     return resp.text
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def get_compound_attributes_from_pubchem(pubchem_compound_id: str) -> str:
     """
     Get compound attributes from PubChem RDF.
@@ -473,7 +473,7 @@ _PDB_ROW_PROJECTORS = {
 }
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_pdb_entity(
     db: Literal["pdb", "cc", "prd"],
     query: str = "",
@@ -639,7 +639,7 @@ async def search_pdb_entity(
 
 
 # DB: MeSH
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_mesh_descriptor(
     query: str = "",
     limit: int = 10,
@@ -803,7 +803,7 @@ def _reactome_is_no_match(body: str | None) -> bool:
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_reactome_entity(
     query: str = "",
     species: str | list[str] | None = None,
@@ -1036,7 +1036,7 @@ _RHEA_MAX_LIMIT = 500
 _RHEA_CHEBI_DOUBLE_PREFIX_RE = re.compile(r"(?i)\bchebi:chebi:")
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_rhea_entity(
     query: str = "",
     limit: int | None = 25,

--- a/togo_mcp/chembl.py
+++ b/togo_mcp/chembl.py
@@ -265,7 +265,7 @@ async def _search_chembl_inchi_sparql(
     return await _run_chembl_sparql(sparql)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_chembl_id_lookup(
     query: Annotated[
         str, Field(description="The query string to search for.", default="")
@@ -481,7 +481,7 @@ async def search_chembl_id_lookup(
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_chembl_target(
     query: str = "",
     limit: int = 20,
@@ -615,7 +615,7 @@ async def search_chembl_target(
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_chembl_molecule(
     query: str = "",
     limit: int = 20,

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -768,6 +768,10 @@
     <ul class="whatsnew-list">
       <!-- WHATSNEW:START -->
       <li>
+        <span class="whatsnew-date">2026-07-29</span>
+        <span>All tools now declare themselves <strong>read-only</strong> in the MCP protocol, so clients such as ChatGPT no longer treat every query as a write action needing confirmation.</span>
+      </li>
+      <li>
         <span class="whatsnew-date">2026-07-24</span>
         <span>The database knowledge files (MIE) were rewritten to a leaner format — about half the size, with faster and more reliable query construction. The three database-discovery tools (<code>list_databases</code>, <code>find_databases</code>, <code>list_categories</code>) were consolidated into the built-in Usage Guide, which now carries a catalog of all 36 databases.</span>
       </li>

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -977,8 +977,9 @@
     </div>
 
     <div id="tab-chatgpt" class="setup-panel">
-      <h4>ChatGPT — Developer Mode (Plus, Pro, Business, Enterprise, or Edu)</h4>
-      <p>Custom MCP connectors run in ChatGPT's <strong>Developer Mode</strong> on the web, available to Plus, Pro, Business, Enterprise, and Education accounts. (On Business/Enterprise/Edu, an admin must first enable developer access under <strong>Workspace Settings → Permissions</strong>.)</p>
+      <h4>ChatGPT — Developer Mode</h4>
+      <p>Custom MCP connectors run in ChatGPT's <strong>Developer Mode</strong> on the web. Developer Mode is a <strong>beta</strong>: which plans can add a custom connector — and what that connector is permitted to do — has changed during the beta and rolls out in stages, so check <a href="https://developers.openai.com/api/docs/guides/developer-mode" target="_blank" rel="noopener">OpenAI's Developer Mode guide</a> for the current eligibility rather than relying on this page. (On Business/Enterprise/Edu, an admin must first enable developer access under <strong>Workspace Settings → Permissions</strong>.)</p>
+      <p><strong>TogoMCP needs only read access.</strong> Every tool it exposes is a query, search, or ID conversion — it never writes to a database. So on a plan whose custom connectors are limited to read/search, TogoMCP still works in full.</p>
       <ol>
         <li>Enable Developer Mode: go to <strong>Settings → Apps &amp; Connectors → Advanced settings</strong> and turn on <strong>Developer mode</strong>.</li>
         <li>Back under <strong>Settings → Apps &amp; Connectors</strong>, click <strong>Create</strong> (next to Advanced settings) to add a custom connector.</li>
@@ -993,7 +994,7 @@
         <li>In your chat, open the <strong>"+"</strong> menu and enable TogoMCP for the conversation.</li>
       </ol>
       <div class="setup-note">
-        ℹ️ Developer mode requires confirmation for write actions and shows tool usage explicitly. See the <a href="https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt" target="_blank" rel="noopener">ChatGPT MCP documentation</a> for more details.
+        ℹ️ Developer mode shows tool usage explicitly and requires confirmation for write actions — TogoMCP performs none. See <a href="https://developers.openai.com/api/docs/guides/developer-mode" target="_blank" rel="noopener">OpenAI's Developer Mode guide</a> for details and current plan eligibility.
       </div>
     </div>
 

--- a/togo_mcp/ncbi_tools.py
+++ b/togo_mcp/ncbi_tools.py
@@ -25,7 +25,7 @@ from fastmcp import FastMCP
 import httpx
 from mcp.types import TextContent
 
-from .server import raise_for_status_with_body
+from .server import READ_ONLY_TOOL, raise_for_status_with_body
 
 # Get API key from environment
 NCBI_API_KEY = os.environ.get("NCBI_API_KEY")
@@ -339,7 +339,7 @@ def _normalize_ids(ids: str | list[str]) -> list[str]:
     return [str(i).strip() for i in ids if str(i).strip()]
 
 
-@ncbi_mcp.tool()
+@ncbi_mcp.tool(annotations=READ_ONLY_TOOL)
 async def esearch(
     database: str = "",
     query: str = "",
@@ -485,7 +485,7 @@ async def esearch(
         return [TextContent(type="text", text=f"Unexpected error: {str(e)}")]
 
 
-@ncbi_mcp.tool()
+@ncbi_mcp.tool(annotations=READ_ONLY_TOOL)
 async def list_databases() -> list[TextContent]:
     """
     List all supported NCBI databases with descriptions and example queries.
@@ -516,7 +516,7 @@ async def list_databases() -> list[TextContent]:
 
 
 # Additional utility functions for future use
-@ncbi_mcp.tool()
+@ncbi_mcp.tool(annotations=READ_ONLY_TOOL)
 async def esummary(
     database: str = "",
     ids: str | list[str] = "",
@@ -596,7 +596,7 @@ async def esummary(
             ]
 
 
-@ncbi_mcp.tool()
+@ncbi_mcp.tool(annotations=READ_ONLY_TOOL)
 async def efetch(
     database: str = "",
     ids: str | list[str] = "",

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -28,7 +28,7 @@ def _is_system_graph(graph: str) -> bool:
     return any(pat in g for pat in _SYSTEM_GRAPH_PATTERNS)
 
 
-@mcp.tool(name="TogoMCP_Usage_Guide")
+@mcp.tool(name="TogoMCP_Usage_Guide", annotations=READ_ONLY_TOOL)
 def togomcp_usage_guide() -> str:
     """
     ⚠️ CALL THIS TOOL FIRST every turn, before any other TogoMCP tool.
@@ -70,7 +70,7 @@ def togomcp_usage_guide() -> str:
 # --- Tools for RDF Portal --- #
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY_TOOL)
 async def get_sparql_endpoints() -> dict[str, Any]:
     """Get the available SPARQL endpoints for RDF Portal.
 
@@ -96,6 +96,7 @@ async def get_sparql_endpoints() -> dict[str, Any]:
 
 
 @mcp.tool(
+    annotations=READ_ONLY_TOOL,
     name="run_sparql",
     description=(
         "Run a SPARQL query on an RDF database. "
@@ -169,6 +170,7 @@ async def run_sparql(
 
 
 @mcp.tool(
+    annotations=READ_ONLY_TOOL,
     name="get_graph_list",
     description=(
         "Get a list of named graphs on a SPARQL endpoint. ALWAYS pass database "
@@ -293,6 +295,7 @@ SELECT DISTINCT ?graph WHERE {
 
 
 @mcp.tool(
+    annotations=READ_ONLY_TOOL,
     name="get_MIE_file",
     description="**At the start of any task, identify ALL databases needed and call this tool for EACH of them before writing any SPARQL queries.** Do not query a database until its MIE file has been read. Get the MIE (Metadata Interoperability Exchange) file containing the ShEx schema, RDF and SPARQL examples of a specific RDF database. RETURNS the MIE file as a YAML-formatted string; an unknown database returns a string beginning with 'Error:' that lists the valid database names.",
 )

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -297,6 +297,24 @@ except PackageNotFoundError:  # not installed as a distribution (source-tree run
 
 mcp = FastMCP("TogoMCP: RDF Portal MCP Server", version=_TOGOMCP_VERSION)
 
+# Every tool this server exposes is a query, search, or ID conversion — nothing
+# writes to any database. Say so in the protocol rather than only in prose: a
+# client cannot infer it from the tool name, and the MCP default is the unsafe
+# one. OpenAI's ChatGPT developer-mode docs are explicit that "tools without this
+# hint are treated as write actions", which means an unannotated read-only server
+# gets a confirmation prompt on EVERY call, and can be refused outright by a plan
+# that only permits read/search connectors. Claude and other clients use the same
+# hint to decide what may be auto-approved.
+#
+# `openWorldHint` is True because every tool reaches an external endpoint (RDF
+# Portal SPARQL, NCBI, TogoID, …) rather than a closed local dataset.
+# `destructiveHint`/`idempotentHint` are deliberately unset: the MCP spec defines
+# both as meaningful only when readOnlyHint is false.
+#
+# Apply this to EVERY new tool — a tool without it silently reverts to being
+# treated as a writer. `tests/test_tool_descriptions.py` enforces it.
+READ_ONLY_TOOL = {"readOnlyHint": True, "openWorldHint": True}
+
 
 from fastmcp.server.middleware import Middleware as _Middleware
 import inspect as _inspect

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -39,7 +39,7 @@ togoid_mcp = FastMCP("TogoID API server")
 # ============================================================================
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def getAllRelation() -> dict:
     """Discover all available ID conversion routes between databases.
 
@@ -78,7 +78,7 @@ async def getAllRelation() -> dict:
     return response.json()
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def getRelation(source: str, target: str) -> str:
     """Check if a specific ID conversion route exists and get its details.
 
@@ -123,7 +123,7 @@ async def getRelation(source: str, target: str) -> str:
     return json.dumps(response.json())
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def getAllDataset() -> dict:
     """List all databases registered in TogoID with their ID formats.
 
@@ -148,7 +148,7 @@ async def getAllDataset() -> dict:
     return response.json()
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def getDataset(dataset: str) -> dict:
     """Get configuration for a specific database in TogoID.
 
@@ -183,7 +183,7 @@ async def getDataset(dataset: str) -> dict:
     return response.json()
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def getDescription() -> dict:
     """Get human-readable descriptions for all databases in TogoID.
 
@@ -204,7 +204,7 @@ async def getDescription() -> dict:
 # ============================================================================
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def convertId(
     ids: str | list[str],
     route: str,
@@ -282,7 +282,7 @@ async def convertId(
     return json.dumps(response.json().get("results") or [])
 
 
-@togoid_mcp.tool()
+@togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def countId(source: str, target: str, ids: str | list[str]) -> dict:
     """Check how many of your IDs can be converted before doing bulk conversion.
 

--- a/togo_mcp/togovar.py
+++ b/togo_mcp/togovar.py
@@ -607,7 +607,7 @@ def _label_facets(stats: dict[str, Any]) -> dict[str, Any]:
     return labeled
 
 
-@togovar_mcp.tool()
+@togovar_mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_gene(
     query: Annotated[str, Field(description="Gene symbol or alias, e.g. 'ALDH2'.")] = "",
     limit: Annotated[int, Field(ge=1, le=100)] = 10,
@@ -660,7 +660,7 @@ async def search_gene(
     return json.dumps(results)
 
 
-@togovar_mcp.tool()
+@togovar_mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_disease(
     query: Annotated[
         str, Field(description="Disease term, e.g. 'breast cancer'.")
@@ -722,7 +722,7 @@ async def search_disease(
     return json.dumps(results)
 
 
-@togovar_mcp.tool()
+@togovar_mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_variant(
     tgv_id: str | list[str] = "",
     gene_hgnc_id: int | None = None,

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
**Release 2.1.0** — MINOR. Three commits.

MINOR rather than PATCH because tool annotations are an **addition to the tool surface a client sees**. Nothing is removed, renamed, or made required, and every existing call works unchanged — but clients now observe something they previously could not, which is the "new capability, old calls still work" case in the agent-pragmatic policy.

## Added — all 29 tools declare `readOnlyHint`

TogoMCP has always been read-only: every tool is a query, search, or ID conversion, and nothing writes to a database. That was stated only in prose — and MCP's default for an *unannotated* tool is the unsafe one.

OpenAI's ChatGPT developer-mode guide is explicit:

> *"We respect the `readOnlyHint` tool annotation… Tools without this hint are treated as **write actions**."*

So in practice ChatGPT was treating all 29 as writers: a confirmation prompt on **every call**, on a server built for iterative querying — and possible outright refusal on a plan that only permits read/search connectors. Claude and other clients use the same hint to decide what may be auto-approved.

Implementation notes:

- A shared `READ_ONLY_TOOL` constant in `server.py` rather than 29 inline literals, so the value has one home.
- `openWorldHint: True` — every tool reaches an external endpoint (RDF Portal SPARQL, NCBI, TogoID), not a closed local dataset.
- `destructiveHint` / `idempotentHint` deliberately **unset**: the MCP spec defines both as meaningful only when `readOnlyHint` is false, so setting them on a read-only tool implies the opposite of what's meant.
- **A test guard** asserts every registered tool declares both hints and leaves the other two unset. Verified it actually fires by registering an unannotated probe tool. Without it a new tool silently reverts to being treated as a writer — which is exactly how this went unnoticed.

## Changed — ChatGPT setup guide no longer states a plan-tier list

The page claimed Developer Mode was available to "Plus, Pro, Business, Enterprise, or Edu". User feedback said otherwise. Checking it found **three mutually inconsistent accounts**:

| Source | Claim |
|---|---|
| OpenAI's own developer guide | Pro, Plus, Business, Enterprise, Edu — full read **and** write |
| Secondary write-ups | Plus/Pro read-only; only B/E/E get writes |
| User report | Plus excluded entirely; Pro read-only |

The authoritative help-center article is Cloudflare-blocked to any automated check (403 even with a browser UA) and has been renamed at least once. Developer Mode is a staged-rollout beta, so two users on one plan can legitimately see different things.

Rather than swap one disputed list for another, the tier claim is gone. The page links to OpenAI's guide for eligibility and states the fact that settles it regardless of who is right: **TogoMCP needs only read access**, so a plan limited to read/search connectors runs it in full. A "do not state a plan-tier list" rule is recorded in `make_intro.md` so the next edit doesn't helpfully re-add one.

The two changes are connected: that page claim was true of our *intentions* but unobservable by any client until the annotations landed in this same release.

## Release checklist

- [x] `pyproject.toml` + `uv.lock` bumped in one commit (`addf269`)
- [x] Dated `## [2.1.0] - 2026-07-29` heading; `[Unreleased]` emptied; compare link
- [x] `whatsnew` marker added and `generate_whatsnew.py` re-run — the intro page now leads with the read-only change
- [x] 233 tests pass; catalog + whatsnew drift guards green
- [x] `serverInfo.version` reports `2.1.0`
- [ ] **Tag the merge commit**: `git tag v2.1.0 <merge-sha> && git push origin v2.1.0`
- [ ] Deploy (test → prod); confirm via the `initialize` version probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
