### PR TITLE
Release 2.1.3 — correct the Claude setup path, add the Team/Enterprise route

### DIFF
--- a/.claude/skills/intro-page-updater/references/make_intro.md
+++ b/.claude/skills/intro-page-updater/references/make_intro.md
@@ -69,9 +69,11 @@ Key Results:
 
 ## Setup guide
 Read the following webpages carefully and write a concise, accurate setup guide for each.
-- [Claude Desktop](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp#h_3d1a65aded)
-  * Method 1 (for paid plans). Settings -> Connectors -> "Add custom connectors"
-  * Method 2. (alternative). Settings -> Developer -> Edit Config (JSON config file)
+- **Claude** ([custom connectors article](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp)) — unlike OpenAI's help centre, `support.claude.com` **is** fetchable (200), so verify against it directly rather than from memory. It carries an "Updated" date. As of 2026-07-30:
+  * Custom connectors work on Claude, Claude Desktop **and Cowork**, on **ALL plans** — Free, Pro, Max, Team, Enterprise. Free is capped at one connector; paid plans uncapped. Do not describe this as paid-only.
+  * Method 1 path is **Settings → Customize → Connectors → "+" → "Add custom connector"**. Not "Settings → Connectors", and not a button "at the bottom of the page" — both were wrong on the page until 2026-07-30.
+  * **Team/Enterprise need an owner to add it org-wide FIRST** (Organization settings → Connectors → Add → hover Custom → Web); members then connect individually. Members cannot self-add before that, so omitting this step strands every Team/Enterprise user.
+  * Method 2 (`claude_desktop_config.json` + `npx mcp-remote`) is a **community bridge, not an Anthropic-documented path** — the article says that file is for genuinely local MCP servers. Keep it as an optional fallback only; since Method 1 covers Free, its original "for people without a paid plan" rationale is gone.
 - [ChatGPT](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) (Developer Mode, beta). **This help-center article is the ONLY canonical source for plan eligibility** — it carries an "Updated" date and is revised often. As of 2026-07-29: Business/Enterprise/Edu get full MCP (admin must enable *and publish*); **Pro is read/fetch only**; **Plus has no custom MCP at all**. Web only, no mobile.
 
   Two traps, both hit on 2026-07-29:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.1.3] - 2026-07-30
+
 ### Fixed
 
 - **Claude setup guide: wrong settings path, and Team/Enterprise had no route at all.** Verified against
@@ -630,7 +634,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.3...HEAD
+[2.1.3]: https://github.com/dbcls/togomcp/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/dbcls/togomcp/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/dbcls/togomcp/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/dbcls/togomcp/compare/v2.0.2...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,21 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Claude setup guide: wrong settings path, and Team/Enterprise had no route at all.** Verified against
+  Anthropic's custom-connectors article (which, unlike OpenAI's help centre, is fetchable and carries an
+  "Updated" date). Three corrections: the path is **Settings → Customize → Connectors → "+" →
+  "Add custom connector"**, not "Settings → Connectors" with a button "at the bottom of the page";
+  **Team and Enterprise require an owner to add the connector organization-wide first**
+  (Organization settings → Connectors → Add → Custom → Web) and members cannot self-add before that, so
+  the omission stranded every Team/Enterprise user; and custom connectors are available on **all plans**
+  including Free (capped at one) rather than paid-only as the heading implied — also on Cowork, not just
+  Claude and Claude Desktop.
+- **Method 2 reframed honestly.** The `claude_desktop_config.json` + `npx mcp-remote` recipe is a
+  community bridge, not an Anthropic-documented path — the article states that file is for genuinely
+  local MCP servers. It is now marked optional, with the note that Method 1 covers every plan, which
+  removes its original "for people without a paid plan" rationale.
 
 ## [2.1.2] - 2026-07-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,39 @@ Two intentional, *different* error conventions coexist — preserve each module'
 
 List-style result tools return a **JSON string of a bare array** (not a Python `list`): empty and non-empty then share one wire shape. Returning a bare `list` makes FastMCP double-represent it (text array + wrapped `{"result": ...}`), so empty vs non-empty diverge for clients. `dict` returns (ChEMBL, `search_reactome_entity`, `get_sparql_endpoints`) and NCBI `list[TextContent]` returns are exempt — they aren't wrapped. `search_reactome_entity` uses the ChEMBL envelope `{total_count, has_more, results}` on success and `{"error": ...}` on failure (it validates+normalizes `species`/`types` case-insensitively against vendored vocabularies and raises on an unknown value — the server-side filter is case-sensitive and silently ignores a mis-cased value; `limit` is a true overall cap, not per-type; `summation` is opt-in).
 
