### PR TITLE
Release 2.1.2 — Gemini CLI was retired; document Antigravity instead

### DIFF
--- a/.claude/skills/intro-page-updater/references/make_intro.md
+++ b/.claude/skills/intro-page-updater/references/make_intro.md
@@ -79,17 +79,19 @@ Read the following webpages carefully and write a concise, accurate setup guide 
   - **The help-center article is Cloudflare-blocked (403) to WebFetch and to curl even with a browser UA**, so it cannot be checked by a tool or from CI. A human must open it in a browser. Do not conclude from the 403 that the link is dead, and do not "fix" it by switching to a fetchable-but-wrong source — that is exactly the mistake made on 2026-07-29.
 
   Because eligibility genuinely differs by tier, **do state it** — a Plus user who follows the setup steps will otherwise just fail. Pair it with the fact that resolves the read/fetch restriction: TogoMCP needs only read access (every tool is a query/search/ID conversion, and all 29 declare `readOnlyHint`), so Pro's read-only limit does not constrain it.
-- [Gemini CLI](https://geminicli.com/docs/tools/mcp-server/#how-to-set-up-your-mcp-server) Note that TogoMCP is provided via **Streamable-HTTP, not SSE**.
-For Gemini CLI, the settings.json should be 
-```
-{
-  "mcpServers": {
-    "togomcp": {
-      "httpUrl": "https://togomcp.rdfportal.org/mcp"
-    }
-  }
-}
-```
+- **Antigravity CLI** ([config docs](https://antigravity.google/docs/mcp)) — the tab formerly labelled "Gemini CLI". **Gemini CLI was retired 2026-06-18** for the free tier, Google AI Pro, Ultra and Google One, replaced by Antigravity CLI (official announcement: [Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), [repo discussion #27274](https://github.com/google-gemini/gemini-cli/discussions/27274)). Gemini CLI survives only for Gemini Code Assist Standard/Enterprise, Google Cloud access, and paid Gemini API keys — so the Antigravity config is the primary one and Gemini CLI is the footnote, not the reverse.
+
+  The two are **not** interchangeable, and getting it wrong fails silently:
+
+  | | Antigravity | Gemini CLI (legacy) |
+  |---|---|---|
+  | file | `~/.gemini/config/mcp_config.json` (or `.agents/mcp_config.json` per project) | `~/.gemini/settings.json` |
+  | key | `serverUrl` | `httpUrl` |
+
+  Antigravity's docs are explicit that "legacy fields like `url` or `httpUrl` are not supported". Either way TogoMCP is **Streamable HTTP, not SSE** (`url` means SSE in Gemini CLI).
+
+  **Link only to first-party docs**: `antigravity.google/docs/mcp` and `google-gemini.github.io/gemini-cli/docs/`. The page previously linked `geminicli.com`, which is one of several unofficial mirrors (`gemini-cli.xyz`, `geminicli.cloud`, `geminicli.work`) — they return 200 and look official, which is exactly the hazard. A mirror kept serving Gemini CLI instructions six weeks after the product was retired.
+
 
 ## List available databases
 Create a list of available databases with a summary of each. Exclude SuperCon from the list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.1.2] - 2026-07-29
+
 ### Fixed
 
 - **Setup guide: the "Gemini CLI" tab documented a retired product with the wrong config key.** Google
@@ -612,7 +616,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.2...HEAD
+[2.1.2]: https://github.com/dbcls/togomcp/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/dbcls/togomcp/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/dbcls/togomcp/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/dbcls/togomcp/compare/v2.0.1...v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,22 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Setup guide: the "Gemini CLI" tab documented a retired product with the wrong config key.** Google
+  retired Gemini CLI on **2026-06-18** for the free tier, Google AI Pro, Ultra and Google One,
+  replacing it with **Antigravity CLI**; it survives only for Gemini Code Assist Standard/Enterprise,
+  Google Cloud access, and paid Gemini API keys. The page had carried the old instructions for six
+  weeks. Worse, the two are not interchangeable and the mismatch fails *silently*: Antigravity reads
+  `~/.gemini/config/mcp_config.json` and requires `serverUrl`, and its docs state that "legacy fields
+  like `url` or `httpUrl` are not supported" — while the page showed `settings.json` with `httpUrl`.
+  Anyone who followed it got a connector that never connected, with no error explaining why.
+  The tab is now Antigravity-first with Gemini CLI as a footnote for the plans that still have it.
+- **Setup guide links now point only at first-party docs.** The Gemini tab linked `geminicli.com`,
+  one of several unofficial mirrors (`gemini-cli.xyz`, `geminicli.cloud`, `geminicli.work`). It returns
+  200 and looks authoritative, which is precisely the hazard — it was still serving Gemini CLI
+  instructions six weeks after the product was retired. Replaced with `antigravity.google/docs/mcp`
+  and `google-gemini.github.io/gemini-cli/docs/`.
 
 ## [2.1.1] - 2026-07-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.1.1"
+version = "2.1.2"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -750,7 +750,7 @@
       </div>
       <div class="summary-card">
         <h3>🤖 AI-Ready</h3>
-        <p>Designed for integration with LLM-based assistants. Compatible with Claude Desktop, ChatGPT, and Gemini CLI. No bioinformatics expertise required — use natural language to explore data.</p>
+        <p>Designed for integration with LLM-based assistants. Compatible with Claude Desktop, ChatGPT, and Antigravity (formerly Gemini CLI). No bioinformatics expertise required — use natural language to explore data.</p>
       </div>
     </div>
   </div>
@@ -947,7 +947,7 @@
     <div class="setup-tabs">
       <button class="setup-tab-btn active" onclick="showTab(event,'tab-claude')">Claude Desktop</button>
       <button class="setup-tab-btn" onclick="showTab(event,'tab-chatgpt')">ChatGPT</button>
-      <button class="setup-tab-btn" onclick="showTab(event,'tab-gemini')">Gemini CLI</button>
+      <button class="setup-tab-btn" onclick="showTab(event,'tab-gemini')">Antigravity / Gemini CLI</button>
     </div>
 
     <div id="tab-claude" class="setup-panel active">
@@ -1009,18 +1009,20 @@
     </div>
 
     <div id="tab-gemini" class="setup-panel">
-      <h4>Gemini CLI — Streamable HTTP Configuration</h4>
-      <p>TogoMCP uses <strong>Streamable HTTP</strong> transport (not SSE). Configure your <code>settings.json</code> as follows:</p>
+      <h4>Antigravity CLI — Streamable HTTP Configuration</h4>
+      <p><strong>Gemini CLI was retired on 18 June 2026</strong> for the free tier, Google AI Pro, Ultra and Google One, and replaced by <strong>Antigravity CLI</strong>. If that is you, use the Antigravity configuration below — the old Gemini CLI settings will not work. (Gemini Code Assist Standard/Enterprise, Google Cloud access, and paid Gemini API keys keep Gemini CLI; see the note at the end.)</p>
+      <p>Edit <code>~/.gemini/config/mcp_config.json</code> (or <code>.agents/mcp_config.json</code> in a project):</p>
 <pre class="code-block">{
   <span class="k">"mcpServers"</span>: {
     <span class="k">"togomcp"</span>: {
-      <span class="k">"httpUrl"</span>: <span class="s">"https://togomcp.rdfportal.org/mcp"</span>
+      <span class="k">"serverUrl"</span>: <span class="s">"https://togomcp.rdfportal.org/mcp"</span>
     }
   }
 }</pre>
-      <p>Save the file — Gemini CLI will automatically detect the new MCP server on next launch.</p>
+      <p>The field is <code>serverUrl</code>. Antigravity does <strong>not</strong> accept the older <code>httpUrl</code> or <code>url</code> keys — a config using them silently fails to connect.</p>
+      <p>Save the file, then type <code>/mcp</code> in the Antigravity CLI prompt to open the MCP Manager and reload. In the Antigravity IDE, use <strong>MCP Servers</strong> in the agent side panel instead.</p>
       <div class="setup-note">
-        ℹ️ For full setup instructions, see the <a href="https://geminicli.com/docs/tools/mcp-server/" target="_blank" rel="noopener">Gemini CLI MCP documentation</a>.
+        ℹ️ Config reference: <a href="https://antigravity.google/docs/mcp" target="_blank" rel="noopener">Antigravity MCP documentation</a>. Still on Gemini CLI via a paid/enterprise path? It uses a different file and key — <code>~/.gemini/settings.json</code> with <code>"httpUrl"</code> instead of <code>"serverUrl"</code>; see the <a href="https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html" target="_blank" rel="noopener">Gemini CLI MCP docs</a>. Either way TogoMCP is <strong>Streamable HTTP, not SSE</strong>.
       </div>
     </div>
   </div>

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -947,7 +947,7 @@
     <div class="setup-tabs">
       <button class="setup-tab-btn active" onclick="showTab(event,'tab-claude')">Claude Desktop</button>
       <button class="setup-tab-btn" onclick="showTab(event,'tab-chatgpt')">ChatGPT</button>
-      <button class="setup-tab-btn" onclick="showTab(event,'tab-gemini')">Antigravity / Gemini CLI</button>
+      <button class="setup-tab-btn" onclick="showTab(event,'tab-gemini')">Antigravity</button>
     </div>
 
     <div id="tab-claude" class="setup-panel active">

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
**Release 2.1.2** — PATCH. Landing-page content only; no change to the served tool surface.

## The setup guide documented a retired product

Google retired **Gemini CLI on 2026-06-18** — six weeks ago — for the free tier, Google AI Pro, Ultra and Google One, replacing it with **Antigravity CLI** ([Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), [repo discussion #27274](https://github.com/google-gemini/gemini-cli/discussions/27274)). Gemini CLI survives only for Gemini Code Assist Standard/Enterprise, Google Cloud access, and paid Gemini API keys.

The page had carried the old instructions the whole time — and the two configs are **not** interchangeable:

| | Antigravity | Gemini CLI (legacy) |
|---|---|---|
| file | `~/.gemini/config/mcp_config.json` (or `.agents/mcp_config.json` per project) | `~/.gemini/settings.json` |
| key | `serverUrl` | `httpUrl` |

Antigravity's docs state that *"legacy fields like `url` or `httpUrl` are not supported."* The page showed `settings.json` + `httpUrl`, so anyone on the majority path configured a connector that never connected, with **no error explaining why**.

The tab is now Antigravity-first, with Gemini CLI kept as a footnote for the plans that retain it, and renamed to plain **Antigravity**.

## The link was to an unofficial mirror

The tab linked `geminicli.com` — one of several mirrors (`gemini-cli.xyz`, `geminicli.cloud`, `geminicli.work`). It returns 200, carries the product branding, and reads as official; it was still serving instructions for a retired product. Replaced with `antigravity.google/docs/mcp` and `google-gemini.github.io/gemini-cli/docs/`, both verified 200.

## The pattern

This is the third instance in two days of the same failure: **a fetchable, plausible, non-authoritative source outliving the facts it described** — `developers.openai.com` on ChatGPT plan tiers (2.1.1), and now a doc mirror on an entire product lifecycle.

`make_intro.md` now carries the config table, the retirement date, and a "first-party docs only" rule that names the mirror domains explicitly, so the next edit doesn't reach for whichever source happens to be fetchable.

## Release checklist

- [x] `pyproject.toml` + `uv.lock` bumped in one commit
- [x] Dated `## [2.1.2] - 2026-07-29` heading; `[Unreleased]` emptied; compare link
- [x] No `whatsnew` marker — corrects a third party's lifecycle, not a TogoMCP capability
- [x] 233 tests pass; catalog + whatsnew drift guards green
- [x] `serverInfo.version` reports `2.1.2`; tab panel ids unchanged so tab JS still resolves
- [ ] **Tag the merge commit**: `git tag v2.1.2 <merge-sha> && git push origin v2.1.2`
- [ ] Redeploy — the page is served from the container, so the fix needs a rebuild to go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
