### PR TITLE
Release 2.2.1 — SPARQL timeout sat inside the endpoints' cold-cache band; raw-log download on /stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 _Nothing yet._
 
+## [2.2.1] - 2026-07-30
+
+### Fixed
+
+- **A 60s SPARQL timeout sat inside the endpoints' cold-cache band, so valid queries failed by chance.**
+  RDF Portal endpoints charge a large penalty on the *first* touch of an entity's index pages. Measured
+  on the SIB endpoint across five never-queried UniProt accessions, a **minimal** single-protein lookup
+  (one IRI, `LIMIT 5`) took **53.9–62.1s cold and 0.2s warm**. The client ceiling was exactly 60.0s —
+  inside that spread — so whether a perfectly good query succeeded was a coin flip. Two such lookups
+  timed out in production on 2026-07-27. Raised to **90s**, which clears the observed cold maximum with
+  headroom while still cutting off genuinely runaway queries.
+  Raising the ceiling is the fix precisely *because* retrying is not: an **aborted** query does not warm
+  the cache (verified — abort at 20s, retry still 55.3s), so only a query allowed to *complete* pays the
+  cost once on behalf of every query after it.
+- **The timeout message diagnosed the wrong cause and forbade the one thing that would have worked.** It
+  asserted "the query is likely too heavy", told the caller to add `LIMIT` and narrow with specific IRIs,
+  and ended "Do not retry the same query without changes" — advice that is impossible to follow for a
+  query that is *already* a single IRI with `LIMIT 5`. The logs show an agent obeying it faithfully:
+  it simplified a 26-predicate query down to 8 predicates and timed out again 74 seconds later. The
+  message now names both causes, says which is likelier, and permits exactly one retry rather than
+  banning it outright — while keeping the narrow-it guidance, which remains correct for genuinely heavy
+  queries (the same log's MassBank timeout is a 4-way `mb:has_peak` self-join, and that advice fits it).
+
 ## [2.2.0] - 2026-07-30
 
 <!-- whatsnew: 2026-07-30 | Drug lookups in ChEMBL now find <strong>biologics</strong> — antibodies, therapeutic proteins, vaccines and cell therapies were silently missing, so names like <em>Rituxan</em> or <em>efalizumab</em> returned nothing. A new <code>mode='extract'</code> also resolves the drugs named inside a clinical-trial intervention string such as "Ropivacaine 10% + Clonidine". -->
@@ -709,7 +732,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/dbcls/togomcp/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/dbcls/togomcp/compare/v2.1.3...v2.2.0
 [2.1.3]: https://github.com/dbcls/togomcp/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/dbcls/togomcp/compare/v2.1.1...v2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ _Nothing yet._
 
 ## [2.2.1] - 2026-07-30
 
+### Added
+
+- **`GET /stats/log` — download the raw JSONL tool-call log, linked from the top of `/stats`.** The
+  dashboard's tables are lossy roll-ups, and the failures worth finding tend not to be the ones already
+  tabulated: 2.2.0 came out of reading the raw log directly, where a 62% zero-row rate on one tool and a
+  single repeated dead-end query shape were plainly visible while every pre-computed table showed them as
+  unremarkable traffic. This makes that escape hatch a link instead of an SSH session.
+  Serves the *same* files `compute_stats` aggregates — active plus every rotated sibling, concatenated
+  oldest-first — so a download is verifiably the input the dashboard's numbers came from; serving only the
+  active file would silently under-report against the tables above it. Streamed in chunks rather than read
+  into memory (the log reaches ~550 MB across rotations), with `X-Log-Bytes`/`X-Log-Files` headers and no
+  `Content-Length`, since rotation can change the real length mid-stream.
+  Behind the **same HTTP Basic gate as `/stats`**: 503 when `TOGOMCP_STATS_USER`/`TOGOMCP_STATS_PASSWORD`
+  are unset (never an unauthenticated fallback), 401 without valid credentials, 404 when no log exists.
+  The served path comes from `TOGOMCP_QUERY_LOG` only — nothing is caller-supplied, so there is no
+  traversal surface. Documented in `log_file_specs.md`.
+  Still PATCH: the semver policy scopes the public contract to the *tool surface* (tool names, parameters,
+  return shapes), and this adds no tool and changes no return shape.
+
 ### Fixed
 
 - **A 60s SPARQL timeout sat inside the endpoints' cold-cache band, so valid queries failed by chance.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.2.0"
+version = "2.2.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -607,3 +607,83 @@ class TestSparqlTimeout:
         assert "TOO HEAVY" in msg and "COLD" in msg  # both causes offered
         assert "retry at most ONCE" in msg  # bounded retry, not a blanket ban
         assert "90" in msg  # reports the real ceiling
+
+
+class TestRawLogDownload:
+    """/stats/log streams the raw JSONL behind the same Basic auth as /stats.
+
+    The dashboard's tables are lossy roll-ups. Release 2.2.0 came out of reading
+    the raw log directly — it surfaced two silent zero-row bugs and a timeout
+    misdiagnosis that every aggregate had shown as unremarkable — so the escape
+    hatch is the point of the feature, not a nicety.
+    """
+
+    @staticmethod
+    def _client(tmp_path, monkeypatch, *, rotated: bool = True, auth: bool = True):
+        import json as _json
+
+        from starlette.testclient import TestClient
+
+        from togo_mcp.main import mcp
+
+        active = tmp_path / "log.jsonl"
+        # ts values chosen so a chronological stream is oldest-first.
+        active.write_text(_json.dumps({"ts": "2026-07-30T00:00:00+00:00", "n": 3}) + "\n")
+        if rotated:
+            (tmp_path / "log.jsonl.1").write_text(
+                _json.dumps({"ts": "2026-07-28T00:00:00+00:00", "n": 1}) + "\n"
+                + _json.dumps({"ts": "2026-07-29T00:00:00+00:00", "n": 2}) + "\n"
+            )
+        monkeypatch.setenv("TOGOMCP_QUERY_LOG", str(active))
+        if auth:
+            monkeypatch.setenv("TOGOMCP_STATS_USER", "u")
+            monkeypatch.setenv("TOGOMCP_STATS_PASSWORD", "p")
+        else:
+            monkeypatch.delenv("TOGOMCP_STATS_USER", raising=False)
+            monkeypatch.delenv("TOGOMCP_STATS_PASSWORD", raising=False)
+        return TestClient(mcp.http_app())
+
+    def test_requires_auth(self, tmp_path, monkeypatch) -> None:
+        with self._client(tmp_path, monkeypatch) as c:
+            assert c.get("/stats/log").status_code == 401
+            assert c.get("/stats/log", auth=("u", "nope")).status_code == 401
+
+    def test_refuses_when_stats_not_configured(self, tmp_path, monkeypatch) -> None:
+        # Never expose the log just because credentials happen to be unset.
+        with self._client(tmp_path, monkeypatch, auth=False) as c:
+            assert c.get("/stats/log").status_code == 503
+
+    def test_streams_all_files_oldest_first(self, tmp_path, monkeypatch) -> None:
+        import json as _json
+
+        with self._client(tmp_path, monkeypatch) as c:
+            r = c.get("/stats/log", auth=("u", "p"))
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("application/x-ndjson")
+        assert "attachment" in r.headers["content-disposition"]
+        assert r.headers["x-log-files"] == "2"
+        rows = [_json.loads(x) for x in r.text.splitlines() if x.strip()]
+        # Rotated siblings must be included, or the download silently under-
+        # reports versus the dashboard that aggregates them.
+        assert [x["n"] for x in rows] == [1, 2, 3]
+
+    def test_404_when_no_log_exists(self, tmp_path, monkeypatch) -> None:
+        from starlette.testclient import TestClient
+
+        from togo_mcp.main import mcp
+
+        monkeypatch.setenv("TOGOMCP_QUERY_LOG", str(tmp_path / "absent.jsonl"))
+        monkeypatch.setenv("TOGOMCP_STATS_USER", "u")
+        monkeypatch.setenv("TOGOMCP_STATS_PASSWORD", "p")
+        with TestClient(mcp.http_app()) as c:
+            assert c.get("/stats/log", auth=("u", "p")).status_code == 404
+
+    def test_dashboard_link_is_absolute(self, tmp_path, monkeypatch) -> None:
+        """/stats has no trailing slash, so a relative href would go to /log."""
+        import re
+
+        with self._client(tmp_path, monkeypatch) as c:
+            html = c.get("/stats", auth=("u", "p")).text
+            href = re.search(r"<a href='([^']+)' download", html).group(1)
+            assert href == "/stats/log"
+            assert c.get(href, auth=("u", "p")).status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -559,3 +559,51 @@ class TestForwardedAllowIps:
         assert "forwarded_allow_ips" in inspect.signature(uvicorn.Config.__init__).parameters
         src = inspect.getsource(FastMCP.run_http_async)
         assert "config_kwargs.update(uvicorn_config_from_user)" in src
+
+
+class TestSparqlTimeout:
+    """The SPARQL client timeout is load-bearing, not a round number.
+
+    RDF Portal endpoints charge a large cold-cache penalty on first touch of an
+    entity's index pages: measured 2026-07-30 on the SIB endpoint, a minimal
+    single-protein UniProt lookup (one IRI, LIMIT 5) took 53.9-62.1s cold and
+    0.2s warm. The previous 60s ceiling sat inside that band, so a perfectly
+    good query succeeded or failed by chance — two did time out in production
+    on 2026-07-27. Anything at or below ~62s reopens that bug.
+    """
+
+    def test_timeout_clears_the_measured_cold_band(self) -> None:
+        from togo_mcp.server import _SPARQL_TIMEOUT_SECONDS, _sparql_client
+
+        assert _SPARQL_TIMEOUT_SECONDS >= 75.0, (
+            "cold single-entity lookups were measured up to 62.1s; a ceiling near "
+            "that makes a valid query fail by coin flip"
+        )
+        assert _sparql_client.timeout.read == _SPARQL_TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_timeout_message_names_both_causes(self) -> None:
+        """The old message asserted 'too heavy' and forbade any retry.
+
+        That advice is unfollowable for a single-IRI query with a small LIMIT —
+        there is nothing left to narrow. In the 2026-07-27 logs an agent obeyed
+        it, simplified a 26-predicate query to 8 predicates, and timed out again.
+        """
+        import httpx
+
+        from togo_mcp import server as srv
+
+        async def _boom(*a, **k):
+            raise httpx.ReadTimeout("simulated")
+
+        original = srv._sparql_client.post
+        srv._sparql_client.post = _boom  # type: ignore[method-assign]
+        try:
+            with pytest.raises(ValueError) as ei:
+                await srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="uniprot")
+        finally:
+            srv._sparql_client.post = original  # type: ignore[method-assign]
+        msg = str(ei.value)
+        assert "TOO HEAVY" in msg and "COLD" in msg  # both causes offered
+        assert "retry at most ONCE" in msg  # bounded retry, not a blanket ban
+        assert "90" in msg  # reports the real ceiling