+## Deployment
+
+**`compose.yaml` is NOT the production path.** Production and test run on the DBCLS host (vs94) via
+`scripts/deploy.sh` — **rootless podman** (`podman run -p`, network mode `slirp4netns`), test-before-prod,
+promoting the exact tested image without rebuilding. Compose is for local/dev only. `deploy.sh` is
+DBCLS-internal and deliberately absent from `README.md`.
+
+This distinction is written down because assuming Compose was the deployment cost two releases in a row
+(2026-07-29):
+
+- `forwarded_allow_ips` was defaulted to Docker's `172.16.0.0/12`, read off `compose.yaml`. Under rootless
+  podman + slirp4netns the rootlesskit port handler SNATs every inbound connection to the container's own
+  address `10.0.2.100`, so the value never matched and `X-Forwarded-Proto` kept being discarded.
+- `deploy.sh` forwards a **fixed list** of env vars (`TOGOMCP_PERSERVICE_VARS` / `TOGOMCP_SHARED_VARS`).
+  A knob added to `compose.yaml` and `.env.example` but not to that list is **inert in production**. Add
+  new env vars in all three places.
+
+Both failures were silent, and both passed a green test suite, because the tests asserted the assumption
+(the Docker range) rather than the environment. Two checks read what a client actually receives and cut
+through this class of bug — prefer them over local assertions whenever a change has to survive the deploy
+boundary:
+
+```bash
+# version actually being served (no session needed; /health returns only "OK")
+curl -sS -X POST https://togomcp.rdfportal.org/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
+```
+
+For tool metadata, capture `Mcp-Session-Id` from that response, POST `notifications/initialized`, then
+`tools/list` with the session header — that is how the 2.1.0 `readOnlyHint` annotations were confirmed to
+reach clients rather than merely to build.
+
 ## Versioning
 
 The version in `pyproject.toml` is read at runtime via `importlib.metadata` and reported in `serverInfo.version` (the deployment tell — a stale build shows the old number). Bump it on every `dev → main` release, and sync `uv.lock` in the same commit.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ docker compose up -d togomcp-test                   # after rebuilding, recreate
 
 Override image tags and host ports via `.env` — see `.env.example` for the full list. Use `docker compose up -d --force-recreate <svc>` if compose doesn't pick up a rebuilt image, and `docker image prune -f` to clean up dangling layers.
 
+#### Behind a reverse proxy
+
+Two env vars matter if you put TogoMCP behind nginx/Caddy/Traefik. Both fail in ways that are easy to misdiagnose:
+
+- **`TOGOMCP_ALLOWED_HOSTS`** — FastMCP validates the `Host` header (DNS-rebinding protection) and answers **421** for any host not on the allow-list. The default list is localhost plus the public DBCLS vhosts, so your own hostname must be added or *every* proxied request is rejected.
+- **`TOGOMCP_FORWARDED_ALLOW_IPS`** — which peer addresses may set `X-Forwarded-Proto`/`-For`. uvicorn parses those headers but trusts only `127.0.0.1` unless told otherwise, and a container reached via a published port never arrives as loopback. Left wrong, the header is **silently dropped** (not rejected): the app then believes it is serving plain HTTP and emits redirects that downgrade `https://` to `http://`. The default covers the usual container-runtime ranges; set this only if your proxy sits elsewhere.
+
+Your proxy must also send `X-Forwarded-Proto` — nginx does not by default (`proxy_set_header X-Forwarded-Proto $scheme;`), while Caddy and Traefik do. Both halves are required; neither works alone.
+
 ### Simple: `docker run`
 
 For a single container without compose:
@@ -115,7 +124,10 @@ docker run -e NCBI_API_KEY="your-key-here" -p 8000:8000 togo-mcp
 TogoMCP can record every MCP tool call as one JSON line per call (timestamp,
 tool name, arguments, status, elapsed_ms, session/request/client IDs, transport,
 client IP). SPARQL calls are enriched with endpoint URL, HTTP code, row/byte
-counts, and a SHA-256 of the query. Useful for benchmarking, MIE iteration,
+counts, and a SHA-256 of the query. Note the client IP is the *peer* address as
+the app sees it — behind a proxy or container that is the proxy/gateway, the same
+value for every caller, unless `TOGOMCP_FORWARDED_ALLOW_IPS` lets uvicorn trust
+`X-Forwarded-For`. Useful for benchmarking, MIE iteration,
 and reconstructing multi-tool sequences.
 
 **On/off is a single env var**: `TOGOMCP_QUERY_LOG`. Unset/empty = disabled
@@ -195,7 +207,8 @@ togomcp/
 │   ├── server.py           # Root FastMCP instance + tool-call logging middleware
 │   ├── main.py             # Assembles the server, mounts sub-servers, entry points
 │   ├── rdf_portal.py       # RDF Portal / SPARQL, MIE, and endpoint tools
-│   ├── api_tools.py        # REST search wrappers (UniProt, PDB, ChEMBL, Reactome, etc.)
+│   ├── api_tools.py        # REST search wrappers (UniProt, PDB, Reactome, MeSH, PubChem, etc.)
+│   ├── chembl.py           # ChEMBL REST search wrappers
 │   ├── ncbi_tools.py       # NCBI E-utilities sub-server
 │   ├── togoid.py           # TogoID identifier-conversion sub-server
 │   ├── togovar.py          # TogoVar human-variation sub-server
@@ -217,7 +230,13 @@ togomcp/
 
 ## Contributing
 
-Contributions are welcome! To add support for a new database, add an MIE file under `togo_mcp/data/mie/` and a corresponding row in `togo_mcp/data/resources/endpoints.csv` (see the MIE spec in `togo_mcp/data/docs/`). Please open an issue or pull request on GitHub.
+Contributions are welcome!
+
+**Adding a database**: add an MIE file under `togo_mcp/data/mie/` and a corresponding row in `togo_mcp/data/resources/endpoints.csv` (see the MIE spec in `togo_mcp/data/docs/`).
+
+**Adding a tool**: pass `annotations=READ_ONLY_TOOL` to the `@mcp.tool` decorator. Every TogoMCP tool is read-only, and MCP's default for an *unannotated* tool is the unsafe one — clients such as ChatGPT treat a tool with no `readOnlyHint` as a write action, which means a confirmation prompt on every call. A test asserts this, so omitting it fails the build.
+
+Please open an issue or pull request on GitHub.
 
 ## Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.1.2"
+version = "2.1.3"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -951,15 +951,18 @@
     </div>
 
     <div id="tab-claude" class="setup-panel active">
-      <h4>Method 1: Custom Connectors (Recommended — Claude Pro, Max, Team, or Enterprise; Free is limited to one connector)</h4>
+      <h4>Method 1: Custom Connectors (recommended — every plan)</h4>
+      <p>Available on Claude, Claude Desktop and Cowork, on <strong>all plans</strong> — Free, Pro, Max, Team and Enterprise. Free accounts may add one custom connector; the paid plans have no cap.</p>
       <ol>
-        <li>Open Claude and navigate to <strong>Settings → Connectors</strong>.</li>
-        <li>Click <strong>"Add custom connector"</strong> at the bottom of the page.</li>
+        <li>Open Claude and navigate to <strong>Settings → Customize → Connectors</strong>.</li>
+        <li>Click <strong>"+"</strong>, then <strong>"Add custom connector"</strong>.</li>
         <li>Enter the MCP server URL: <code>https://togomcp.rdfportal.org/mcp</code></li>
         <li>Click <strong>"Add"</strong> to complete the setup.</li>
         <li>In your chat interface, click the <strong>"+"</strong> button and select <strong>Connectors</strong> to enable it for the conversation.</li>
       </ol>
