### PR TITLE
Release 2.2.0 — ChEMBL was silently dropping every biologic; extract mode for trial intervention strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,71 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`search_chembl_molecule(mode='extract')` — resolve drugs NAMED INSIDE a string.** Exact synonym
+  matching cannot resolve a clinical-trial intervention string, a dosed/formulated product, or a
+  multi-drug regimen, because none of those *is* a synonym: `"Ustekinumab 90 mg"`, `"Diclofenac SR"` and
+  `"Ropivacaine 10% + Clonidine 1 µg/kg"` all return zero rows under exact matching. These were **420 of
+  the 531** zero-row `search_chembl_molecule` calls in the 2026-07-27..29 logs. The new opt-in mode finds
+  every substance named inside the string and recovers **239 of the 420** (measured end-to-end through the
+  tool, 0 errors).
+  Nested synonyms collapse to the longest match, so `"Sofpironium Bromide Gel"` yields SOFPIRONIUM BROMIDE
+  and not also the bare counter-ion BROMIDE, while genuinely distinct components all survive
+  (`"Cisplatin, Vinblastine, Temozolomide"` → all three). Each result carries `matched_span` and
+  `match_type` (`exact` | `contained`) so a caller can tell a derived hit from a real one.
+  **Exact remains the default and is byte-for-byte unchanged** — this is a retry path, not a relaxation of
+  the existing contract. It is a text-extraction heuristic: measured false-positive rate ~1% (2 of 239, both
+  a plausible component picked out of a compound name), and it resolves a regimen to its *components*, so
+  it will never return "FOLFIRI" itself.
+  The remaining **181 terms are a genuine floor** — placeholders (`"Treatment A"`), procedures
+  (`"Sonoporation"`), sponsor codes ChEMBL does not carry (`BIIB023`, `VK-2019`), and vaccines
+  (`Synflorix`). No string technique reaches them.
+- **Zero-result returns now explain themselves.** An empty `search_chembl_molecule` result was
+  indistinguishable from "not in ChEMBL". Both modes now attach a `note` naming the likely cause and the
+  next step (exact → suggests `mode='extract'` for a decorated string; extract → names the regimen /
+  procedure / placeholder / absent-sponsor-code cases).
+
+### Fixed
+
+- **ChEMBL name and structure lookups silently dropped every biologic.** `search_chembl_molecule` and the
+  COMPOUND branch of `search_chembl_id_lookup` constrained matches to `?m a cco:SmallMolecule`. ChEMBL's
+  substance tree roots at `cco:Substance` (`SmallMolecule` | `Biological` | `UndefinedSubstance`), so
+  antibodies, therapeutic proteins, vaccines, oligos and cell therapies matched the synonym but failed the
+  type check and returned zero rows — no error, just an empty result that reads as "not in ChEMBL".
+  `efalizumab`, `Rituxan`→RITUXIMAB, `Nivolumab` and `filgrastim` were all unreachable by name; the
+  InChI/InChIKey path was hit too, where ~940k substances carry a key but are typed `UnknownSubstance`,
+  `ProteinMolecule`, `Oligonucleotide` or `Oligosaccharide` rather than `SmallMolecule`.
+  All three sites now match any drug-substance type. Found in the 2026-07-27..29 production tool logs
+  (531 of 854 `search_chembl_molecule` calls returned zero rows); replaying the distinct failing terms
+  against the widened type set recovered **110 real drugs**. The remainder are clinical-trial intervention
+  strings ("Modified FOLFOX6", "Ustekinumab 90 mg") that exact synonym matching is not meant to resolve.
+  `cco:TargetComponent` stays excluded so protein targets don't leak into molecule results.
+
+### Changed
+
+- **ChEMBL MIE: the same `cco:SmallMolecule` trap was in the *guidance*, not just the code.** The
+  `name_resolve` example's `traps_avoided` prescribed `?m a cco:SmallMolecule ; skos:altLabel ?alt` as the
+  brand/synonym→molecule idiom — so an LLM following the MIE reproduced the bug the code fix removed, and
+  there was no worked example for molecule name resolution at all. Added `molecule_name_resolve` (Rituxan,
+  Humira, Keytruda, Lipitor → 3 antibodies + 2 small molecules in 0.15s) with the counterfactual recorded:
+  pinning `cco:SmallMolecule` cuts the same query from 5 rows to 2. `xdb_chebi` carried the pin too and was
+  under-answering its own "approved drugs" question by 56 substances; the pin is redundant there
+  (`moleculeXref`/`highestDevelopmentPhase` are molecule-only) and is now gone. `entity_counts` gained
+  `drug_substances: 2,878,135` — the file previously reported only `small_molecules: 1,920,603`, which
+  reads as the size of ChEMBL and hides 33% of it.
+- **ChEMBL MIE: `xdb_chebi`'s `verified` block was stale.** Its recorded `first_row` (ABACAVIR, dated
+  2026-07-22) no longer reproduces — re-running the *original* query verbatim today returns
+  2-MERCAPTOETHANESULFONIC ACID first, so this is upstream drift rather than a consequence of the type-pin
+  removal. Re-verified and re-dated, with that distinction noted inline.
+- **ClinVar MIE: new `sig_by_gene` example, and a warning off the `TypeAlleleDescr` dead end.** The
+  per-gene significance breakdown — the composition of the gene pin and the classification walk — had no
+  worked example, and the plausible-looking shortcut through `cvo:TypeAlleleDescr` +
+  `cvo:clinical_significance` returns zero rows with no error for essentially every gene: of 26,161
+  `TypeAlleleDescr` nodes only 280 carry `clinical_significance`, and those 280 cover **BRCA2 and BRCA1
+  only**. That shape accounted for 340 of 341 zero-row ClinVar queries in the same production logs. The
+  correct route (via `cvo:classified_record`) answers the EGFR case in ~0.3s and now ships as a verified
+  example with the trap recorded in its `traps_avoided`.
 
 ## [2.1.3] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.2.0] - 2026-07-30