--- a/togo_mcp/data/docs/log_file_specs.md
+++ b/togo_mcp/data/docs/log_file_specs.md
@@ -213,6 +213,31 @@ python -m togo_mcp.stats "$TOGOMCP_QUERY_LOG" \
   --mie togo_mcp/data/mie
 ```
 
+### Getting the raw file off a running server
+
+`GET /stats/log` streams the raw JSONL — the active file plus every rotated
+sibling, concatenated **oldest first** so the stream reads chronologically. It
+serves exactly the files `compute_stats` aggregates, so a download is verifiably
+the same input the dashboard's numbers came from. The `/stats` dashboard links
+it at the top.
+
+```bash
+curl -u "$TOGOMCP_STATS_USER:$TOGOMCP_STATS_PASSWORD" \
+  https://togomcp.rdfportal.org/stats/log -o togomcp-log.jsonl
+```
+
+Same HTTP Basic gate as `/stats`: **503** when `TOGOMCP_STATS_USER` /
+`TOGOMCP_STATS_PASSWORD` are unset (never an unauthenticated fallback), **401**
+without valid credentials, **404** when no log file exists. The response carries
+`X-Log-Bytes` and `X-Log-Files`; no `Content-Length`, because rotation can change
+the real length mid-stream.
+
+Reach for this when a question outruns the dashboard. The aggregates are lossy
+by construction, and the failures worth finding tend not to be the ones already
+tabulated — release 2.2.0 came out of reading the raw log directly, where a 62%
+zero-row rate on one tool and a single repeated dead-end query shape were plainly
+visible while every pre-computed table showed them as unremarkable traffic.
+
 ## Stability notes
 
 - New top-level or `extra` fields may be **added** over time; readers must

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -50,8 +50,23 @@ ENDPOINTS_CSV = str(CWD.joinpath("resources", "endpoints.csv"))
 INDEX_HTML = str(CWD.joinpath("docs", "togomcp-intro.html"))
 KW_SEARCH_INSTRUCTIONS = str(CWD.joinpath("kw_search"))
 
-# Shared httpx client for SPARQL queries
-_sparql_client = httpx.AsyncClient(timeout=60.0)
+# Shared httpx client for SPARQL queries.
+#
+# 90s, not 60s: RDF Portal endpoints charge a large COLD-CACHE penalty on the
+# first touch of an entity's index pages. Measured on the SIB endpoint
+# 2026-07-30 across five never-queried UniProt accessions, a MINIMAL
+# single-protein lookup (one IRI, LIMIT 5) took 53.9-62.1s cold and 0.2s warm.
+# A 60s ceiling sat INSIDE that band, so whether a perfectly good query
+# succeeded was a coin flip — two such lookups timed out in production
+# 2026-07-27. 90s clears the observed cold maximum with headroom while still
+# cutting off genuinely runaway queries.
+#
+# Raising it does NOT make retries free: an ABORTED query does not warm the
+# cache (verified — abort at 20s, retry still 55.3s), so only a query allowed
+# to COMPLETE pays the cost once for everyone after it. That is the whole point
+# of the higher ceiling.
+_SPARQL_TIMEOUT_SECONDS = 90.0
+_sparql_client = httpx.AsyncClient(timeout=_SPARQL_TIMEOUT_SECONDS)
 
 
 def load_sparql_endpoints(path: str) -> dict[str, dict[str, str]]:
@@ -248,9 +263,18 @@ async def execute_sparql(
         extra["sparql_status"] = "timeout"
         raise ValueError(
             f"SPARQL endpoint at {url} timed out after {_sparql_client.timeout.read}s. "
-            "The query is likely too heavy. Add LIMIT, narrow with specific IRIs or GRAPH "
-            "clauses, or split into smaller queries. Do not retry the same query without "
-            f"changes. ({exc.__class__.__name__})"
+            "TWO different causes are possible — check which one before acting:\n"
+            "(1) THE QUERY IS TOO HEAVY (most likely at this duration). Narrow it: "
+            "add or lower LIMIT, anchor on specific IRIs, drop repeated self-joins on "
+            "the same predicate (?s p ?a, ?b, ?c), and split multi-graph joins into "
+            "separate queries. Do not re-send it unchanged.\n"
+            "(2) THE ENDPOINT WAS COLD. A first-ever query against a large graph can "
+            "take ~1 minute while indexes page in, even for a minimal lookup. If your "
+            "query is ALREADY anchored on specific IRIs and carries a small LIMIT, "
+            "there is nothing to narrow and this is the likely cause — the same query "
+            "may well succeed on a second attempt. But an aborted query does NOT warm "
+            "the cache, so a retry costs the same again: retry at most ONCE, never loop."
+            f" ({exc.__class__.__name__})"
         ) from exc
     except httpx.HTTPError as exc:
         extra["sparql_status"] = "network_error"

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -18,7 +18,12 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_request
 import httpx
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from starlette.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -674,6 +679,60 @@ async def stats_dashboard(request: Request) -> HTMLResponse:
     except Exception as exc:  # never 500 with a stack trace; logging stays read-only
         logger.warning("stats render failed: %s", exc)
         return HTMLResponse("<h1>500</h1><p>Could not compute stats.</p>", status_code=500)
+
+
+@mcp.custom_route("/stats/log", methods=["GET"])
+async def stats_raw_log(request: Request):
+    """Stream the raw JSONL tool-call log behind the same Basic auth as /stats.
+
+    The dashboard's tables are lossy roll-ups; the questions worth asking next
+    are usually ones no pre-computed table answers (this release came out of
+    exactly that — reading the raw log surfaced two silent zero-row bugs and a
+    timeout misdiagnosis that every aggregate had shown as unremarkable).
+
+    Serves the SAME files `compute_stats` aggregates — active plus rotated —
+    concatenated OLDEST FIRST so the stream reads chronologically. Streaming,
+    not read-into-memory: this file grows without bound between rotations.
+    The path comes from TOGOMCP_QUERY_LOG only; nothing is caller-supplied, so
+    there is no traversal surface.
+    """
+    creds = _stats_configured()
+    if creds is None:
+        return PlainTextResponse("Stats dashboard not configured.", status_code=503)
+    if not _check_basic_auth(request, creds):
+        return PlainTextResponse(
+            "Authentication required", status_code=401, headers=_AUTH_HEADERS
+        )
+    from togo_mcp import stats as _stats_mod
+
+    base = os.getenv("TOGOMCP_QUERY_LOG", "").strip()
+    paths = _stats_mod.log_paths(base)
+    if not paths:
+        return PlainTextResponse("No log file found.", status_code=404)
+
+    def _iter_chunks():
+        # Reversed: log_paths returns [base (newest), base.1, base.2 (oldest)].
+        for path in reversed(paths):
+            try:
+                with open(path, "rb") as fh:
+                    while chunk := fh.read(64 * 1024):
+                        yield chunk
+            except OSError as exc:  # a file rotated away mid-stream — skip it
+                logger.warning("stats log stream: skipping %s (%s)", path, exc)
+
+    stamp = time.strftime("%Y%m%d", time.gmtime())
+    total = sum(os.path.getsize(p) for p in paths if os.path.exists(p))
+    return StreamingResponse(
+        _iter_chunks(),
+        media_type="application/x-ndjson",
+        headers={
+            "Content-Disposition": f'attachment; filename="togomcp-log-{stamp}.jsonl"',
+            # Advisory only: rotation could change the real length mid-stream,
+            # so this is not sent as Content-Length.
+            "X-Log-Bytes": str(total),
+            "X-Log-Files": str(len(paths)),
+        },
+    )
 
 
 @mcp.custom_route("/stats.json", methods=["GET"])

--- a/togo_mcp/stats.py
+++ b/togo_mcp/stats.py
@@ -601,7 +601,28 @@ def compute_stats(
     log_path = log_path if log_path is not None else os.getenv("TOGOMCP_QUERY_LOG", "").strip()
     groups = load_endpoint_groups(endpoints_csv) if endpoints_csv else {}
     mie_dates = load_mie_dates(mie_dir) if mie_dir else {}
-    return aggregate(iter_records(log_paths(log_path)), groups, mie_dates)
+    paths = log_paths(log_path)
+    out = aggregate(iter_records(paths), groups, mie_dates)
+    # Describe the bytes behind the aggregate so the dashboard's raw-log download
+    # can state its size up front, and so a downloaded file is verifiably the
+    # same input the numbers came from (the download serves exactly `paths`).
+    out["log_files"] = {
+        "n_files": len(paths),
+        "n_bytes": sum(os.path.getsize(p) for p in paths if os.path.exists(p)),
+    }
+    return out
+
+
+def _human_bytes(n: Any) -> str:
+    """Format a byte count for the dashboard ('2.6 MB'). Non-numeric → '?'."""
+    if not isinstance(n, (int, float)):
+        return "?"
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
 
 
 def render_html(stats: dict[str, Any]) -> str:
@@ -629,6 +650,21 @@ def render_html(stats: dict[str, Any]) -> str:
         f"<p class='muted'>Generated {cell(stats.get('generated_at'))} · "
         f"{cell(stats.get('n_records'))} records · months: {cell(', '.join(months)) or '—'}</p>",
     ]
+
+    # Raw-log download. Sits at the top because it is the escape hatch: every
+    # aggregate below is lossy, and the questions worth asking next are usually
+    # ones no pre-computed table answers.
+    _lf = stats.get("log_files") or {}
+    _nb, _nf = _lf.get("n_bytes"), _lf.get("n_files")
+    if _nf:
+        parts.append(
+            # Absolute: the dashboard is served at /stats with NO trailing slash,
+            # so a relative "log" would resolve to /log, not /stats/log.
+            "<p><a href='/stats/log' download>⬇ Download raw log (JSONL)</a> "
+            f"<span class='tag'>{cell(_human_bytes(_nb))} · "
+            f"{cell(_nf)} file{'s' if _nf != 1 else ''}, active + rotated · "
+            "exactly the records these tables aggregate</span></p>"
+        )
 
     cand = stats.get("mie_candidates", [])
     parts.append("<h2>MIE-improvement candidates</h2>")

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Two changes from the same thread of work: the timeout fix that came out of the #182 log analysis, and
the raw-log download that makes that kind of analysis a link instead of an SSH session.

---

# 1. The 60s SPARQL timeout sat inside the endpoints' cold-cache band

Two UniProt `run_sparql` calls timed out on 2026-07-27. Both were legitimate **single-protein lookups**,
and the second was the agent having already simplified the first from 26 predicates to 8 — so the obvious
reading, *"the queries were too heavy"*, was wrong.

## Root cause: cold-cache latency, not query shape

RDF Portal endpoints charge a large penalty on the **first** touch of an entity's index pages. Measured
on the SIB endpoint across five never-queried accessions, a **minimal** lookup (one IRI, `LIMIT 5`):

| accession | cold | warm |
|---|---|---|
| Q8N1G4 | 57.4s | 0.2s |
| P0DP23 | 54.8s | 0.2s |
| Q6ZN17 | 62.1s | 0.2s |
| P35240 | 55.3s | 0.2s |
| Q13315 | 53.9s | 0.2s |

The client ceiling was **exactly 60.0s — inside that spread**, so whether a perfectly good query
succeeded was a coin flip. Raised to **90s**: clears the observed cold maximum with headroom, still cuts
off genuinely runaway queries.

**Raising the ceiling is the fix precisely because retrying is not.** An *aborted* query does not warm
the cache — verified by aborting at 20s and retrying: still 55.3s. Only a query allowed to **complete**
pays the cost once on behalf of every query after it. That also rules out the tempting
"retry-once-on-timeout" fix, which would just burn another 55s.

## The error message compounded it

The old text asserted one cause and forbade the one thing that would have helped:

> "The query is likely too heavy. Add LIMIT, narrow with specific IRIs or GRAPH clauses... **Do not retry
> the same query without changes.**"

For a query that is *already* a single IRI with `LIMIT 5` there is nothing left to narrow. The log shows
the agent obeying faithfully — simplifying 26 predicates down to 8 — and timing out again 74 seconds
later. It was given unfollowable advice for a problem it did not have.

The message now names **both** causes, says which is likelier at that duration, and permits **exactly
one** retry rather than banning it outright. The narrow-it guidance stays, because it remains correct for
genuinely heavy queries: the same log's MassBank timeout is a 4-way `mb:has_peak` self-join with range
filters on each, and that advice fits it exactly.

---

# 2. `GET /stats/log` — raw-log download, linked from the dashboard

The dashboard's tables are lossy roll-ups, and the failures worth finding tend not to be the ones already
tabulated. Release 2.2.0 came out of reading the raw log directly, where a **62% zero-row rate** on one
tool and a single repeated dead-end query shape were plainly visible — while every pre-computed table
showed them as unremarkable traffic. This makes that escape hatch a link.

```
⬇ Download raw log (JSONL)   13.9 KB · 2 files, active + rotated · exactly the records these tables aggregate
```

- **Serves the same files `compute_stats` aggregates** — active plus every rotated sibling, concatenated
  **oldest-first**. Serving only the active file would silently under-report against the tables directly
  above the link, and anyone reconciling a number would be chasing a phantom.
- **Streamed in 64 KB chunks**, not read into memory: the log reaches ~550 MB across rotations.
  `X-Log-Bytes`/`X-Log-Files` are advisory; no `Content-Length`, since rotation can change the real length
  mid-stream.
- **Same HTTP Basic gate as `/stats`** — 503 when `TOGOMCP_STATS_USER`/`TOGOMCP_STATS_PASSWORD` are unset
  (never an unauthenticated fallback), 401 without valid credentials, 404 when no log exists. The path
  comes from `TOGOMCP_QUERY_LOG` only; nothing is caller-supplied, so there is no traversal surface.
- **The link is absolute.** `/stats` is served without a trailing slash, so a relative `log` resolves to
  `/log` and 404s — caught in review of my own first draft. A test asserts the rendered href *and*
  follows it, so it cannot regress silently.

Documented in `log_file_specs.md` with a `curl` recipe and the status-code contract.

---

## Verification

- **253 tests pass** (7 new). Two pin the timeout: the ceiling must stay `>= 75s`, so drift back toward
  60s fails loudly, and the message must name both causes with bounded-retry wording. Five cover the
  download: auth required, 503 when unconfigured, rotated files included in the right order, 404 with no
  log, and link resolution.
- No intro-page drift — neither change carries a `whatsnew` marker; the timeout is internal reliability
  and `/stats` is an auth-protected operator surface.
- **PATCH**: the semver policy scopes the public contract to the *tool surface* (tool names, parameters,
  return shapes). Neither change adds a tool or alters a return shape.

> Tag `v2.2.1` on the merge commit after merging (CLAUDE.md release step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