-      <h4>Method 2: JSON Configuration (Alternative — Claude Desktop App)</h4>
+      <p><strong>Team and Enterprise</strong> take an extra step first: an owner adds it organization-wide via <strong>Organization settings → Connectors → Add</strong>, hovering <strong>Custom</strong> and choosing <strong>Web</strong>. Members then connect it themselves under <strong>Customize → Connectors</strong>. Individual members cannot add a custom connector until the owner has done this.</p>
+      <h4>Method 2: JSON Configuration (optional — Claude Desktop only)</h4>
+      <p>Method 1 covers every plan, so this is rarely needed. It runs a local bridge (<code>mcp-remote</code>) that presents TogoMCP as a local server — useful if custom connectors are unavailable to you. It is a community tool, not an Anthropic-documented path; <code>claude_desktop_config.json</code> is otherwise for genuinely local MCP servers.</p>
       <ol>
         <li>Navigate to <strong>Settings → Developer → Edit Config</strong>. This opens <code>claude_desktop_config.json</code>.</li>
         <li>Add the following configuration:</li>

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.1.2"
+version = "2.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
**Release 2.1.3** — PATCH. Landing-page content only; no change to the served tool surface.

**2.1.2 was tagged but never deployed**, so promoting 2.1.3 delivers both the Antigravity and the Claude corrections in a single rebuild.

## Claude setup guide — three errors

Verified against [Anthropic's custom-connectors article](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp), which — unlike OpenAI's help centre — is fetchable and carries an "Updated" date, so it could be checked directly rather than from memory.

**1. Wrong settings path.** It is **Settings → Customize → Connectors → "+" → "Add custom connector"**. The page said "Settings → Connectors" with the button "at the bottom of the page".

**2. Team and Enterprise had no route at all.** An owner must add the connector organization-wide first — Organization settings → Connectors → Add → hover **Custom** → **Web** — and members then connect individually. **Members cannot self-add before that.** The page never mentioned it, so every Team/Enterprise reader was hunting for an option that could not appear for them. Same shape as the ChatGPT Plus problem fixed in 2.1.1.

**3. The heading implied paid-only** — "Claude Pro, Max, Team, or Enterprise; Free is limited to one connector". Custom connectors are available on **all** plans: Free capped at one, paid uncapped. Also on **Cowork**, not just Claude and Claude Desktop. We were discouraging Free users who would have been fine.

## Method 2 reframed

`claude_desktop_config.json` + `npx mcp-remote` is a **community bridge, not an Anthropic-documented path** — the article states that file is for genuinely local MCP servers. Now marked optional, with a note that Method 1 covers every plan, which removes the "for people without a paid plan" rationale it originally existed for. Kept rather than deleted, since `make_intro.md` specifies both methods.

## All three tabs are now first-party verified

With this release, Claude, ChatGPT and Antigravity have each been checked against the vendor's own documentation, and `make_intro.md` records the per-vendor hazard:

| Vendor | Canonical source | Hazard |
|---|---|---|
| Anthropic | `support.claude.com` | none — fetchable, dated |
| OpenAI | `help.openai.com` | Cloudflare-blocked to tools; a human must read it. The fetchable `developers.openai.com` is stale |
| Google | `antigravity.google` | several unofficial mirrors return 200 and look official; one outlived the product by six weeks |

## Release checklist

- [x] `pyproject.toml` + `uv.lock` bumped in one commit
- [x] Dated `## [2.1.3] - 2026-07-30` heading; `[Unreleased]` emptied; compare link
- [x] No `whatsnew` marker — corrects third-party setup surfaces, not a TogoMCP capability
- [x] 233 tests pass; catalog + whatsnew drift guards green
- [x] `serverInfo.version` reports `2.1.3`
- [ ] **Tag the merge commit**: `git tag v2.1.3 <merge-sha> && git push origin v2.1.3`
- [ ] Redeploy — carries both 2.1.2 and 2.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