+
+<!-- whatsnew: 2026-07-30 | Drug lookups in ChEMBL now find <strong>biologics</strong> — antibodies, therapeutic proteins, vaccines and cell therapies were silently missing, so names like <em>Rituxan</em> or <em>efalizumab</em> returned nothing. A new <code>mode='extract'</code> also resolves the drugs named inside a clinical-trial intervention string such as "Ropivacaine 10% + Clonidine". -->
+
+Found by reading the production tool log rather than by a bug report: over three days,
+531 of 854 `search_chembl_molecule` calls and 341 of 351 ClinVar `run_sparql` calls
+returned zero rows. Two independent causes — one a real bug, one a documentation gap
+that made an LLM reproduce the same bug in hand-written SPARQL.
+
 ### Added
 
 - **`search_chembl_molecule(mode='extract')` — resolve drugs NAMED INSIDE a string.** Exact synonym
@@ -698,7 +709,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.1.3...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/dbcls/togomcp/compare/v2.1.3...v2.2.0
 [2.1.3]: https://github.com/dbcls/togomcp/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/dbcls/togomcp/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/dbcls/togomcp/compare/v2.1.0...v2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.1.3"
+version = "2.2.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_chembl.py
+++ b/tests/test_chembl.py
@@ -15,6 +15,8 @@ import respx
 import togo_mcp.api_tools as api_tools
 from togo_mcp.api_tools import _strip_html
 from togo_mcp.chembl import (
+    _containment_match_block,
+    _resolve_spans,
     _UNIPROT_ACCESSION_RE,
     _bif_and,
     _bif_longest_token,
@@ -495,3 +497,175 @@ class TestChemblStructureRetryAndErrorCleaning:
         html = "<div>  hello   <b>world</b> </div>"
         assert _strip_html(html) == "hello world"
         assert _strip_html("<p>" + "x" * 500 + "</p>", max_len=50).endswith("…")
+
+
+class TestBiologicsAreNotDropped:
+    """Regression: the name/structure lookups constrained matches to
+    `?m a cco:SmallMolecule`, which silently dropped EVERY biologic — antibodies,
+    therapeutic proteins, vaccines, oligos, cell therapies. Production logs for
+    2026-07-27..29 showed 531/854 `search_chembl_molecule` calls returning zero
+    rows; replaying the failures against a widened type set recovered 110 real
+    drugs (efalizumab, Rituxan→RITUXIMAB, Nivolumab, filgrastim, …).
+    """
+
+    @pytest.mark.asyncio
+    async def test_name_search_includes_biologic_types(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL1201575,EFALIZUMAB")
+                )
+            )
+            result = await search_chembl_molecule("efalizumab")
+        sent = _sent_query(route)
+        # Small molecules must still match, and the biologic branches too.
+        for frag in ("cco:SmallMolecule", "cco:Antibody", "cco:ProteinMolecule",
+                     "cco:UnknownSubstance", "cco:Vaccine", "cco:CellTherapy"):
+            assert frag in sent, frag
+        assert result["results"][0]["chembl_id"] == "CHEMBL1201575"
+
+    @pytest.mark.asyncio
+    async def test_molecule_search_excludes_target_components(self) -> None:
+        # cco:TargetComponent also carries skos:altLabel; letting it into the
+        # molecule type set would leak ~12.8k protein targets into drug results.
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(200, text=_csv("chembl_id,name"))
+            )
+            await search_chembl_molecule("EGFR")
+        assert "cco:TargetComponent" not in _sent_query(route)
+
+    @pytest.mark.asyncio
+    async def test_inchikey_lookup_includes_biologic_types(self) -> None:
+        # ~940k InChIKey-bearing substances are typed UnknownSubstance /
+        # ProteinMolecule / Oligonucleotide / Oligosaccharide, not SmallMolecule.
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL25,ASPIRIN")
+                )
+            )
+            await search_chembl_molecule("BSYNRYMUTXBXSQ-UHFFFAOYSA-N")
+        sent = _sent_query(route)
+        assert "CHEMINF_000059" in sent  # still the InChIKey value-node path
+        for frag in ("cco:SmallMolecule", "cco:UnknownSubstance",
+                     "cco:ProteinMolecule", "cco:Oligonucleotide"):
+            assert frag in sent, frag
+
+    @pytest.mark.asyncio
+    async def test_id_lookup_compound_branch_includes_biologics(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,entity_type,name,organism",
+                        "CHEMBL1201575,COMPOUND,EFALIZUMAB,",
+                    ),
+                )
+            )
+            result = await search_chembl_id_lookup("efalizumab", entity_type="compound")
+        sent = _sent_query(route)
+        assert "cco:Antibody" in sent and "cco:SmallMolecule" in sent
+        assert result["results"][0]["entity_type"] == "COMPOUND"
+
+
+class TestExtractMode:
+    """`mode='extract'` resolves substances NAMED INSIDE a string — the clinical-
+    trial intervention strings exact matching cannot resolve by design. In the
+    2026-07-27..29 logs, 420 of the 531 zero-row `search_chembl_molecule` calls
+    were of this shape; extraction recovers 239 of them.
+    """
+
+    def test_spans_collapse_nested_synonyms(self) -> None:
+        # "Sofpironium Bromide Gel" matches the full salt, the base, AND the bare
+        # counter-ion. Longest-span-first must keep only SOFPIRONIUM BROMIDE.
+        rows = [
+            {"chembl_id": "CHEMBL3707223", "name": "SOFPIRONIUM BROMIDE",
+             "alt": "sofpironium bromide"},
+            {"chembl_id": "CHEMBL3707224", "name": "SOFPIRONIUM", "alt": "sofpironium"},
+            {"chembl_id": "CHEMBL1231461", "name": "BROMIDE", "alt": "bromide"},
+        ]
+        out = _resolve_spans("Sofpironium Bromide Gel, 15%", rows)
+        assert [r["chembl_id"] for r in out] == ["CHEMBL3707223"]
+        assert out[0]["matched_span"] == "Sofpironium Bromide"
+        assert out[0]["match_type"] == "contained"
+
+    def test_spans_keep_distinct_components(self) -> None:
+        # Non-overlapping spans are genuinely different drugs — keep them all.
+        rows = [
+            {"chembl_id": "CHEMBL1077896", "name": "ROPIVACAINE", "alt": "ropivacaine"},
+            {"chembl_id": "CHEMBL134", "name": "CLONIDINE", "alt": "clonidine"},
+        ]
+        out = _resolve_spans("5 ml Ropivacaine 10% + Clonidine 1 ug/kg", rows)
+        assert [r["name"] for r in out] == ["ROPIVACAINE", "CLONIDINE"]
+
+    def test_spans_drop_unnamed_and_non_matching(self) -> None:
+        rows = [
+            # rdfs:label == its own ChEMBL id: carries no usable information.
+            {"chembl_id": "CHEMBL4248195", "name": "CHEMBL4248195", "alt": "temozolomide"},
+            {"chembl_id": "CHEMBL810", "name": "TEMOZOLOMIDE", "alt": "temozolomide"},
+            # present in the row set but not actually a substring of the query
+            {"chembl_id": "CHEMBL999", "name": "NOTHERE", "alt": "cisplatin"},
+        ]
+        out = _resolve_spans("Temozolomide 20 mg", rows)
+        assert [r["chembl_id"] for r in out] == ["CHEMBL810"]
+
+    def test_span_equal_to_whole_query_is_exact(self) -> None:
+        rows = [{"chembl_id": "CHEMBL25", "name": "ASPIRIN", "alt": "aspirin"}]
+        out = _resolve_spans("Aspirin", rows)
+        assert out[0]["match_type"] == "exact"
+
+    def test_containment_block_uses_or_and_length_floor(self) -> None:
+        block = _containment_match_block("Ropivacaine 10% + Clonidine")
+        assert " OR " in block  # any token may carry the drug (not AND)
+        assert "STRLEN" in block and "CONTAINS(" in block
+        # the exact-equality leg is OR'd back in so a short exact name survives
+        assert "LCASE(STR(?alt)) =" in block
+
+    @pytest.mark.asyncio
+    async def test_extract_mode_collapses_case_variants_server_side(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv("chembl_id,name,alt", "CHEMBL139,DICLOFENAC,diclofenac"),
+                )
+            )
+            result = await search_chembl_molecule("Diclofenac SR", mode="extract")
+        sent = _sent_query(route)
+        # LCASE in the projection is what stops case-variants from eating the
+        # row budget and silently dropping later components of a regimen.
+        assert "LCASE(STR(?alt))" in sent
+        assert result["mode"] == "extract"
+        assert result["results"][0]["chembl_id"] == "CHEMBL139"
+
+    @pytest.mark.asyncio
+    async def test_exact_mode_is_unchanged_and_is_the_default(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name", "CHEMBL25,ASPIRIN")
+                )
+            )
+            result = await search_chembl_molecule("aspirin")
+        sent = _sent_query(route)
+        assert 'FILTER(LCASE(STR(?alt)) = "aspirin")' in sent  # still exact
+        assert "mode" not in result  # exact returns the original shape
+        assert result["results"][0] == {"chembl_id": "CHEMBL25", "name": "ASPIRIN"}
+
+    @pytest.mark.asyncio
+    async def test_empty_exact_result_explains_itself(self) -> None:
+        # An empty result is otherwise indistinguishable from "not in ChEMBL".
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(200, text=_csv("chembl_id,name"))
+            )
+            result = await search_chembl_molecule("Ustekinumab 90 mg")
+        assert result["total_count"] == 0
+        assert "extract" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown mode"):
+            await search_chembl_molecule("aspirin", mode="fuzzy")

--- a/togo_mcp/chembl.py
+++ b/togo_mcp/chembl.py
@@ -94,6 +94,20 @@ _CHEMBL_TARGET_TYPES = frozenset(
 )
 
 
+# Tuning for the `extract` (containment) resolution path.
+# 5 chars: measured floor that keeps incidental synonyms ("urea", "gel") out
+# while every real drug name in the 2026-07-27..29 log sample cleared it. The
+# exact-equality leg is OR'd back in so a shorter exact name is never lost.
+_MIN_CONTAINED_LEN = 5
+# Virtuoso's free-text parser degrades on long OR disjunctions; a drug name is
+# effectively always within the first few tokens of an intervention string.
+_MAX_BIF_TOKENS = 8
+# Rows fetched before span-resolution prunes nested/duplicate hits. Generous
+# because the pruning is client-side: a 3-drug regimen can legitimately draw
+# dozens of raw synonym rows, and truncating early silently loses a component.
+_EXTRACT_ROW_BUDGET = 200
+
+
 def _bif_and(text: str) -> str | None:
     """Build a ``bif:contains`` argument from arbitrary caller text.
 
@@ -131,6 +145,89 @@ def _altlabel_match_block(query: str) -> str | None:
         f'  ?alt bif:contains "{bif}" .\n'
         f'  FILTER(LCASE(STR(?alt)) = "{_sparql_literal(query.lower())}")'
     )
+
+
+def _containment_match_block(query: str) -> str | None:
+    """WHERE-clause fragment matching ``?alt`` synonyms CONTAINED IN ``query``.
+
+    The inverse of `_altlabel_match_block`: instead of "the synonym equals the
+    caller's string", this asks "the synonym occurs inside it" — which is what
+    turns a clinical-trial intervention string ("Ropivacaine 10% + Clonidine")
+    into the substances it names. bif:contains ORs the tokens (any one may carry
+    the drug); the FILTER then does the real work.
+
+    A 5-character floor keeps incidental short synonyms out; the exact-equality
+    leg is OR'd back in so a shorter *exact* name is never lost to that floor.
+    Returns None when the query has no searchable token.
+    """
+    toks = [t for t in re.findall(r"[a-z0-9]+", query.lower()) if len(t) > 2]
+    if not toks:
+        return None
+    # Cap the OR list: Virtuoso's free-text parser degrades on very long
+    # disjunctions, and a drug name is nearly always in the first few tokens.
+    bif = " OR ".join(f"'{t}'" for t in toks[:_MAX_BIF_TOKENS])
+    q = _sparql_literal(query.lower())
+    return (
+        f'  ?alt bif:contains "{bif}" .\n'
+        f"  FILTER(\n"
+        f'    (STRLEN(STR(?alt)) >= {_MIN_CONTAINED_LEN} '
+        f'&& CONTAINS("{q}", LCASE(STR(?alt))))\n'
+        f'    || LCASE(STR(?alt)) = "{q}"\n'
+        f"  )"
+    )
+
+
+def _resolve_spans(query: str, rows: list[dict]) -> list[dict]:
+    """Reduce raw containment hits to the maximal non-overlapping drug mentions.
+
+    The endpoint returns every synonym occurring anywhere in ``query``, which
+    over-generates in two ways this collapses:
+
+    * **Nested synonyms** — "Sofpironium Bromide Gel" matches SOFPIRONIUM
+      BROMIDE, SOFPIRONIUM *and* BROMIDE (the bare counter-ion). Longest-span-
+      first selection keeps only SOFPIRONIUM BROMIDE, since the shorter spans
+      overlap it. Likewise "fexofenadine HCL" keeps the hydrochloride salt
+      rather than also emitting bare FEXOFENADINE.
+    * **Genuinely distinct components** — "Ropivacaine 10% + Clonidine" yields
+      two non-overlapping spans, so both survive: a regimen resolves to its
+      parts rather than to whichever part happened to sort first.
+
+    Rows whose rdfs:label is just the ChEMBL ID (unnamed entries) are dropped —
+    they carry no information a caller can act on.
+    """
+    low = query.lower()
+    spans: list[tuple[int, int, str, str, str]] = []
+    for r in rows:
+        alt = (r.get("alt") or "").lower()
+        cid, name = r.get("chembl_id") or "", r.get("name") or ""
+        if not alt or not cid or not name or name == cid:
+            continue
+        start = low.find(alt)
+        if start < 0:  # LCASE mismatch (accents/whitespace) — not a real span
+            continue
+        spans.append((start, start + len(alt), cid, name, alt))
+    # Longest first, so a nested synonym never displaces the phrase containing it.
+    spans.sort(key=lambda s: (-(s[1] - s[0]), s[0]))
+    taken: list[tuple[int, int, str, str, str]] = []
+    for s in spans:
+        if any(not (s[1] <= t[0] or s[0] >= t[1]) for t in taken):
+            continue
+        taken.append(s)
+    seen: set[str] = set()
+    out: list[dict] = []
+    for start, end, cid, name, alt in sorted(taken):
+        if cid in seen:
+            continue
+        seen.add(cid)
+        out.append(
+            {
+                "chembl_id": cid,
+                "name": name,
+                "matched_span": query[start:end],
+                "match_type": "exact" if alt == low else "contained",
+            }
+        )
+    return out
 
 
 async def _run_chembl_sparql(query: str) -> list[dict] | dict:
@@ -180,6 +277,41 @@ _CHEMINF = {
     "inchikey": "http://semanticscience.org/resource/CHEMINF_000059",
     "inchi": "http://semanticscience.org/resource/CHEMINF_000113",
 }
+
+# Every drug-substance type a name/structure lookup may legitimately return.
+# ChEMBL's substance tree roots at cco:Substance (SmallMolecule | Biological |
+# UndefinedSubstance); a bare `?m a cco:SmallMolecule` therefore drops EVERY
+# biologic — antibodies, therapeutic proteins, vaccines, oligos, cell therapies —
+# so "efalizumab", "Rituxan" and ~1M other substances resolved to zero rows.
+#
+# Enumerated rather than matched with `?t rdfs:subClassOf* cco:Substance` for two
+# reasons: the property path costs ~17s vs ~0.15s for VALUES, and cco:Unclassified-
+# Molecule (390 instances) is orphaned in the ontology — it has no subClassOf edge,
+# so the path would silently miss it. Verified against the live endpoint 2026-07-30.
+#
+# cco:TargetComponent is deliberately EXCLUDED: it carries skos:altLabel and would
+# otherwise leak ~12.8k protein targets into molecule results (use search_chembl_target).
+_CHEMBL_MOLECULE_TYPES = (
+    "cco:SmallMolecule cco:Inorganic cco:NaturalProductDerived cco:Synthetic "
+    "cco:Biological cco:ProteinMolecule cco:Oligonucleotide cco:Oligosaccharide "
+    "cco:Enzyme cco:CellTherapy cco:Vaccine cco:Virus "
+    "cco:Antibody cco:Mab cco:Fab cco:FabPrime cco:FabPrime2 cco:ScFv cco:DiScFv "
+    "cco:SdAb cco:BiTE cco:Immunoadhesin cco:IIIfunct "
+    "cco:UndefinedSubstance cco:UnknownSubstance cco:UnclassifiedSubstance "
+    "cco:UnclassifiedMolecule"
+)
+
+
+def _molecule_type_block(var: str, *, indent: str = "  ") -> str:
+    """SPARQL constraining ``var`` to any ChEMBL drug-substance type.
+
+    Replaces a hard-coded ``a cco:SmallMolecule`` so biologics resolve too.
+    """
+    tvar = f"?_{var.lstrip('?')}_type"
+    return (
+        f"{indent}{var} a {tvar} .\n"
+        f"{indent}VALUES {tvar} {{ {_CHEMBL_MOLECULE_TYPES} }}"
+    )
 
 
 def _looks_like_structure(query: str) -> str | None:
@@ -258,8 +390,9 @@ async def _search_chembl_inchi_sparql(
         f"  ?node a <{_CHEMINF[kind]}> ; sio:SIO_000300 ?v .\n"
         f'  ?v bif:contains "{prefilter}" .\n'
         f'  FILTER(STR(?v) = "{_sparql_literal(query)}")\n'
-        f"  ?m sio:SIO_000008 ?node ; a cco:SmallMolecule ;\n"
-        f"     cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        f"  ?m sio:SIO_000008 ?node .\n"
+        f"{_molecule_type_block('?m')}\n"
+        f"  ?m cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
         f"}} LIMIT {int(limit)}"
     )
     return await _run_chembl_sparql(sparql)
@@ -382,7 +515,8 @@ async def search_chembl_id_lookup(
         "COMPOUND": exact_branch(
             "COMPOUND",
             "?e skos:altLabel ?alt .",
-            "?e a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .",
+            f"{_molecule_type_block('?e', indent='').lstrip()}\n"
+            "    ?e cco:chemblId ?chembl_id ; rdfs:label ?name .",
             prefilter=True,
             has_organism=False,  # molecules have no organism
         ),
@@ -615,10 +749,54 @@ async def search_chembl_target(
     }
 
 
+async def _extract_chembl_molecules(query: str, limit: int) -> dict:
+    """Resolve every ChEMBL substance NAMED INSIDE ``query`` (mode='extract').
+
+    For clinical-trial intervention strings and dosed/formulated product names,
+    which exact synonym matching cannot resolve by design: "Ropivacaine 10% +
+    Clonidine 1 ug/kg" is not a synonym of anything, but it names two substances.
+    """
+    match = _containment_match_block(query)
+    if match is None:
+        return {"total_count": 0, "has_more": False, "results": [], "mode": "extract"}
+    # LCASE(?alt) collapses case-variant synonyms server-side. Without it the row
+    # budget is spent on ("Temozolomide","TEMOZOLOMIDE","temozolomide") and later
+    # components of a regimen fall off the end of the LIMIT.
+    sparql = (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"SELECT DISTINCT ?chembl_id ?name (LCASE(STR(?alt)) AS ?alt)\n"
+        f"FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"  ?m skos:altLabel ?alt .\n"
+        f"{match}\n"
+        f"{_molecule_type_block('?m')}\n"
+        f"  ?m cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        f"}} LIMIT {_EXTRACT_ROW_BUDGET}"
+    )
+    rows = await _run_chembl_sparql(sparql)
+    if isinstance(rows, dict):
+        return rows  # {"error": ...}
+    results = _resolve_spans(query, rows)
+    results, has_more = _paginate(results, limit)
+    out = {
+        "total_count": len(results),
+        "has_more": has_more,
+        "results": results,
+        "mode": "extract",
+    }
+    if not results:
+        out["note"] = (
+            f"No ChEMBL substance is named inside {query!r}. It may be a regimen "
+            "acronym (FOLFIRI), a procedure, a placeholder ('Treatment A'), or a "
+            "sponsor code ChEMBL does not carry."
+        )
+    return out
+
+
 @mcp.tool(annotations=READ_ONLY_TOOL)
 async def search_chembl_molecule(
     query: str = "",
     limit: int = 20,
+    mode: str = "exact",
     search: str = "",
     term: str = "",
     keyword: str = "",
@@ -656,18 +834,38 @@ async def search_chembl_molecule(
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
+    ⚠️ `mode='extract'` — for a string that NAMES a drug rather than IS one.
+       Exact matching (the default) cannot resolve a clinical-trial intervention
+       string, a dosed/formulated product, or a multi-drug regimen, because none
+       of those is a synonym of anything: "Ustekinumab 90 mg", "Diclofenac SR",
+       "Ropivacaine 10% + Clonidine 1 µg/kg" all return 0 rows under 'exact'.
+       `mode='extract'` instead finds every substance NAMED INSIDE the string,
+       returning one result per distinct drug — so the combination above yields
+       ROPIVACAINE and CLONIDINE. Nested synonyms collapse to the longest match
+       ("Sofpironium Bromide Gel" → SOFPIRONIUM BROMIDE, not also BROMIDE).
+       Use it as the RETRY when 'exact' returns nothing, not as the first call:
+       it is a text-extraction heuristic, so treat a hit as a candidate to
+       confirm, and note that it resolves a regimen to its COMPONENTS — it will
+       never return "FOLFIRI" itself, only the drugs a string spells out.
+
     RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is rows
     RETURNED (capped by `limit`), not the full match count; `has_more` is true if
     more exist beyond this page. Each result has 'chembl_id' (e.g. "CHEMBL25") and
-    'name' (rdfs:label, may be None for some structure hits). On endpoint/HTTP
-    failure this tool does NOT raise — it returns a dict with a single 'error' key
-    instead; CHECK FOR 'error' BEFORE READING 'results'.
+    'name' (rdfs:label, may be None for some structure hits). Under
+    `mode='extract'` each result additionally carries 'matched_span' (the text
+    that matched) and 'match_type' ('exact' if the span is the whole query,
+    else 'contained') — CHECK 'match_type' before trusting a hit. When a call
+    returns no results, a 'note' key explains why and what to try next. On
+    endpoint/HTTP failure this tool does NOT raise — it returns a dict with a
+    single 'error' key instead; CHECK FOR 'error' BEFORE READING 'results'.
 
     Args:
         query (str): Drug/compound name, brand, synonym, or a structure string.
             Examples: "Aspirin", "Gleevec", "CC(=O)Oc1ccccc1C(=O)O",
             "BSYNRYMUTXBXSQ-UHFFFAOYSA-N".
         limit (int, optional): Maximum number of results to return. Defaults to 20.
+        mode (str, optional): "exact" (default) matches the WHOLE string against a
+            synonym; "extract" finds substances named INSIDE it. Defaults to "exact".
     """
     query = _resolve_query_alias(
         query,
@@ -683,6 +881,14 @@ async def search_chembl_molecule(
             "Missing search string. Pass it as `query` (canonical) or any of: "
             "search, term, keyword, keywords, search_term, name."
         )
+    mode = (mode or "exact").strip().lower()
+    if mode not in ("exact", "extract"):
+        raise ValueError(
+            f"Unknown mode {mode!r}. Use 'exact' (default: the whole string must "
+            "BE a synonym) or 'extract' (find substances NAMED INSIDE the string)."
+        )
+    if mode == "extract":
+        return await _extract_chembl_molecules(query, int(limit))
     # Structure-shaped input.
     structure_kind = _looks_like_structure(query)
     if structure_kind == "smiles":
@@ -731,7 +937,8 @@ async def search_chembl_molecule(
         f"SELECT DISTINCT ?chembl_id ?name FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
         f"  ?m skos:altLabel ?alt .\n"
         f"{match}\n"
-        f"  ?m a cco:SmallMolecule ; cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
+        f"{_molecule_type_block('?m')}\n"
+        f"  ?m cco:chemblId ?chembl_id ; rdfs:label ?name .\n"
         f"}} LIMIT {int(limit) + 1}"
     )
     rows = await _run_chembl_sparql(sparql)
@@ -742,8 +949,20 @@ async def search_chembl_molecule(
         {"chembl_id": r.get("chembl_id"), "name": r.get("name")}
         for r in rows
     ]
-    return {
+    out = {
         "total_count": len(parsed_results),
         "has_more": has_more,
         "results": parsed_results,
     }
+    if not parsed_results:
+        # An empty exact match is indistinguishable from "not in ChEMBL" unless
+        # we say why. The dominant real-world cause is a decorated string (dose,
+        # formulation, regimen) that is not itself a synonym of anything.
+        out["note"] = (
+            f"0 EXACT synonym matches for {query!r}. ChEMBL indexes single "
+            "substances, not regimens or dosed/formulated products. If this "
+            "string carries a dose, a formulation, or several drugs "
+            "(\"Ustekinumab 90 mg\", \"Ropivacaine 10% + Clonidine\"), retry "
+            "with mode='extract' to resolve the substances named inside it."
+        )
+    return out

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -768,6 +768,10 @@
     <ul class="whatsnew-list">
       <!-- WHATSNEW:START -->
       <li>
+        <span class="whatsnew-date">2026-07-30</span>
+        <span>Drug lookups in ChEMBL now find <strong>biologics</strong> — antibodies, therapeutic proteins, vaccines and cell therapies were silently missing, so names like <em>Rituxan</em> or <em>efalizumab</em> returned nothing. A new <code>mode='extract'</code> also resolves the drugs named inside a clinical-trial intervention string such as "Ropivacaine 10% + Clonidine".</span>
+      </li>
+      <li>
         <span class="whatsnew-date">2026-07-29</span>
         <span>All tools now declare themselves <strong>read-only</strong> in the MCP protocol, so clients such as ChatGPT no longer treat every query as a write action needing confirmation.</span>
       </li>

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -35,7 +35,11 @@ graphs:
     ensembl: "co-hosted but NOT directly joinable from ChEMBL IRIs — bridge gene/protein IDs via TogoID."
 
 entity_counts:                     # COUNT(DISTINCT), FROM-pinned; re-run live 2026-07-22
-  small_molecules:        1920603  # cco:SmallMolecule
+  drug_substances:        2878135  # ALL of cco:Substance's leaf types — the real "how many molecules" figure (2026-07-30)
+  small_molecules:        1920603  # cco:SmallMolecule — only 67% of the above; the rest are biologics + UnknownSubstance
+  biologics_and_other:    957532   # UnknownSubstance 932,685 · ProteinMolecule 22,870 · Antibody 1,032 · Unclassified-
+                                   # Molecule 390 · Oligonucleotide 260 · Enzyme 129 · CellTherapy 85 · Oligosaccharide 81
+                                   # (2026-07-30) — NEVER equate "molecule" with cco:SmallMolecule (example molecule_name_resolve)
   assays:                 1890749  # cco:Assay (~100% carry dcterms:description)
   single_protein_targets: 10962    # cco:SingleProtein — the UniProt-mappable / classifiable target subset (17,803 across ALL cco:targetType)
   mechanisms:             7568     # cco:Mechanism (curated MoA link — bounded; use it, not the 21M-row activity fan-out)
@@ -140,7 +144,37 @@ examples:
     verified: {result_rows: 1, date: "2026-07-22", first_row: "CHEMBL210 = Beta-2 adrenergic receptor"}
     teaches: "Gene symbol → target: altLabel is on the target COMPONENT (?target cco:hasTargetComponent ?c . ?c skos:altLabel …). bif:contains prefilters via the text index (~0.1s) then FILTER pins exactness; a bare FILTER(CONTAINS()) scans ~1.8M altLabels (~11s, near timeout). SINGLE PROTEIN + Homo sapiens collapses orthologs/complexes to the one target."
     traps_avoided:
-      - "Brand/synonym → MOLECULE uses the same idiom but altLabel sits on the molecule itself: ?m a cco:SmallMolecule ; skos:altLabel ?alt . ?alt bif:contains \"...\" — NOT on a component."
+      - "Brand/synonym → MOLECULE uses the same idiom but altLabel sits on the molecule ITSELF (?m skos:altLabel ?alt), not on a component — and the molecule's type must NOT be pinned to cco:SmallMolecule. See molecule_name_resolve."
+
+  - id: molecule_name_resolve
+    intent: resolve a brand / trade name to a ChEMBL molecule — INCLUDING biologics (the type-safe route)
+    question: "Which ChEMBL molecules are Rituxan, Humira, Keytruda and Lipitor?"
+    complexity: basic
+    sparql: |
+      PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT DISTINCT ?chembl_id ?name ?substance_type
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        VALUES ?brand { "rituxan" "humira" "keytruda" "lipitor" }
+        ?m skos:altLabel ?alt .                 # altLabel is on the MOLECULE (brand + trade names live here)
+        ?alt bif:contains "'rituxan' OR 'humira' OR 'keytruda' OR 'lipitor'" .
+        FILTER(LCASE(STR(?alt)) = ?brand)       # bif:contains prefilters; FILTER pins exactness
+        ?m a ?substance_type .                  # do NOT write `a cco:SmallMolecule` here — see traps_avoided
+        VALUES ?substance_type { cco:SmallMolecule cco:Antibody cco:ProteinMolecule
+                                 cco:Oligonucleotide cco:Oligosaccharide cco:Enzyme
+                                 cco:CellTherapy cco:Vaccine cco:UnknownSubstance
+                                 cco:UnclassifiedMolecule }
+        ?m cco:chemblId ?chembl_id ; rdfs:label ?name .
+      }
+      ORDER BY ?name
+    verified: {result_rows: 5, date: "2026-07-30", rows: "CHEMBL1201580 ADALIMUMAB (Antibody); CHEMBL1487 ATORVASTATIN + CHEMBL393220 ATORVASTATIN CALCIUM (SmallMolecule); CHEMBL3137343 PEMBROLIZUMAB (Antibody); CHEMBL1201576 RITUXIMAB (Antibody)", runtime: "0.15s"}
+    teaches: "Brand → molecule is an EXACT match on skos:altLabel (trade names are stored there), prefiltered by bif:contains. Binding ?substance_type to the VALUES list instead of pinning one class both keeps biologics in and returns the type as a free column — useful because the answer's shape differs per type (an Antibody has no InChI/SMILES)."
+    traps_avoided:
+      - "`?m a cco:SmallMolecule` DROPS EVERY BIOLOGIC — silently, with no error. ChEMBL's substance tree roots at cco:Substance (SmallMolecule | Biological | UndefinedSubstance), and antibodies/proteins/vaccines/oligos/cell therapies sit under Biological. Verified 2026-07-30: this query returns 5 rows; pinning cco:SmallMolecule returns 2 (only the atorvastatins) — Rituxan, Humira and Keytruda vanish. SmallMolecule is just 1,920,603 of 2,878,135 substances (67%)."
+      - "`?t rdfs:subClassOf* cco:Substance` looks like the elegant fix but is a bad trade: ~17s vs ~0.15s for the VALUES list, and cco:UnclassifiedMolecule (390 instances) has NO subClassOf edge at all, so the path silently misses it. There is also NO RDFS inference on this endpoint — `?m a cco:Substance` matches nothing (verified 2026-07-30)."
+      - "cco:TargetComponent ALSO carries skos:altLabel — leaving the type unconstrained entirely leaks ~12.8k protein targets into molecule results. Keep the VALUES list; for targets use name_resolve."
 
   - id: molecule_structure
     intent: SMILES / InChIKey / formula / MW of a molecule via the SIO qualified-value nodes
@@ -258,8 +292,11 @@ examples:
       SELECT DISTINCT ?moleculeLabel ?chebiLabel ?formula ?mass
       WHERE {
         GRAPH <http://rdf.ebi.ac.uk/dataset/chembl> {
-          ?molecule a cco:SmallMolecule ; rdfs:label ?moleculeLabel ;
-                    cco:moleculeXref ?xref ; cco:highestDevelopmentPhase 4 .   # phase=4 pre-filter: 1.9M → ~4k
+          # No `a cco:SmallMolecule` pin — it would drop 56 approved biologics that DO carry a
+          # ChEBI xref (50 ProteinMolecule, 4 UnknownSubstance, 2 Oligosaccharide). moleculeXref +
+          # highestDevelopmentPhase are molecule-only predicates, so the type constraint is redundant here.
+          ?molecule rdfs:label ?moleculeLabel ;
+                    cco:moleculeXref ?xref ; cco:highestDevelopmentPhase 4 .   # phase=4 pre-filter: 2.9M → ~2.5k
           FILTER(CONTAINS(STR(?xref), "chebi/searchId"))
           # cco:moleculeXref is an EBI WEB URL (…searchId.do?chebiId=CHEBI%3ANNN) — rebuild the obo IRI to join:
           BIND(IRI(CONCAT("http://purl.obolibrary.org/obo/CHEBI_",
@@ -273,7 +310,7 @@ examples:
       }
       ORDER BY ?moleculeLabel
       LIMIT 50
-    verified: {result_rows: 50, date: "2026-07-22", first_row: "ABACAVIR → 'abacavir' C14H18N6O, 286.339"}
+    verified: {result_rows: 50, date: "2026-07-30", first_row: "2-MERCAPTOETHANESULFONIC ACID → 'coenzyme M' C2H6O3S2, 142.201", note: "the 2026-07-22 first_row (ABACAVIR) was stale — re-running the ORIGINAL query today also returns 2-MERCAPTOETHANESULFONIC ACID first, so this is upstream drift, not the type-pin removal"}
     teaches: "Molecule→ChEBI is cco:moleculeXref, but it stores an EBI web URL, NOT the obo:CHEBI_ IRI — BIND+REPLACE rebuilds purl.obolibrary.org/obo/CHEBI_N to join. On the ChEBI side use the chemrof: namespace (chemrof:mass / chemrof:generalized_empirical_formula); the old chebi:formula/chebi:mass were removed upstream (0 rows)."
     traps_avoided:
       - "skos:exactMatch does NOT link a molecule to ChEBI — it is ONLY on TargetComponent (→UniProt). Using it here returns 0 rows silently; use cco:moleculeXref."

--- a/togo_mcp/data/mie/clinvar.yaml
+++ b/togo_mcp/data/mie/clinvar.yaml
@@ -142,6 +142,38 @@ examples:
       - "THREE classification BRANCHES exist under cvo:classifications: cvo:germline_classification, cvo:oncogenicity_classification, cvo:somatic_clinical_impact. This query enumerates ONLY germline; a cancer/somatic variant classified 'Oncogenic' has NO germline node and is silently absent (see oncogenicity_kras for the other two branches)."
       - "Omitting cvo:record_type \"classified\" lets the 712 'included' variants (no classified_record) enter the pattern and adds nothing but risk (gotcha included_no_classrec)."
 
+  - id: sig_by_gene
+    intent: significance breakdown for ONE gene — the gene pin and the classification walk composed in one query
+    question: "How many EGFR variants fall in each germline clinical-significance class?"
+    complexity: aggregation
+    sparql: |
+      PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX sio: <http://semanticscience.org/resource/>
+      # Gene IRI = http://ncbi.nlm.nih.gov/gene/{NCBI gene id}; resolve the id with
+      # ncbi_esearch('gene','EGFR[sym] AND human[organism]') — never text-match rdfs:label.
+      SELECT ?significance (COUNT(DISTINCT ?variant) AS ?n)
+      FROM <http://rdfportal.org/dataset/clinvar>
+      WHERE {
+        ?gene_bn med2rdf:gene <http://ncbi.nlm.nih.gov/gene/1956> .   # EGFR
+        ?classrec sio:SIO_000628 ?gene_bn .
+        ?variant a cvo:VariationArchiveType ;
+                 cvo:record_status "current" ;
+                 cvo:record_type "classified" ;
+                 cvo:classified_record ?classrec .
+        ?classrec cvo:classifications ?classi .
+        ?classi cvo:germline_classification ?germ .
+        ?germ cvo:description ?significance .
+      }
+      GROUP BY ?significance
+      ORDER BY DESC(?n)
+      LIMIT 20
+    verified: {result_rows: 12, date: "2026-07-30", top: "Uncertain significance 1,570; Likely benign 1,309; Conflicting classifications of pathogenicity 155; Benign/Likely benign 120; Benign 107; Pathogenic 80", runtime: "0.3s"}
+    teaches: "The per-gene significance question is the two walks COMPOSED, both hanging off the SAME ?classrec bnode: enter at the gene (med2rdf:gene → sio:SIO_000628 → ?classrec) and read the classification off that same node. Anchoring on the gene IRI first prunes 3.59M variants before the classification join, so the whole query runs in well under a second."
+    traps_avoided:
+      - "DO NOT reach significance via cvo:TypeAlleleDescr + cvo:clinical_significance — it is a near-empty dead end that returns 0 rows with NO error for almost every gene. Verified 2026-07-30: of 26,161 cvo:TypeAlleleDescr nodes only 280 carry cvo:clinical_significance, and those 280 cover BRCA2 (190) and BRCA1 (90) and NOTHING ELSE — so the identical query for EGFR (or any other gene) returns 0. Significance lives on the classification bnode reached through cvo:classified_record, as above. This shape accounted for 340 of 341 zero-row ClinVar queries in the 2026-07-27..29 production logs."
+      - "cvo:name on a TypeAlleleDescr node is \"SYMBOL:c.HGVS\" (e.g. \"BTK:c.1899C>T\"), which makes STRSTARTS(?name, \"EGFR:\") LOOK like a valid gene filter. It is not a substitute for the gene IRI — besides the sparsity above, it is free text with no controlled vocabulary."
+
   - id: count_variation_type
     intent: distribution of active variants across variation types (a typed-predicate aggregation)
     question: "What variation types exist in ClinVar and how many of each?"

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.1.3"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Found by reading the production tool log (`togomcp.jsonl`, 2026-07-27..29) rather than from a bug
report. Over three days **531 of 854** `search_chembl_molecule` calls and **341 of 351** ClinVar
`run_sparql` calls returned zero rows. Two independent causes: one a real bug, one a documentation
gap that made an LLM reproduce the same bug in hand-written SPARQL.

## ChEMBL — the bug

The name and structure lookups constrained matches to `?m a cco:SmallMolecule`. ChEMBL's substance
tree roots at `cco:Substance` (`SmallMolecule` | `Biological` | `UndefinedSubstance`), so **every
biologic matched the synonym and then failed the type check** — returning empty with no error, which
reads as "not in ChEMBL". `efalizumab`, `Rituxan`→RITUXIMAB, `Nivolumab` and `filgrastim` were all
unreachable by name.

The InChI/InChIKey path was hit too: ~940k substances carry a key but are typed `UnknownSubstance`,
`ProteinMolecule`, `Oligonucleotide` or `Oligosaccharide`. Replaying the distinct failing terms
against a widened type set **recovered 110 real drugs**.

Types are enumerated rather than matched with `rdfs:subClassOf* cco:Substance`: the property path
costs **~17s vs ~0.15s**, and `cco:UnclassifiedMolecule` is orphaned in the ontology so the path
would silently miss it. `cco:TargetComponent` stays excluded so protein targets don't leak into
molecule results.

## The same trap was in the MIE, as prescriptive guidance

`chembl.yaml` told callers to write `?m a cco:SmallMolecule ; skos:altLabel ?alt` for
brand/synonym resolution, and carried **no worked example for molecule name resolution at all**.
Fixing only the code would have left the defect fully intact on the SPARQL path.

- Added `molecule_name_resolve` with the counterfactual recorded: 5 rows, or **2** if the type is
  pinned — Rituxan, Humira and Keytruda vanish with no error.
- `xdb_chebi` carried the pin too and was under-answering its own *"approved drugs"* question by 56
  substances. The pin is redundant there (`moleculeXref`/`highestDevelopmentPhase` are molecule-only).
- `entity_counts` reported only `small_molecules: 1,920,603`, which reads as the size of ChEMBL and
  hides a third of it. `drug_substances: 2,878,135` added.
- Re-verified a **stale `verified:` block** in `xdb_chebi`: its recorded `first_row` no longer
  reproduces, and running the *original* query verbatim today returns the same new row — upstream
  drift, not a consequence of this change. Noted inline so nobody re-investigates it.

## `mode='extract'` — the 420 exact matching can't resolve

Most remaining empties are clinical-trial intervention strings that are not synonyms of anything
(`"Ustekinumab 90 mg"`, `"Diclofenac SR"`, `"Ropivacaine 10% + Clonidine 1 µg/kg"`). The new opt-in
mode resolves the substances *named inside* such a string and **recovers 239 of the 420**, measured
end-to-end through the tool with 0 errors.

```
"Ropivacaine 10% + Clonidine 1 µg/kg"  → ROPIVACAINE, CLONIDINE
"Cisplatin, Vinblastine, Temozolomide" → CISPLATIN, VINBLASTINE, TEMOZOLOMIDE
"Sofpironium Bromide Gel, 15%"         → SOFPIRONIUM BROMIDE   (not also BROMIDE)
```

Nested synonyms collapse to the longest match; genuinely distinct components all survive. **Exact
remains the default and is byte-for-byte unchanged** — this is a retry path, not a relaxation of the
existing contract, and a test pins that. Every extract hit carries `matched_span` and `match_type`
so a caller can tell a derived hit from a real one. Measured false-positive rate **~1%** (2 of 239).

Zero-result returns now attach a `note` explaining the likely cause and the next step; previously an
empty result was indistinguishable from "not in ChEMBL", which is what let this class of failure stay
invisible.

The remaining **181 are a genuine floor** — placeholders (`"Treatment A"`), procedures
(`"Sonoporation"`), sponsor codes ChEMBL doesn't carry (`BIIB023`), vaccines (`Synflorix`).

## ClinVar — no code change needed

Two early hypotheses were both wrong on checking: the missing `FROM` clause is harmless (the
endpoint's default graph includes ClinVar), and `cvo:TypeAlleleDescr` is a real class, not
hallucinated. The actual cause is sparsity: of 26,161 `TypeAlleleDescr` nodes only **280** carry
`cvo:clinical_significance`, and those 280 cover **BRCA2 and BRCA1 only** — so that query shape
*must* return 0 for every other gene.

All of it is one automated client: **1,518 calls across 1,518 single-call sessions**, two tools, zero
`get_MIE_file` reads. Not something server behavior can steer — but the documentation gap was real, so
`clinvar.yaml` gains a verified `sig_by_gene` example (the correct route answers the EGFR case in
~0.3s) with the dead end recorded in its `traps_avoided`.

## Verification

- 246 tests pass (10 new; the span logic is pure-function tested without HTTP).
- Both MIEs re-validated live via `check_mie_examples.py`: **8/8** clinvar, **11/11** chembl, 0
  zero-row, 0 error. `examples` byte share rose in both (65.7→70.5%, 72.6→76.4%).
- New example subjects checked against `benchmark/questions/*.yaml` for leakage.
- `mode` confirmed present in the served tool schema with its description and default.
- MINOR under the agent-pragmatic policy: a new optional parameter, old calls unaffected.

> Tag `v2.2.0` on the merge commit after merging (CLAUDE.md release step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
