### PR TITLE
release: 2.4.1 — kegg_pathway_graph response reduction fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ### Fixed
 
+- **`kegg_pathway_graph` could return edges whose endpoints were not in `nodes`.** Under a raised
+  `max_nodes` on a whole-metabolism map, 18 of 50 returned edges (and in a synthetic reproduction all
+  50) referenced node ids that had been trimmed away, so the caller could not resolve a single
+  endpoint — while 878 of 891 returned nodes appeared edgeless on a densely connected map. Both are
+  wrong ANSWERS rather than small ones, and neither looks like an error: "this map is nearly
+  disconnected" is a plausible reading of the second.
+  The cause was reducing `nodes` and `edges` as two independent flat lists. The unit of reduction is
+  now the NODE SET — a binary search finds the largest degree-ordered prefix whose INDUCED subgraph
+  fits the budget, so every returned edge has both endpoints in `nodes` by construction, on every
+  path (no cap, count cap, size cap). Verified across all six validation maps plus both capped cases.
+- **`metabolic_gaps` and `map_links` vanished from every organism global map at default arguments.**
+  The byte budget was computed against each section's UNREDUCED size, so `edges` at its full 8,124-row
+  cost (~370 KB) made the budget look exhausted and the supporting sections were zeroed — even though
+  the actual response was 222 KB against a 250 KB cap, and the 100 gaps cost 11.5 KB. The gaps are
+  this tool's headline output, and they were invisible precisely where they mean most. The budget is
+  now computed on what is actually being returned, with the (already count-capped, ~22 KB) supporting
+  sections reserved BEFORE the graph is fitted into what remains.
+- **`capped_by` mislabelled an induced edge count as a size-budget trim.** Edges follow the node set,
+  so when the node prefix is bound by `max_nodes` the edges are too; reporting that as `size_budget`
+  told the caller to narrow the question when raising `max_nodes` is what actually helps. Edges now
+  inherit the node limit's reason unless their own count cap bound them first, and carry an explicit
+  `note` that they are the induced subgraph.
+- **`truncated.section_bytes_if_complete`** replaces the previous backstop-only diagnostic and is now
+  emitted whenever the graph is reduced, reporting what each of the four sections would have cost
+  unreduced. That is what answers "why are there so few edges?" — the section that drove the
+  reduction is otherwise invisible, since a section that merely occupied the budget has
+  `returned == total` and nothing flags it.
+
 - **Raised count caps could starve `kegg_pathway_graph` of its edges.** With
   `max_nodes=5000, max_edges=20000, max_gaps=5000` on a whole-metabolism map, `metabolic_gaps`
   (186 KB, 84% of the payload) consumed the size budget and `edges` came back as **0** — a pathway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.4.1] - 2026-07-31
+
+Four review rounds against the live KEGG API, all on `kegg_pathway_graph`'s response
+reduction. Every fix below is a case where the tool returned something that looked like a
+valid answer and was not: a graph whose edges pointed at absent nodes, a whole-metabolism map
+with its `metabolic_gaps` silently gone, and a raised-cap call that returned less than the
+defaults. Only the stdio + `TOGOMCP_ENABLE_KEGG=1` audience is affected; nothing here changes
+the hosted tool surface.
+
 ### Fixed
 
 - **Raising every `kegg_pathway_graph` cap returned a SMALLER graph than the defaults.** On hsa01100,
@@ -998,7 +1009,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/dbcls/togomcp/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/dbcls/togomcp/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/dbcls/togomcp/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/dbcls/togomcp/compare/v2.2.0...v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ### Fixed
 
+- **Raised count caps could starve `kegg_pathway_graph` of its edges.** With
+  `max_nodes=5000, max_edges=20000, max_gaps=5000` on a whole-metabolism map, `metabolic_gaps`
+  (186 KB, 84% of the payload) consumed the size budget and `edges` came back as **0** — a pathway
+  graph with no graph in it, which reads as "these molecules are unconnected" and is more dangerous
+  than an error because it does not look like one.
+  This was the swing back from the previous fix: a "gaps first" drop order had thrown away all 25 of
+  hsa00010's gaps to save 2 KB, and reversing it to "edges first" produced this. Neither fixed order
+  is right, because the question is not which section is more precious. The backstop now works in two
+  TIERS — supporting detail (`map_links`, `groups`, `metabolic_gaps`) is spent before the graph
+  itself (`edges`, `nodes`), which additionally keeps a floor of 50 rows — and **within a tier the
+  BIGGEST section goes first**, so the section that occupies the budget is the one that gives it back
+  instead of a small section being zeroed for nothing.
+- **The truncation report no longer hides the section that caused the truncation.** `truncated` now
+  carries `reasons` (a list, so a count-cap trim and a size-backstop firing are distinguishable
+  rather than collapsed into one string), `capped_by` per section (`"count"` / `"size_budget"` /
+  `null`), and `section_bytes` when the size backstop fires. Previously the section that ate the
+  budget was the only one absent from the report — it had `returned == total`, so nothing flagged it,
+  and "why are there so few edges?" was unanswerable from the response.
+
 - **`kegg_pathway_graph` could exceed the 1 MB MCP transport limit, so the caller got nothing.**
   `_bounded` only *labelled* an oversized dict — it set `payload["truncated"]` and then serialized
   everything anyway — so the size cap was decorative for all four dict-returning KEGG tools. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ### Fixed
 
+- **Raising every `kegg_pathway_graph` cap returned a SMALLER graph than the defaults.** On hsa01100,
+  `max_gaps=5000` let 1,555 metabolic gaps take 74% of the payload, so `nodes` fell to the 50-node
+  floor — against the 191 nodes / 560 edges the same map returns at the defaults. No contract was
+  broken (`max_*` are ceilings, not floors) but the tool did the opposite of what asking for more
+  means, and `truncated.hint`'s advice to "raise max_nodes/max_edges/max_gaps" was actively wrong:
+  the only move that bought graph was *lowering* `max_gaps`.
+  The caps are ceilings on ONE shared response budget, and the supporting sections were reserving
+  from it first. `nodes`+`edges` now take half the budget (`_GRAPH_BUDGET_SHARE`) before
+  `metabolic_gaps`/`map_links` may spend any of it; the supporting sections are then count-capped as
+  before and fitted into what remains, biggest-first. Same case now returns 138 nodes / 346 edges
+  with 876 gaps. Default arguments are byte-for-byte unaffected (gaps are ~10% of the payload there,
+  well inside the remainder), and a section cut for the reserve reports `capped_by: "size_budget"`
+  rather than `"count"`, so the report never suggests raising a cap that is already maxed out. When
+  the supporting sections hold enough budget to matter, `hint` now says to lower `max_gaps` and gives
+  the byte split instead of the generic advice.
 - **`kegg_pathway_graph` could return edges whose endpoints were not in `nodes`.** Under a raised
   `max_nodes` on a whole-metabolism map, 18 of 50 returned edges (and in a synthetic reproduction all
   50) referenced node ids that had been trimmed away, so the caller could not resolve a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,38 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **`kegg_pathway_graph` could exceed the 1 MB MCP transport limit, so the caller got nothing.**
+  `_bounded` only *labelled* an oversized dict — it set `payload["truncated"]` and then serialized
+  everything anyway — so the size cap was decorative for all four dict-returning KEGG tools. A
+  whole-metabolism map (`hsa01100`: 6,382 nodes, 8,124 edges, 2,073 metabolic gaps) blew past the
+  transport limit, and because the rejection happens at the transport layer the caller received not
+  even the truncation note meant to help it recover. The dict branch now really shrinks, dropping
+  named sections in priority order and reporting `{returned, total}` PER SECTION while `stats` keeps
+  describing the whole map.
+- **The same fix exposed two bad calls of my own.** The first drop-order sacrificed `metabolic_gaps`
+  first — throwing away all 25 of hsa00010's gaps to save 2 KB, i.e. the tool's unique answer to
+  protect the bulk. And the 90 KB cap, inherited from a row-listing tool, was far too tight for a
+  graph: it was firing on ORDINARY maps and cutting hsa05200 from 311 edges to 43. Graph payloads now
+  get their own 250 KB cap (still ~60k tokens, well under the 1 MB transport limit) and drop
+  bulkiest-and-tunable first, unique-and-cheap last. All six validation maps now return complete,
+  untruncated graphs. New `max_gaps` caps gaps at the source, with the true count always in
+  `stats.metabolic_gap_count`.
+- **Two false statements in the KEGG docstrings**, both found by testing rather than review:
+  global/overview maps like `01100` were said to have no KGML — they do, they are just enormous; and
+  the glycolysis example claimed `C00031 → C00022` works at `max_length` 12, which was measured on
+  `ko00010` and written up as "glycolysis". On `hsa00010`, C00031 (D-Glucose) is an ISOLATED node and
+  returns nothing at any length; the chain starts at C00267 (alpha-D-Glucose). The example is now the
+  measured one, and `kegg_pathway_paths` reports `isolated_endpoints` so a degree-0 endpoint is no
+  longer indistinguishable from "just far away".
+- **`kegg_pathway_paths` wasted its `max_paths` budget on enzyme detours** — a catalysis edge lets a
+  route bypass the enzyme box over the identical reaction sequence, which is the same chemistry drawn
+  differently. Routes repeating a reaction sequence are now collapsed and counted in
+  `enzyme_detours_collapsed`; genuinely different reactions between the same pair stay distinct.
+- **`kegg_find` now returns `entry_id`** (prefix-stripped) alongside the verbatim `entry`, matching
+  `kegg_conv`. The identifier-form policy for all four ID-returning tools is stated once, in the
+  module docstring, instead of being scattered and mutually inconsistent.
 
 ## [2.4.0] - 2026-07-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.4.0"
+version = "2.4.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -156,8 +156,15 @@ class TestFind:
             )
             out = await find(database="compound", query="grape sugar")
         assert route.called
+        # Both forms ship: `entry` verbatim (what KEGG tools take), `entry_id`
+        # prefix-stripped (what downstream/RDF tools take) — same contract as
+        # kegg_conv's source_id/target_id, so a caller never has to guess.
         assert json.loads(out) == [
-            {"entry": "cpd:C00031", "definition": "D-Glucose; Grape sugar"}
+            {
+                "entry": "cpd:C00031",
+                "entry_id": "C00031",
+                "definition": "D-Glucose; Grape sugar",
+            }
         ]
 
     @pytest.mark.asyncio
@@ -357,10 +364,92 @@ class TestPathwayGraph:
             out = await pathway_graph(pathway=MAP, max_nodes=2)
         graph = json.loads(out)
         assert len(graph["nodes"]) == 2
-        assert graph["truncated"]["returned_nodes"] == 2
+        # `truncated` now carries a {returned, total} pair PER SECTION.
+        assert graph["truncated"]["nodes"] == {
+            "returned": 2, "total": graph["stats"]["node_count"]
+        }
         # stats must still describe the WHOLE map, not the trimmed view.
         assert graph["stats"]["node_count"] > 2
-        assert graph["truncated"]["total_nodes"] == graph["stats"]["node_count"]
+
+    @pytest.mark.asyncio
+    async def test_global_map_shape_stays_under_the_transport_limit(self):
+        """A whole-metabolism map must degrade, not exceed the 1 MB MCP limit.
+
+        Regression for the worst failure this tool had: `_bounded` only LABELLED
+        an oversized dict (`payload["truncated"] = ...`) and then serialized it in
+        full, so the cap was decorative for every dict-returning tool. hsa01100
+        (6,382 nodes, 8,124 edges, 2,073 metabolic gaps) then blew past the
+        transport limit and the caller received NOTHING — not even the truncation
+        note meant to help it recover.
+
+        Synthetic rather than fetched: no test may touch rest.kegg.jp, and this
+        reproduces the shape that matters — thousands of unreacted ortholog boxes
+        (metabolic gaps) plus hundreds of cross-map pointers.
+        """
+        entries, relations = [], []
+        for i in range(2500):  # isolated ortholog boxes -> metabolic_gaps
+            entries.append(
+                f'<entry id="{9000 + i}" name="ko:K{i:05d}" type="ortholog">'
+                f'<graphics name="{i}.{i}.{i}.{i}" type="rectangle"/></entry>'
+            )
+        for i in range(400):  # cross-map pointers -> map_links
+            entries.append(
+                f'<entry id="{20000 + i}" name="path:map{i:05d}" type="map">'
+                f'<graphics name="Some other pathway {i}" type="roundrectangle"/></entry>'
+            )
+        for i in range(300):  # a real connected core
+            entries.append(
+                f'<entry id="{i + 1}" name="hsa:{i}" type="gene">'
+                f'<graphics name="GENE{i}" type="rectangle"/></entry>'
+            )
+            if i:
+                relations.append(
+                    f'<relation entry1="{i}" entry2="{i + 1}" type="PPrel">'
+                    '<subtype name="activation" value="--&gt;"/></relation>'
+                )
+        big = (
+            '<?xml version="1.0"?><pathway name="path:xxx01100" org="xxx" '
+            'number="01100" title="Synthetic global map">'
+            + "".join(entries) + "".join(relations) + "</pathway>"
+        )
+
+        with respx.mock(using="httpx") as router:
+            router.get(f"{BASE}/get/xxx01100/kgml").mock(
+                return_value=httpx.Response(200, text=big)
+            )
+            out = await pathway_graph(pathway="xxx01100")
+
+        assert len(out.encode()) < 1_000_000, (
+            f"payload is {len(out.encode())} bytes — over the 1 MB transport limit"
+        )
+        graph = json.loads(out)
+        # stats must still report the FULL map, which is what makes a trimmed
+        # response usable instead of merely small.
+        assert graph["stats"]["metabolic_gap_count"] == 2500
+        assert graph["stats"]["node_count"] > len(graph["nodes"])
+        # …and every trimmed section says what it dropped.
+        t = graph["truncated"]
+        assert t["metabolic_gaps"] == {"returned": len(graph["metabolic_gaps"]),
+                                       "total": 2500}
+        assert t["map_links"]["total"] == 400
+        assert t["nodes"]["total"] == graph["stats"]["node_count"]
+
+    @pytest.mark.asyncio
+    async def test_bounded_actually_shrinks_a_dict_not_just_labels_it(self):
+        """The dict branch used to add a `truncated` key and return everything."""
+        payload = {
+            "stats": {"n": 3000},
+            "keep_me": "small",
+            "big": [{"row": "x" * 100} for _ in range(3000)],
+        }
+        parsed = json.loads(
+            kegg._bounded(payload, note="hint", reducible=("big",))
+        )
+        assert len(json.dumps(parsed)) <= kegg._MAX_RESPONSE_CHARS
+        assert len(parsed["big"]) < 3000
+        assert parsed["truncated"]["big"]["total"] == 3000
+        # Un-named sections are never touched.
+        assert parsed["stats"] == {"n": 3000} and parsed["keep_me"] == "small"
 
     @pytest.mark.asyncio
     async def test_map_without_kgml_raises_a_diagnostic_error(self):

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -365,9 +365,9 @@ class TestPathwayGraph:
         graph = json.loads(out)
         assert len(graph["nodes"]) == 2
         # `truncated` now carries a {returned, total} pair PER SECTION.
-        assert graph["truncated"]["nodes"] == {
-            "returned": 2, "total": graph["stats"]["node_count"]
-        }
+        assert graph["truncated"]["nodes"]["returned"] == 2
+        assert graph["truncated"]["nodes"]["total"] == graph["stats"]["node_count"]
+        assert graph["truncated"]["nodes"]["capped_by"] == "count"
         # stats must still describe the WHOLE map, not the trimmed view.
         assert graph["stats"]["node_count"] > 2
 
@@ -429,10 +429,81 @@ class TestPathwayGraph:
         assert graph["stats"]["node_count"] > len(graph["nodes"])
         # …and every trimmed section says what it dropped.
         t = graph["truncated"]
-        assert t["metabolic_gaps"] == {"returned": len(graph["metabolic_gaps"]),
-                                       "total": 2500}
+        assert t["metabolic_gaps"]["total"] == 2500
         assert t["map_links"]["total"] == 400
         assert t["nodes"]["total"] == graph["stats"]["node_count"]
+        # The graph itself must survive: a pathway tool answering with zero edges
+        # reads as "these molecules are unconnected", which is worse than an error.
+        assert len(graph["edges"]) >= min(kegg._PRIMARY_FLOOR, graph["stats"]["edge_count"])
+
+    @pytest.mark.asyncio
+    async def test_raised_caps_never_starve_the_graph_of_edges(self):
+        """Raising the count caps must not let supporting detail eat the graph.
+
+        Regression for the swing this file has already made in BOTH directions.
+        A "gaps first" drop order threw away all 25 of hsa00010's metabolic gaps
+        to save 2 KB; reversing it to "edges first" then let a whole-metabolism
+        map's 186 KB of gaps push `edges` to ZERO — a pathway graph with no graph
+        in it, which reads as "these molecules are unconnected" and is worse than
+        an error because it does not look like one.
+
+        The rule is not which section is more precious: the section OCCUPYING the
+        budget is the one that pays, and the answer keeps a floor.
+        """
+        entries, relations = [], []
+        for i in range(2073):  # gaps dominate, as on the real hsa01100
+            entries.append(
+                f'<entry id="{90000 + i}" name="ko:K{i:05d}" type="ortholog">'
+                f'<graphics name="{i}.{i}.{i}.{i}" type="rectangle"/></entry>'
+            )
+        for i in range(169):
+            entries.append(
+                f'<entry id="{40000 + i}" name="path:map{i:05d}" type="map">'
+                f'<graphics name="Other pathway {i}" type="roundrectangle"/></entry>'
+            )
+        for i in range(900):
+            entries.append(
+                f'<entry id="{i + 1}" name="hsa:{i} hsa:{i + 9000}" type="gene">'
+                f'<graphics name="GENE{i}, ALIAS{i}" type="rectangle"/></entry>'
+            )
+            if i:
+                relations.append(
+                    f'<relation entry1="{i}" entry2="{i + 1}" type="PPrel">'
+                    '<subtype name="activation" value="--&gt;"/></relation>'
+                )
+        big = (
+            '<?xml version="1.0"?><pathway name="path:xxx01100" org="xxx" '
+            'number="01100" title="Synthetic global map">'
+            + "".join(entries) + "".join(relations) + "</pathway>"
+        )
+
+        async def fetch(**kwargs):
+            kegg._kgml_cache.clear()
+            with respx.mock(using="httpx", assert_all_called=False) as router:
+                router.get(f"{BASE}/get/xxx01100/kgml").mock(
+                    return_value=httpx.Response(200, text=big)
+                )
+                return json.loads(await pathway_graph(pathway="xxx01100", **kwargs))
+
+        raised = await fetch(max_nodes=5000, max_edges=20000, max_gaps=5000)
+        assert len(raised["edges"]) >= kegg._PRIMARY_FLOOR, "the graph was starved"
+        t = raised["truncated"]
+        # The two firing conditions must stay distinguishable…
+        assert "map larger than the requested caps" in t["reasons"]
+        assert "response exceeded the size cap" in t["reasons"]
+        # …and the section that ATE the budget must be visible, even though the
+        # count cap left it untrimmed — otherwise "why are there few edges?" is
+        # unanswerable from the response.
+        assert t["section_bytes"]["metabolic_gaps"] > t["section_bytes"]["edges"]
+        assert t["metabolic_gaps"]["capped_by"] == "size_budget"
+
+        # Default arguments must be untouched by all of this.
+        default = await fetch()
+        assert len(default["nodes"]) == 400
+        assert len(default["metabolic_gaps"]) == 100
+        assert len(default["edges"]) > 0
+        assert default["truncated"]["reasons"] == ["map larger than the requested caps"]
+        assert "section_bytes" not in default["truncated"]
 
     @pytest.mark.asyncio
     async def test_bounded_actually_shrinks_a_dict_not_just_labels_it(self):
@@ -443,11 +514,13 @@ class TestPathwayGraph:
             "big": [{"row": "x" * 100} for _ in range(3000)],
         }
         parsed = json.loads(
-            kegg._bounded(payload, note="hint", reducible=("big",))
+            kegg._bounded(payload, note="hint", secondary=("big",))
         )
         assert len(json.dumps(parsed)) <= kegg._MAX_RESPONSE_CHARS
         assert len(parsed["big"]) < 3000
         assert parsed["truncated"]["big"]["total"] == 3000
+        assert parsed["truncated"]["big"]["capped_by"] == "size_budget"
+        assert "response exceeded the size cap" in parsed["truncated"]["reasons"]
         # Un-named sections are never touched.
         assert parsed["stats"] == {"n": 3000} and parsed["keep_me"] == "small"
 

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -20,6 +20,7 @@ import respx
 from fastmcp import FastMCP
 
 import togo_mcp.kegg as kegg
+from togo_mcp.kegg import _MAX_GRAPH_RESPONSE_CHARS as _MAX_GRAPH_CAP
 import togo_mcp.main as main
 from togo_mcp.kegg import (
     _as_list,
@@ -494,16 +495,30 @@ class TestPathwayGraph:
         # …and the section that ATE the budget must be visible, even though the
         # count cap left it untrimmed — otherwise "why are there few edges?" is
         # unanswerable from the response.
-        assert t["section_bytes"]["metabolic_gaps"] > t["section_bytes"]["edges"]
-        assert t["metabolic_gaps"]["capped_by"] == "size_budget"
+        # The diagnostic that answers "why so few edges?": what each section
+        # would have cost unreduced, including one that was never trimmed.
+        complete = t["section_bytes_if_complete"]
+        assert set(complete) == {"nodes", "edges", "metabolic_gaps", "map_links"}
+        assert complete["nodes"] + complete["edges"] > _MAX_GRAPH_CAP
+        # Every returned edge resolves — the invariant that independent clipping
+        # of nodes and edges used to break (50/50 edges dangling).
+        node_ids = {n["id"] for n in raised["nodes"]}
+        assert all(
+            e["source"] in node_ids and e["target"] in node_ids
+            for e in raised["edges"]
+        )
+        # …and the returned nodes are not overwhelmingly edgeless.
+        touched = {e["source"] for e in raised["edges"]} | {
+            e["target"] for e in raised["edges"]
+        }
+        assert len(touched) >= len(node_ids) / 2
 
         # Default arguments must be untouched by all of this.
         default = await fetch()
         assert len(default["nodes"]) == 400
         assert len(default["metabolic_gaps"]) == 100
         assert len(default["edges"]) > 0
-        assert default["truncated"]["reasons"] == ["map larger than the requested caps"]
-        assert "section_bytes" not in default["truncated"]
+        assert "map larger than the requested caps" in default["truncated"]["reasons"]
 
     @pytest.mark.asyncio
     async def test_bounded_actually_shrinks_a_dict_not_just_labels_it(self):

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -46,6 +46,65 @@ KGML = FIXTURE.read_text()
 MAP = "xxx00000"
 
 
+def _synthetic_global_map(*, gaps: int, map_links: int, genes: int) -> str:
+    """A whole-metabolism map's SHAPE, with no KEGG-derived content.
+
+    hsa01100 is thousands of unreacted ortholog boxes (metabolic gaps) and
+    hundreds of cross-map pointers wrapped around a connected core — the only
+    shape in which the response caps compete for the budget at all.
+    """
+    entries, relations = [], []
+    for i in range(gaps):
+        entries.append(
+            f'<entry id="{90000 + i}" name="ko:K{i:05d}" type="ortholog">'
+            f'<graphics name="{i}.{i}.{i}.{i}" type="rectangle"/></entry>'
+        )
+    for i in range(map_links):
+        entries.append(
+            f'<entry id="{40000 + i}" name="path:map{i:05d}" type="map">'
+            f'<graphics name="Other pathway {i}" type="roundrectangle"/></entry>'
+        )
+    for i in range(genes):
+        entries.append(
+            f'<entry id="{i + 1}" name="hsa:{i} hsa:{i + 9000}" type="gene">'
+            f'<graphics name="GENE{i}, ALIAS{i}" type="rectangle"/></entry>'
+        )
+        if i:
+            relations.append(
+                f'<relation entry1="{i}" entry2="{i + 1}" type="PPrel">'
+                '<subtype name="activation" value="--&gt;"/></relation>'
+            )
+    return (
+        '<?xml version="1.0"?><pathway name="path:xxx01100" org="xxx" '
+        'number="01100" title="Synthetic global map">'
+        + "".join(entries) + "".join(relations) + "</pathway>"
+    )
+
+
+def _assert_graph_invariants(payload: str, graph: dict) -> None:
+    """The three properties that must hold on EVERY kegg_pathway_graph return.
+
+    They are asserted together, on every reduction path (count cap, size cap,
+    neither), because each was a shipped bug: edges pointing at nodes that were
+    cut, and a payload over the 1 MB transport limit that the caller never
+    received at all.
+    """
+    node_ids = {n["id"] for n in graph["nodes"]}
+    assert all(
+        e["source"] in node_ids and e["target"] in node_ids for e in graph["edges"]
+    ), "dangling edge: an endpoint is missing from `nodes`"
+    assert len(payload.encode()) < 1_048_576, (
+        f"payload is {len(payload.encode())} bytes — over the 1 MB transport limit"
+    )
+    touched = {e["source"] for e in graph["edges"]} | {
+        e["target"] for e in graph["edges"]
+    }
+    if graph["edges"]:
+        assert len(node_ids - touched) <= len(node_ids) / 2, (
+            "more than half the returned nodes are isolated"
+        )
+
+
 @pytest.fixture(autouse=True)
 def _isolate_module_state(monkeypatch):
     """Clear the KGML memo and disable throttling between tests.
@@ -451,32 +510,8 @@ class TestPathwayGraph:
         The rule is not which section is more precious: the section OCCUPYING the
         budget is the one that pays, and the answer keeps a floor.
         """
-        entries, relations = [], []
-        for i in range(2073):  # gaps dominate, as on the real hsa01100
-            entries.append(
-                f'<entry id="{90000 + i}" name="ko:K{i:05d}" type="ortholog">'
-                f'<graphics name="{i}.{i}.{i}.{i}" type="rectangle"/></entry>'
-            )
-        for i in range(169):
-            entries.append(
-                f'<entry id="{40000 + i}" name="path:map{i:05d}" type="map">'
-                f'<graphics name="Other pathway {i}" type="roundrectangle"/></entry>'
-            )
-        for i in range(900):
-            entries.append(
-                f'<entry id="{i + 1}" name="hsa:{i} hsa:{i + 9000}" type="gene">'
-                f'<graphics name="GENE{i}, ALIAS{i}" type="rectangle"/></entry>'
-            )
-            if i:
-                relations.append(
-                    f'<relation entry1="{i}" entry2="{i + 1}" type="PPrel">'
-                    '<subtype name="activation" value="--&gt;"/></relation>'
-                )
-        big = (
-            '<?xml version="1.0"?><pathway name="path:xxx01100" org="xxx" '
-            'number="01100" title="Synthetic global map">'
-            + "".join(entries) + "".join(relations) + "</pathway>"
-        )
+        # gaps dominate, as on the real hsa01100
+        big = _synthetic_global_map(gaps=2073, map_links=169, genes=900)
 
         async def fetch(**kwargs):
             kegg._kgml_cache.clear()
@@ -519,6 +554,74 @@ class TestPathwayGraph:
         assert len(default["metabolic_gaps"]) == 100
         assert len(default["edges"]) > 0
         assert "map larger than the requested caps" in default["truncated"]["reasons"]
+
+    @pytest.mark.asyncio
+    async def test_raising_max_gaps_cannot_spend_the_graphs_reserved_share(self):
+        """The caps must not interact backwards: raising them all shrank the graph.
+
+        `max_gaps=5000` on hsa01100 let 1,555 metabolic gaps take 74% of the
+        payload, so the graph fell to the 50-node floor — FEWER nodes than the
+        191 the same map returns at the defaults. A caller raising every cap is
+        asking for more, so `nodes`+`edges` now take `_GRAPH_BUDGET_SHARE` of the
+        budget before the supporting sections may spend any of it.
+        """
+        big = _synthetic_global_map(gaps=2073, map_links=169, genes=900)
+
+        async def fetch(**kwargs):
+            kegg._kgml_cache.clear()
+            with respx.mock(using="httpx", assert_all_called=False) as router:
+                router.get(f"{BASE}/get/xxx01100/kgml").mock(
+                    return_value=httpx.Response(200, text=big)
+                )
+                out = await pathway_graph(pathway="xxx01100", **kwargs)
+            graph = json.loads(out)
+            _assert_graph_invariants(out, graph)
+            return graph
+
+        raised = await fetch(max_nodes=5000, max_edges=20000, max_gaps=5000)
+        graph_bytes = len(
+            json.dumps({"nodes": raised["nodes"], "edges": raised["edges"]})
+        )
+        reserve = _MAX_GRAPH_CAP * kegg._GRAPH_BUDGET_SHARE
+        assert graph_bytes > reserve * 0.8, (
+            f"the graph got {graph_bytes} bytes of its {reserve:.0f}-byte reserve"
+        )
+        assert len(raised["nodes"]) > kegg._PRIMARY_FLOOR, "collapsed to the floor"
+
+        # The gaps that could not fit are reported as size_budget, NOT count:
+        # telling a caller to raise a cap it already maxed out is worse than
+        # silence, and `map_links` (small, count-capped) must keep saying count.
+        assert raised["truncated"]["metabolic_gaps"]["capped_by"] == "size_budget"
+        assert raised["truncated"]["map_links"]["capped_by"] == "count"
+        # …and the hint must name the move that actually works here. "Raise
+        # max_nodes" does not: the graph is size-bound, not count-bound.
+        hint = raised["truncated"]["hint"]
+        assert "LOWER `max_gaps`" in hint
+
+        # Lowering max_gaps is what buys graph — the property the hint asserts.
+        starved = await fetch(max_nodes=5000, max_edges=20000, max_gaps=0)
+        assert len(starved["nodes"]) > len(raised["nodes"])
+        assert starved["metabolic_gaps"] == []
+
+    @pytest.mark.asyncio
+    async def test_graph_invariants_hold_on_every_reduction_path(self):
+        """Count cap, size cap and neither: same three guarantees each time."""
+        cases = [
+            (MAP, {}),                                   # neither cap fires
+            (MAP, {"max_nodes": 2}),                     # count cap
+            ("xxx01100", {}),                            # size cap
+            ("xxx01100", {"max_nodes": 5000, "max_gaps": 5000}),
+        ]
+        big = _synthetic_global_map(gaps=2073, map_links=169, genes=900)
+        for pathway, kwargs in cases:
+            kegg._kgml_cache.clear()
+            with respx.mock(using="httpx", assert_all_called=False) as router:
+                _mock_kgml(router)
+                router.get(f"{BASE}/get/xxx01100/kgml").mock(
+                    return_value=httpx.Response(200, text=big)
+                )
+                out = await pathway_graph(pathway=pathway, **kwargs)
+            _assert_graph_invariants(out, json.loads(out))
 
     @pytest.mark.asyncio
     async def test_bounded_actually_shrinks_a_dict_not_just_labels_it(self):

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -30,6 +30,25 @@ MODULE CONVENTIONS (same as togovar.py — keep uniform)
   non-empty share one wire shape. `dict` returns are exempt.
 * Every tool carries `annotations=READ_ONLY_TOOL`.
 
+IDENTIFIER FORMS — THE ONE PLACE THIS IS STATED
+------------------------------------------------
+KEGG uses two forms of the same id: database-PREFIXED (`cpd:C00031`, `hsa:7157`,
+`path:hsa04151`) and BARE (`C00031`, `7157`, `hsa04151`). Which one a response
+carries is decided by KEGG's own output, not by us, so every tool here surfaces
+BOTH wherever they can differ:
+
+* ``kegg_find``   -> ``entry`` (verbatim from KEGG) + ``entry_id`` (bare).
+* ``kegg_conv``   -> ``source``/``target`` (verbatim) + ``source_id``/``target_id`` (bare).
+* ``kegg_link``   -> ``source``/``target`` verbatim; KEGG prefixes both columns here.
+* ``kegg_get_entry`` -> ``entry_id`` is BARE and cannot be otherwise: it is read
+  from the flat file's ENTRY line, which KEGG writes unprefixed (`C00031`,
+  `7157`). Re-attach the database prefix before passing it to another KEGG tool.
+
+Rule of thumb: KEGG tools accept EITHER form on input (``_as_list`` +
+``_check_path_token`` do not care), so this matters mainly when you carry an id
+OUT of KEGG — use the bare `*_id` form for RDF queries and ID-conversion
+services, and the prefixed form when staying inside KEGG.
+
 RATE LIMIT
 ----------
 KEGG asks for <= 3 requests/second and blocks abusers. The limiter below is
@@ -194,14 +213,26 @@ _T_NUMBER = re.compile(r"^T\d{5}$")
 # A pathway map id, with the optional `path:` prefix KEGG itself emits.
 _PATHWAY_ID = re.compile(r"^(?:path:)?([a-z]{2,4})(\d{5})$")
 
-# Response soft cap, mirroring togovar._MAX_RESPONSE_CHARS.
+# Response soft cap, mirroring togovar.cap.
 _MAX_RESPONSE_CHARS = 90_000
+
+# A pathway graph is inherently bulkier than a row listing: hsa05200's 255 nodes
+# alone serialize to ~77 KB because each carries its paralog member list. At the
+# 90 KB row-listing cap the backstop was firing on ORDINARY maps and cutting
+# hsa05200 from 311 edges to 43 — a technically-bounded but useless answer. This
+# cap still protects the caller's context (250 KB is ~60k tokens) while letting
+# every normal map through whole; the MCP transport limit is 1 MB.
+_MAX_GRAPH_RESPONSE_CHARS = 250_000
 
 # Default graph-size ceilings for kegg_pathway_graph. hsa05200 ("Pathways in
 # cancer"), the largest map in the validation set, is 255 nodes / 311 edges, so
 # these clear every ordinary map and only bite on member-expanded ones.
 _DEFAULT_MAX_NODES = 400
 _DEFAULT_MAX_EDGES = 1200
+# A whole-metabolism map carries thousands of gaps and hundreds of cross-map
+# pointers; unbounded they dominate the payload (hsa01100: 2,073 + 169).
+_DEFAULT_MAX_GAPS = 100
+_MAX_MAP_LINKS = 100
 
 # In-process KGML memo. A single reasoning chain calls kegg_pathway_graph and
 # kegg_pathway_neighborhood on the same map repeatedly; without this each one is
@@ -308,14 +339,31 @@ def _parse_flat_file(text: str) -> list[dict[str, Any]]:
     return records
 
 
-def _bounded(payload: Any, *, note: str) -> str:
-    """Serialize, and if it blows the soft cap say so instead of truncating mutely."""
+def _bounded(
+    payload: Any, *, note: str, reducible: tuple[str, ...] = (),
+    cap: int = _MAX_RESPONSE_CHARS,
+) -> str:
+    """Serialize, shrinking to the soft cap and SAYING what was dropped.
+
+    `reducible` names the dict keys whose list values may be trimmed, in
+    drop-priority order (first = dropped first). Anything not named is kept —
+    which is how `stats` keeps describing the WHOLE graph while the arrays that
+    quote it get cut.
+
+    This used to only LABEL an oversized dict and return it in full: the branch
+    set `payload["truncated"]` and serialized everything anyway, so the cap was
+    decorative for every dict-returning tool. A whole-metabolism map
+    (`hsa01100`: 6,382 nodes, 2,073 metabolic gaps) then blew past the 1 MB
+    transport limit, and the caller got NOTHING — not even the truncation note
+    that was supposed to help it recover.
+    """
     out = json.dumps(payload, ensure_ascii=False)
-    if len(out) <= _MAX_RESPONSE_CHARS:
+    if len(out) <= cap:
         return out
+
     if isinstance(payload, list):
         kept = list(payload)
-        while kept and len(json.dumps(kept, ensure_ascii=False)) > _MAX_RESPONSE_CHARS:
+        while kept and len(json.dumps(kept, ensure_ascii=False)) > cap:
             del kept[-max(1, len(kept) // 4):]
         return json.dumps(
             {
@@ -329,8 +377,37 @@ def _bounded(payload: Any, *, note: str) -> str:
             },
             ensure_ascii=False,
         )
+
     payload = dict(payload)
-    payload["truncated"] = {"reason": "response exceeded the size cap", "hint": note}
+    existing = payload.get("truncated")
+    truncated: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+
+    dropped: dict[str, Any] = {}
+    for key in reducible:
+        if len(json.dumps(payload, ensure_ascii=False)) <= cap:
+            break
+        seq = payload.get(key)
+        if not isinstance(seq, list) or not seq:
+            continue
+        before = len(seq)
+        while payload[key] and (
+            len(json.dumps(payload, ensure_ascii=False)) > cap
+        ):
+            payload[key] = payload[key][: -max(1, len(payload[key]) // 4)]
+        if len(payload[key]) != before:
+            # A caller-level cap may already have trimmed this section, in which
+            # case `before` is the capped length, not the real total. Keep the
+            # ORIGINAL total: reporting the intermediate figure would understate
+            # how much of the map is missing, which is the one thing `truncated`
+            # exists to prevent.
+            prior = truncated.get(key)
+            total = prior["total"] if isinstance(prior, dict) and "total" in prior else before
+            dropped[key] = {"returned": len(payload[key]), "total": total}
+
+    truncated.setdefault("reason", "response exceeded the size cap")
+    truncated["hint"] = note
+    truncated.update(dropped)
+    payload["truncated"] = truncated
     return json.dumps(payload, ensure_ascii=False)
 
 
@@ -368,8 +445,12 @@ async def find(
     ID this tool produces. KEGG IDs are not RDF-resolvable — convert them with
     `kegg_conv` before using them in any downstream RDF query.
 
-    RETURNS a JSON string of a bare array of `{"entry": str, "definition": str}`,
-    e.g. `[{"entry": "cpd:C00031", "definition": "D-Glucose; Grape sugar; ..."}]`.
+    RETURNS a JSON string of a bare array of
+    `{"entry": str, "entry_id": str, "definition": str}`, e.g.
+    `[{"entry": "cpd:C00031", "entry_id": "C00031", "definition": "D-Glucose; …"}]`.
+    `entry` is verbatim from KEGG (prefixed for some databases, bare for others)
+    and `entry_id` is always the bare form — pass `entry` to other KEGG tools and
+    `entry_id` to anything outside KEGG.
     Empty and non-empty results share the same `[...]` shape — an empty array
     means KEGG matched nothing (KEGG answers "no match" with an empty HTTP 200,
     not a 404). With `option="formula"`/`"exact_mass"`/`"mol_weight"` the
@@ -429,7 +510,16 @@ async def find(
 
     text = await _kegg_get(path, context="KEGG find")
     results = [
-        {"entry": entry, "definition": definition}
+        # `entry` is verbatim from KEGG (the form the other KEGG tools take);
+        # `entry_id` is the same value with any database prefix stripped, matching
+        # kegg_conv's source_id/target_id. Emitting BOTH is what stops a caller
+        # from guessing which form a downstream tool wants — KEGG's own output is
+        # prefixed for some databases and bare for others.
+        {
+            "entry": entry,
+            "entry_id": entry.split(":", 1)[1] if ":" in entry else entry,
+            "definition": definition,
+        }
         for entry, definition in _parse_tsv_pairs(text)
     ][:limit]
     return _bounded(results, note="narrow the query or lower `limit`.")
@@ -455,7 +545,10 @@ async def get_entry(
     `{"entry_id": str, "entry_type": str|null, "fields": {FIELD: [line, ...]}}`.
     `fields` holds KEGG's own flat-file field names (ENTRY, NAME, FORMULA,
     DBLINKS, ORTHOLOGY, PATHWAY, …), each value ALWAYS a list of lines even when
-    there is only one — the shape does not vary with the data. An empty array
+    there is only one — the shape does not vary with the data. `entry_id` is
+    BARE (`C00031`, `7157`), because that is how KEGG writes the flat file's
+    ENTRY line; re-attach the database prefix (`cpd:`, `hsa:`) before feeding it
+    to another KEGG tool. An empty array
     means no entry matched (KEGG returns an empty HTTP 200, not a 404). With
     `sequence="aaseq"`/`"ntseq"` each object is instead
     `{"entry_id", "header", "sequence"}` carrying the FASTA record.
@@ -536,9 +629,10 @@ async def _fetch_kgml(pathway: str) -> str:
     if not text.strip():
         raise ValueError(
             f"KEGG has no KGML for {pathway!r} (empty response). Not every KEGG "
-            "map has a KGML file — global/overview maps (e.g. 01100, 01110) and "
-            "some BRITE-style maps have none. Pick a regular pathway map, e.g. "
-            "'hsa04151' or 'hsa00010'."
+            "map has a KGML file; BRITE-style and some specialised maps have "
+            "none. (Global/overview maps such as 01100 DO have KGML — they are "
+            "simply very large.) Verify the id with kegg_find(database='pathway', "
+            "...) or pick a regular map such as 'hsa04151' or 'hsa00010'."
         )
 
     _kgml_cache[pathway] = text
@@ -671,6 +765,7 @@ async def pathway_graph(
     ] = False,
     max_nodes: Annotated[int, Field(ge=10, le=5000)] = _DEFAULT_MAX_NODES,
     max_edges: Annotated[int, Field(ge=10, le=20000)] = _DEFAULT_MAX_EDGES,
+    max_gaps: Annotated[int, Field(ge=0, le=5000)] = _DEFAULT_MAX_GAPS,
 ) -> str:
     """Fetch a KEGG pathway map as a normalized SIGNED DIRECTED GRAPH.
 
@@ -696,15 +791,21 @@ async def pathway_graph(
     across maps and is 0 for purely metabolic ones. `metabolic_gaps` is a
     RESULT, not an error: in an organism map KEGG keeps the reference layout and
     leaves the steps that organism LACKS as bare ortholog boxes, so this lists
-    the metabolic steps the organism cannot perform. If the map exceeds
-    `max_nodes`/`max_edges` the arrays are trimmed to the highest-degree
-    subgraph and a `truncated` object states what was dropped; `stats` always
-    describes the FULL map.
+    the metabolic steps the organism cannot perform. Whenever a map exceeds the
+    caps, the arrays are trimmed (nodes/edges to the highest-degree subgraph) and
+    `truncated` carries a `{"returned", "total"}` pair PER SECTION; `stats`
+    always describes the FULL map, so a trimmed response still reports the real
+    node/edge/gap counts.
 
-    RAISES ValueError on a malformed map id, when the map has no KGML at all
-    (global/overview maps like 01100 do not), when `expand_members` would
-    produce more than `max_edges` edges, and on any HTTP error — including
-    HTTP 403/429 for the 3 requests/second rate limit, which must not be retried.
+    GLOBAL/OVERVIEW MAPS (01100, 01110, 01120 …) DO have KGML, but they are
+    whole-metabolism drawings — hsa01100 parses to 6,382 nodes, 8,124 edges and
+    2,073 metabolic gaps. They are returned heavily reduced by the caps above;
+    prefer a specific map, or `kegg_pathway_neighborhood`, over fetching one whole.
+
+    RAISES ValueError on a malformed map id, when KEGG returns no KGML for the
+    map, when `expand_members` would produce more than `max_edges` edges, and on
+    any HTTP error — including HTTP 403/429 for the 3 requests/second rate limit,
+    which must not be retried.
 
     Args:
         pathway: KEGG map id, with or without the `path:` prefix. An organism
@@ -725,6 +826,9 @@ async def pathway_graph(
             highest-degree subgraph. Default 400.
         max_edges: Edge ceiling, applied the same way, and the cap that governs
             whether `expand_members` is allowed. Default 1200.
+        max_gaps: Maximum `metabolic_gaps` rows to return. Default 100; the full
+            count is always in `stats.metabolic_gap_count`. Whole-metabolism maps
+            have thousands, which would otherwise dominate the response.
 
     Returns:
         str: JSON object as described above.
@@ -754,12 +858,30 @@ async def pathway_graph(
             pathway, expand_members=True, include_maplink=include_maplink
         )
 
-    gaps = metabolic_gaps(graph)
-    stats = graph["stats"]
+    all_gaps = metabolic_gaps(graph)
+    # `stats` must keep describing the WHOLE map even when the arrays below are
+    # cut, so the caller can always see what it is looking at a slice of.
+    stats = {**graph["stats"], "metabolic_gap_count": len(all_gaps)}
 
     nodes = graph["nodes"]
     edges = graph["edges"]
-    truncated: dict[str, Any] | None = None
+    all_map_links = graph["map_links"]
+    gaps = all_gaps[:max_gaps]
+    map_links = all_map_links[:_MAX_MAP_LINKS]
+    truncated: dict[str, Any] = {}
+    # A whole-metabolism map is mostly gaps and cross-map pointers, not nodes:
+    # hsa01100 carries 2,073 metabolic gaps and 169 map links, which alone
+    # serialize to ~220 KB — past the 1 MB transport limit before nodes/edges are
+    # even counted. Cap them at the source rather than relying on the size
+    # backstop, so the common case degrades predictably instead of by byte count.
+    if len(all_gaps) > len(gaps):
+        truncated["metabolic_gaps"] = {
+            "returned": len(gaps), "total": len(all_gaps)
+        }
+    if len(all_map_links) > len(map_links):
+        truncated["map_links"] = {
+            "returned": len(map_links), "total": len(all_map_links)
+        }
     if len(nodes) > max_nodes or len(edges) > max_edges:
         # Degrade to the best-connected core rather than an arbitrary prefix: the
         # hub nodes are what a caller asking about a pathway is actually after.
@@ -772,19 +894,9 @@ async def pathway_graph(
         edges = [e for e in edges if e["source"] in kept and e["target"] in kept][
             :max_edges
         ]
-        truncated = {
-            "reason": "map exceeded max_nodes/max_edges",
-            "returned_nodes": len(nodes),
-            "returned_edges": len(edges),
-            "total_nodes": stats["node_count"],
-            "total_edges": stats["edge_count"],
-            "selection": "highest-degree nodes and the edges among them",
-            "hint": (
-                "`stats` still describes the full map. Use "
-                "kegg_pathway_neighborhood for a focused view, or raise "
-                "max_nodes/max_edges."
-            ),
-        }
+        truncated["nodes"] = {"returned": len(nodes), "total": stats["node_count"]}
+        truncated["edges"] = {"returned": len(edges), "total": stats["edge_count"]}
+        truncated["selection"] = "highest-degree nodes and the edges among them"
 
     result: dict[str, Any] = {
         "pathway": {**graph["pathway"], "id": pathway},
@@ -793,7 +905,7 @@ async def pathway_graph(
         "nodes": nodes,
         "edges": edges,
         "groups": graph["groups"],
-        "map_links": graph["map_links"],
+        "map_links": map_links,
         "metabolic_gaps": gaps,
         "metabolic_gaps_note": (
             "Ortholog boxes this organism's map draws but has no gene for — the "
@@ -804,8 +916,26 @@ async def pathway_graph(
         "options": graph["options"],
     }
     if truncated:
+        truncated["reason"] = "map larger than the requested caps"
+        truncated["hint"] = (
+            "`stats` still describes the full map. Raise max_nodes/max_edges/"
+            "max_gaps, or use kegg_pathway_neighborhood for a focused view."
+        )
         result["truncated"] = truncated
-    return _bounded(result, note="lower max_nodes/max_edges or use a neighborhood query.")
+    # Backstop: anything still oversized loses whole sections in this order, so a
+    # global map degrades to a usable answer instead of exceeding the transport
+    # limit and reaching the caller as nothing at all.
+    return _bounded(
+        result,
+        note="lower max_nodes/max_edges/max_gaps or use a neighborhood query.",
+        # Drop order = bulkiest-and-tunable first, smallest-and-unique last.
+        # `edges`/`nodes` are the bulk AND have explicit caps a caller can lower,
+        # whereas `metabolic_gaps` is this tool's unique answer and costs almost
+        # nothing to keep — sacrificing 25 gaps to save 2 KB, as an earlier order
+        # did, throws away the reason to call the tool at all.
+        reducible=("edges", "nodes", "map_links", "groups", "metabolic_gaps"),
+        cap=_MAX_GRAPH_RESPONSE_CHARS,
+    )
 
 
 @kegg_mcp.tool(annotations=READ_ONLY_TOOL)
@@ -959,8 +1089,16 @@ async def pathway_paths(
 
     ON METABOLIC MAPS, RAISE `max_length`. Compounds are joined through their
     enzyme (substrate → enzyme → product), so the hop count is roughly DOUBLE the
-    number of reactions: glucose to pyruvate in glycolysis (~10 reactions) needs
-    `max_length` around 12 and returns nothing at the default 6.
+    number of reactions: on hsa00010, alpha-D-Glucose (C00267) to pyruvate
+    (C00022) needs `max_length` 12 (the routes are 11 hops) and returns nothing
+    at the default 6.
+
+    AND CHECK THE ANOMER. A metabolic map draws specific chemical species, not
+    the name you have in mind: hsa00010 draws D-Glucose (C00031) as an ISOLATED
+    node and starts the chain at alpha-D-Glucose (C00267), so C00031 returns no
+    path at ANY `max_length`. An empty `paths` with an empty `unresolved` can
+    therefore mean you picked the un-drawn species — the `no_path_note` says so
+    when an endpoint has no edges at all.
 
     RAISES ValueError on a malformed map id, a missing endpoint, or when the map
     has no KGML, and on any HTTP error — including HTTP 403/429 for the 3
@@ -1008,6 +1146,25 @@ async def pathway_paths(
         if not unresolved
         else []
     )
+    # A catalysis edge lets a route detour through the ENZYME box between the same
+    # substrate and product, producing a second path over the identical reaction
+    # sequence — chemically the same route, drawn differently. Those duplicates
+    # eat the `max_paths` budget, so collapse routes whose reaction sequence is
+    # already present. Different REACTIONS between the same pair stay distinct
+    # (that is the whole reason the accession is on each edge).
+    seen_reactions: set[tuple] = set()
+    deduped = []
+    for path in paths:
+        key = tuple(
+            tuple(e.get("reaction") or ()) for e in path["edges"] if e.get("reaction")
+        )
+        if key and key in seen_reactions:
+            continue
+        if key:
+            seen_reactions.add(key)
+        deduped.append(path)
+    enzyme_detours = len(paths) - len(deduped)
+    paths = deduped
 
     payload: dict[str, Any] = {
         "pathway": {**graph["pathway"], "id": pathway},
@@ -1029,12 +1186,42 @@ async def pathway_paths(
             "with kegg_link(target=<org>, source=<pathway>) or pick another map."
         )
     elif not paths:
-        payload["no_path_note"] = (
-            "Both endpoints are present on this map, but no directed route of at "
-            f"most {max_length} edges connects them. On a METABOLIC map raise "
-            "`max_length`: compounds are joined through their enzyme, so the hop "
-            "count is about double the number of reactions."
-        )
+        # An endpoint with NO edges at all is a different finding from one that is
+        # merely far away, and only the first is hopeless at any max_length. KEGG
+        # maps routinely draw a named compound as an isolated box while the chain
+        # actually runs through a specific species (hsa00010 draws D-Glucose
+        # C00031 isolated and starts at alpha-D-Glucose C00267), so an agent that
+        # cannot tell these apart concludes "no route exists" from a bad pick.
+        degree: dict[str, int] = {}
+        for e in graph["edges"]:
+            degree[e["source"]] = degree.get(e["source"], 0) + 1
+            degree[e["target"]] = degree.get(e["target"], 0) + 1
+        isolated = [
+            label
+            for label, hits in ((source, source_nodes), (target, target_nodes))
+            if not any(degree.get(n) for n in hits)
+        ]
+        if isolated:
+            payload["isolated_endpoints"] = isolated
+            payload["no_path_note"] = (
+                f"{isolated} is drawn on this map but has NO edges at all "
+                "(degree 0), so no route exists at any `max_length` — raising it "
+                "will not help. KEGG maps draw specific chemical species: a "
+                "compound you name may be the un-drawn one while the chain runs "
+                "through another (hsa00010 draws D-Glucose C00031 isolated and "
+                "starts at alpha-D-Glucose C00267). Check the neighbourhood with "
+                "kegg_pathway_neighborhood(direction='both', depth=1) and pick the "
+                "species the map actually connects."
+            )
+        else:
+            payload["no_path_note"] = (
+                "Both endpoints are present AND connected on this map, but no "
+                f"directed route of at most {max_length} edges joins them. On a "
+                "METABOLIC map raise `max_length`: compounds are joined through "
+                "their enzyme, so the hop count is about double the reaction count."
+            )
+    if enzyme_detours:
+        payload["enzyme_detours_collapsed"] = enzyme_detours
     if len(paths) >= max_paths:
         payload["truncated"] = {
             "reason": "enumeration stopped at `max_paths`",

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -339,23 +339,40 @@ def _parse_flat_file(text: str) -> list[dict[str, Any]]:
     return records
 
 
+# A graph tool must never answer with zero edges: that is indistinguishable from
+# "these molecules are unconnected", so it is more dangerous than an error.
+_PRIMARY_FLOOR = 50
+
+
+def _section_bytes(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    return len(json.dumps(value, ensure_ascii=False)) if isinstance(value, list) else 0
+
+
 def _bounded(
-    payload: Any, *, note: str, reducible: tuple[str, ...] = (),
+    payload: Any,
+    *,
+    note: str,
     cap: int = _MAX_RESPONSE_CHARS,
+    secondary: tuple[str, ...] = (),
+    primary: tuple[str, ...] = (),
+    primary_floor: int = 0,
 ) -> str:
-    """Serialize, shrinking to the soft cap and SAYING what was dropped.
+    """Serialize, shrinking to `cap`, and SAY what was dropped and why.
 
-    `reducible` names the dict keys whose list values may be trimmed, in
-    drop-priority order (first = dropped first). Anything not named is kept —
-    which is how `stats` keeps describing the WHOLE graph while the arrays that
-    quote it get cut.
+    Sections are reduced in two tiers: `secondary` (supporting detail) is spent
+    first, `primary` (the answer itself) only after, and never below
+    `primary_floor` rows. WITHIN a tier the BIGGEST section goes first, because
+    the goal is to reclaim bytes — zeroing a 2 KB section to cover a 6 KB
+    overflow destroys content and fixes nothing.
 
-    This used to only LABEL an oversized dict and return it in full: the branch
-    set `payload["truncated"]` and serialized everything anyway, so the cap was
-    decorative for every dict-returning tool. A whole-metabolism map
-    (`hsa01100`: 6,382 nodes, 2,073 metabolic gaps) then blew past the 1 MB
-    transport limit, and the caller got NOTHING — not even the truncation note
-    that was supposed to help it recover.
+    That ordering is the product of getting it wrong twice in both directions. A
+    fixed "gaps first" order threw away all 25 of hsa00010's metabolic gaps to
+    save 2 KB — the tool's unique answer, spent to protect bulk. Reversing it to
+    "edges first" then let a whole-metabolism map's 186 KB of gaps push `edges`
+    to ZERO, i.e. a pathway graph with no graph in it. Neither is a matter of
+    which section is more precious; it is that the section which OCCUPIES the
+    budget must be the one that pays, and the answer must keep a floor.
     """
     out = json.dumps(payload, ensure_ascii=False)
     if len(out) <= cap:
@@ -378,35 +395,73 @@ def _bounded(
             ensure_ascii=False,
         )
 
+    if not isinstance(payload, dict):
+        return out
+
     payload = dict(payload)
     existing = payload.get("truncated")
     truncated: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    # What each section costs BEFORE the backstop touches it — this is what tells
+    # a caller which section ate the budget, including one that was never trimmed.
+    occupancy = {
+        key: _section_bytes(payload, key)
+        for key in (*secondary, *primary)
+        # Skip empty sections: an empty list serializes to 2 bytes and would
+        # otherwise show up as a budget occupant, which is pure noise.
+        if isinstance(payload.get(key), list) and payload[key]
+    }
 
-    dropped: dict[str, Any] = {}
-    for key in reducible:
-        if len(json.dumps(payload, ensure_ascii=False)) <= cap:
-            break
-        seq = payload.get(key)
-        if not isinstance(seq, list) or not seq:
-            continue
-        before = len(seq)
-        while payload[key] and (
-            len(json.dumps(payload, ensure_ascii=False)) > cap
-        ):
-            payload[key] = payload[key][: -max(1, len(payload[key]) // 4)]
-        if len(payload[key]) != before:
-            # A caller-level cap may already have trimmed this section, in which
-            # case `before` is the capped length, not the real total. Keep the
-            # ORIGINAL total: reporting the intermediate figure would understate
-            # how much of the map is missing, which is the one thing `truncated`
-            # exists to prevent.
-            prior = truncated.get(key)
-            total = prior["total"] if isinstance(prior, dict) and "total" in prior else before
-            dropped[key] = {"returned": len(payload[key]), "total": total}
+    def _fits() -> bool:
+        return len(json.dumps(payload, ensure_ascii=False)) <= cap
 
-    truncated.setdefault("reason", "response exceeded the size cap")
+    for tier, floor in ((secondary, 0), (primary, primary_floor)):
+        # Biggest first: reclaim where the bytes actually are.
+        for key in sorted(tier, key=lambda k: -_section_bytes(payload, k)):
+            if _fits():
+                break
+            seq = payload.get(key)
+            if not isinstance(seq, list) or len(seq) <= floor:
+                continue
+            before = len(seq)
+            while len(payload[key]) > floor and not _fits():
+                step = max(1, len(payload[key]) // 4)
+                payload[key] = payload[key][: max(floor, len(payload[key]) - step)]
+            if len(payload[key]) != before:
+                prior = truncated.get(key)
+                total = (
+                    prior["total"]
+                    if isinstance(prior, dict) and "total" in prior
+                    else before
+                )
+                truncated[key] = {
+                    "returned": len(payload[key]),
+                    "total": total,
+                    "capped_by": "size_budget",
+                }
+
+    # Mark every section that was already count-capped, and every section that
+    # merely OCCUPIED the budget — the one that starved the others is otherwise
+    # the only one absent from the report.
+    for key, size in occupancy.items():
+        entry = truncated.get(key)
+        if isinstance(entry, dict):
+            entry.setdefault("capped_by", "count")
+        elif isinstance(payload.get(key), list):
+            truncated[key] = {
+                "returned": len(payload[key]),
+                "total": len(payload[key]),
+                "capped_by": None,
+            }
+
+    reasons = truncated.get("reasons") or (
+        [truncated["reason"]] if truncated.get("reason") else []
+    )
+    reasons = [r for r in reasons if r != "response exceeded the size cap"]
+    reasons.append("response exceeded the size cap")
+    truncated.pop("reason", None)
+    truncated["reasons"] = reasons
+    truncated["section_bytes"] = occupancy
     truncated["hint"] = note
-    truncated.update(dropped)
     payload["truncated"] = truncated
     return json.dumps(payload, ensure_ascii=False)
 
@@ -876,11 +931,13 @@ async def pathway_graph(
     # backstop, so the common case degrades predictably instead of by byte count.
     if len(all_gaps) > len(gaps):
         truncated["metabolic_gaps"] = {
-            "returned": len(gaps), "total": len(all_gaps)
+            "returned": len(gaps), "total": len(all_gaps),
+            "capped_by": "count",
         }
     if len(all_map_links) > len(map_links):
         truncated["map_links"] = {
-            "returned": len(map_links), "total": len(all_map_links)
+            "returned": len(map_links), "total": len(all_map_links),
+            "capped_by": "count",
         }
     if len(nodes) > max_nodes or len(edges) > max_edges:
         # Degrade to the best-connected core rather than an arbitrary prefix: the
@@ -894,8 +951,12 @@ async def pathway_graph(
         edges = [e for e in edges if e["source"] in kept and e["target"] in kept][
             :max_edges
         ]
-        truncated["nodes"] = {"returned": len(nodes), "total": stats["node_count"]}
-        truncated["edges"] = {"returned": len(edges), "total": stats["edge_count"]}
+        truncated["nodes"] = {
+            "returned": len(nodes), "total": stats["node_count"], "capped_by": "count"
+        }
+        truncated["edges"] = {
+            "returned": len(edges), "total": stats["edge_count"], "capped_by": "count"
+        }
         truncated["selection"] = "highest-degree nodes and the edges among them"
 
     result: dict[str, Any] = {
@@ -916,7 +977,7 @@ async def pathway_graph(
         "options": graph["options"],
     }
     if truncated:
-        truncated["reason"] = "map larger than the requested caps"
+        truncated["reasons"] = ["map larger than the requested caps"]
         truncated["hint"] = (
             "`stats` still describes the full map. Raise max_nodes/max_edges/"
             "max_gaps, or use kegg_pathway_neighborhood for a focused view."
@@ -928,12 +989,13 @@ async def pathway_graph(
     return _bounded(
         result,
         note="lower max_nodes/max_edges/max_gaps or use a neighborhood query.",
-        # Drop order = bulkiest-and-tunable first, smallest-and-unique last.
-        # `edges`/`nodes` are the bulk AND have explicit caps a caller can lower,
-        # whereas `metabolic_gaps` is this tool's unique answer and costs almost
-        # nothing to keep — sacrificing 25 gaps to save 2 KB, as an earlier order
-        # did, throws away the reason to call the tool at all.
-        reducible=("edges", "nodes", "map_links", "groups", "metabolic_gaps"),
+        # `nodes`/`edges` ARE the graph — they are what the caller asked for, so
+        # they pay last and keep a floor. Everything else is supporting detail
+        # and is spent first, largest first, so the section actually occupying
+        # the budget is the one that gives it back.
+        secondary=("map_links", "groups", "metabolic_gaps"),
+        primary=("edges", "nodes"),
+        primary_floor=_PRIMARY_FLOOR,
         cap=_MAX_GRAPH_RESPONSE_CHARS,
     )
 

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -234,6 +234,14 @@ _DEFAULT_MAX_EDGES = 1200
 _DEFAULT_MAX_GAPS = 100
 _MAX_MAP_LINKS = 100
 
+# Share of the response cap that nodes+edges get FIRST, before the supporting
+# sections are allowed to spend any of it. Without it the caps interact
+# backwards: `max_gaps=5000` on hsa01100 let 1,555 gaps take 74% of the payload
+# and the graph collapsed to the 50-node floor — i.e. raising every cap returned
+# a SMALLER graph than the defaults (191 nodes). A caller raising caps is asking
+# for more, so the primary answer must not be what pays for it.
+_GRAPH_BUDGET_SHARE = 0.5
+
 # In-process KGML memo. A single reasoning chain calls kegg_pathway_graph and
 # kegg_pathway_neighborhood on the same map repeatedly; without this each one is
 # another request against a 3/s budget.
@@ -858,6 +866,30 @@ def _fit_graph_to_budget(
     return take(max(low, min(_PRIMARY_FLOOR, ceiling)))
 
 
+def _fit_sections_to_budget(
+    sections: dict[str, list[Any]], budget: int
+) -> dict[str, list[Any]]:
+    """Largest prefixes of the supporting sections whose combined JSON fits.
+
+    Biggest-first, the same rule `_bounded` applies: reclaim where the bytes
+    actually are, so a 10 KB section is never emptied to cover a 100 KB
+    overflow. Applied BEFORE the graph is fitted, this is what keeps the caps
+    from interacting backwards — see `_GRAPH_BUDGET_SHARE`.
+    """
+    kept = {key: list(rows) for key, rows in sections.items()}
+
+    def size(rows: list[Any]) -> int:
+        return len(json.dumps(rows, ensure_ascii=False))
+
+    while sum(size(rows) for rows in kept.values()) > budget:
+        key = max(kept, key=lambda k: size(kept[k]))
+        if not kept[key]:
+            break
+        step = max(1, len(kept[key]) // 4)
+        kept[key] = kept[key][:-step]
+    return kept
+
+
 @kegg_mcp.tool(annotations=READ_ONLY_TOOL)
 async def pathway_graph(
     pathway: Annotated[
@@ -901,7 +933,11 @@ async def pathway_graph(
     caps, the arrays are trimmed (nodes/edges to the highest-degree subgraph) and
     `truncated` carries a `{"returned", "total"}` pair PER SECTION; `stats`
     always describes the FULL map, so a trimmed response still reports the real
-    node/edge/gap counts.
+    node/edge/gap counts. `max_nodes`, `max_edges` and `max_gaps` are ceilings on
+    ONE shared response budget, not independent quotas — half of it is reserved
+    for `nodes`+`edges` so raising `max_gaps` can no longer starve the graph, but
+    beyond that half the sections still trade against each other. Raise one cap
+    at a time, and set `max_gaps=0` when you want the largest graph.
 
     GLOBAL/OVERVIEW MAPS (01100, 01110, 01120 …) DO have KGML, but they are
     whole-metabolism drawings — hsa01100 parses to 6,382 nodes, 8,124 edges and
@@ -934,7 +970,10 @@ async def pathway_graph(
             whether `expand_members` is allowed. Default 1200.
         max_gaps: Maximum `metabolic_gaps` rows to return. Default 100; the full
             count is always in `stats.metabolic_gap_count`. Whole-metabolism maps
-            have thousands, which would otherwise dominate the response.
+            have thousands, which would otherwise dominate the response — gaps
+            may only spend what is left after `nodes`+`edges` take their reserved
+            half of the budget, so a high `max_gaps` is honored only as far as
+            that remainder allows.
 
     Returns:
         str: JSON object as described above.
@@ -970,18 +1009,9 @@ async def pathway_graph(
     stats = {**graph["stats"], "metabolic_gap_count": len(all_gaps)}
 
     all_map_links = graph["map_links"]
-    gaps = all_gaps[:max_gaps]
-    map_links = all_map_links[:_MAX_MAP_LINKS]
+    counted_gaps = all_gaps[:max_gaps]
+    counted_map_links = all_map_links[:_MAX_MAP_LINKS]
     truncated: dict[str, Any] = {}
-    if len(all_gaps) > len(gaps):
-        truncated["metabolic_gaps"] = {
-            "returned": len(gaps), "total": len(all_gaps), "capped_by": "count",
-        }
-    if len(all_map_links) > len(map_links):
-        truncated["map_links"] = {
-            "returned": len(map_links), "total": len(all_map_links),
-            "capped_by": "count",
-        }
 
     # Order by degree: a caller asking about a pathway wants its hubs.
     degree: dict[str, int] = {}
@@ -990,17 +1020,20 @@ async def pathway_graph(
         degree[e["target"]] = degree.get(e["target"], 0) + 1
     ordered = sorted(graph["nodes"], key=lambda n: -degree.get(n["id"], 0))
 
-    # Reserve everything that is NOT the graph first — it is already count-capped
-    # and small (gaps + map_links are ~22 KB), so spending it to buy nodes is a
-    # bad trade: metabolic_gaps is this tool's unique answer and vanished from
-    # every organism global map when the budget was computed the other way round.
+    # The supporting sections are reserved BEFORE the graph — spending them to
+    # buy nodes is a bad trade, since metabolic_gaps is this tool's unique answer
+    # and vanished from every organism global map when the budget was computed
+    # the other way round. But they may only reserve what is left after the graph
+    # has taken its guaranteed share, or the two caps fight and `max_gaps` wins:
+    # that is how raising every cap came to return 50 nodes where the defaults
+    # return 191. Count cap first, then this byte allowance.
     envelope = {
         "pathway": {**graph["pathway"], "id": pathway},
         "signal_quality": _signal_quality(graph),
         "stats": stats,
         "groups": graph["groups"],
-        "map_links": map_links,
-        "metabolic_gaps": gaps,
+        "map_links": [],
+        "metabolic_gaps": [],
         "metabolic_gaps_note": (
             "Ortholog boxes this organism's map draws but has no gene for — the "
             "white boxes in KEGG's rendered image. These are metabolic steps the "
@@ -1009,6 +1042,31 @@ async def pathway_graph(
         ),
         "options": graph["options"],
     }
+    fixed = len(json.dumps(envelope, ensure_ascii=False)) + 2_000  # + truncated
+    graph_share = int(_MAX_GRAPH_RESPONSE_CHARS * _GRAPH_BUDGET_SHARE)
+    supporting = _fit_sections_to_budget(
+        {"metabolic_gaps": counted_gaps, "map_links": counted_map_links},
+        max(_MAX_GRAPH_RESPONSE_CHARS - fixed - graph_share, 0),
+    )
+    gaps = supporting["metabolic_gaps"]
+    map_links = supporting["map_links"]
+    envelope["metabolic_gaps"] = gaps
+    envelope["map_links"] = map_links
+
+    for key, kept, counted, whole in (
+        ("metabolic_gaps", gaps, counted_gaps, all_gaps),
+        ("map_links", map_links, counted_map_links, all_map_links),
+    ):
+        if len(kept) < len(whole):
+            truncated[key] = {
+                "returned": len(kept),
+                "total": len(whole),
+                # "count" only if the requested cap alone bound it: a section cut
+                # further to leave the graph its share must not tell the caller
+                # that raising the cap will help.
+                "capped_by": "size_budget" if len(kept) < len(counted) else "count",
+            }
+
     reserved = len(json.dumps(envelope, ensure_ascii=False)) + 2_000  # + truncated
     nodes, edges = _fit_graph_to_budget(
         ordered,
@@ -1068,10 +1126,34 @@ async def pathway_graph(
                 ("size_budget", "response exceeded the size cap"),
             ) if kind in kinds
         ]
-        truncated["hint"] = (
-            "`stats` still describes the full map. Raise max_nodes/max_edges/"
-            "max_gaps, or use kegg_pathway_neighborhood for a focused view."
+        # A generic "raise the caps" hint is actively wrong when the supporting
+        # sections are what the graph is competing with: there the only move that
+        # buys nodes is LOWERING max_gaps, and raising it costs graph.
+        supporting_bytes = sum(
+            len(json.dumps(rows, ensure_ascii=False)) for rows in supporting.values()
         )
+        graph_bytes = len(
+            json.dumps({"nodes": nodes, "edges": edges}, ensure_ascii=False)
+        )
+        # Fire it when reclaiming those bytes would visibly grow the graph (>25%
+        # of what it currently costs), not merely when they outweigh it — at the
+        # default max_gaps they are ~10% of the payload and the generic advice is
+        # the right one.
+        if node_limit == "size_budget" and supporting_bytes * 4 > graph_bytes:
+            truncated["hint"] = (
+                f"`metabolic_gaps` and `map_links` are occupying {supporting_bytes} "
+                f"bytes against the graph's {graph_bytes} — they draw on the SAME "
+                "response budget. LOWER `max_gaps` (0 for none) to spend it on "
+                "nodes and edges instead; raising max_nodes alone will not help "
+                "here. `stats` still describes the full map."
+            )
+        else:
+            truncated["hint"] = (
+                "`stats` still describes the full map. Raise max_nodes/max_edges/"
+                "max_gaps, or use kegg_pathway_neighborhood for a focused view. "
+                "All three draw on ONE response budget, so raising one can shrink "
+                "the others."
+            )
         result["truncated"] = truncated
 
     # Backstop only for the supporting sections; nodes/edges are already fitted

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -807,6 +807,57 @@ def _cycle_interpretation(
     return notes
 
 
+def _fit_graph_to_budget(
+    ordered_nodes: list[dict[str, Any]],
+    all_edges: list[dict[str, Any]],
+    *,
+    max_nodes: int,
+    max_edges: int,
+    budget: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Largest top-N node prefix whose INDUCED edge set still fits `budget`.
+
+    Returning nodes and edges as two independently-clipped lists is what produced
+    the worst bug this tool has had: trimming `nodes` to 1,062 and `edges` to 50
+    left every one of those 50 edges pointing at a node that had been cut, so the
+    caller could not resolve a single endpoint — and 1,062 nodes appeared
+    isolated on a densely-connected map. Both are wrong ANSWERS, not merely small
+    ones, and neither looks like an error.
+
+    So the unit of reduction is the NODE SET, and the edges are always the
+    induced subgraph over it. Shrinking nodes shrinks the edge set with them, so
+    one binary search over N satisfies the byte budget while keeping the result
+    internally consistent by construction.
+    """
+    ceiling = min(max_nodes, len(ordered_nodes))
+
+    def take(n: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        nodes = ordered_nodes[:n]
+        ids = {node["id"] for node in nodes}
+        edges = [
+            e for e in all_edges if e["source"] in ids and e["target"] in ids
+        ][:max_edges]
+        return nodes, edges
+
+    def cost(n: int) -> int:
+        nodes, edges = take(n)
+        return len(json.dumps({"nodes": nodes, "edges": edges}, ensure_ascii=False))
+
+    if ceiling == 0 or cost(ceiling) <= budget:
+        return take(ceiling)
+
+    low, high = 0, ceiling
+    while low < high:
+        mid = (low + high + 1) // 2
+        if cost(mid) <= budget:
+            low = mid
+        else:
+            high = mid - 1
+    # Never answer with nothing: a floor of nodes is more useful than an empty
+    # graph, even if it overshoots the soft budget slightly.
+    return take(max(low, min(_PRIMARY_FLOOR, ceiling)))
+
+
 @kegg_mcp.tool(annotations=READ_ONLY_TOOL)
 async def pathway_graph(
     pathway: Annotated[
@@ -918,53 +969,35 @@ async def pathway_graph(
     # cut, so the caller can always see what it is looking at a slice of.
     stats = {**graph["stats"], "metabolic_gap_count": len(all_gaps)}
 
-    nodes = graph["nodes"]
-    edges = graph["edges"]
     all_map_links = graph["map_links"]
     gaps = all_gaps[:max_gaps]
     map_links = all_map_links[:_MAX_MAP_LINKS]
     truncated: dict[str, Any] = {}
-    # A whole-metabolism map is mostly gaps and cross-map pointers, not nodes:
-    # hsa01100 carries 2,073 metabolic gaps and 169 map links, which alone
-    # serialize to ~220 KB — past the 1 MB transport limit before nodes/edges are
-    # even counted. Cap them at the source rather than relying on the size
-    # backstop, so the common case degrades predictably instead of by byte count.
     if len(all_gaps) > len(gaps):
         truncated["metabolic_gaps"] = {
-            "returned": len(gaps), "total": len(all_gaps),
-            "capped_by": "count",
+            "returned": len(gaps), "total": len(all_gaps), "capped_by": "count",
         }
     if len(all_map_links) > len(map_links):
         truncated["map_links"] = {
             "returned": len(map_links), "total": len(all_map_links),
             "capped_by": "count",
         }
-    if len(nodes) > max_nodes or len(edges) > max_edges:
-        # Degrade to the best-connected core rather than an arbitrary prefix: the
-        # hub nodes are what a caller asking about a pathway is actually after.
-        degree: dict[str, int] = {}
-        for e in edges:
-            degree[e["source"]] = degree.get(e["source"], 0) + 1
-            degree[e["target"]] = degree.get(e["target"], 0) + 1
-        nodes = sorted(nodes, key=lambda n: -degree.get(n["id"], 0))[:max_nodes]
-        kept = {n["id"] for n in nodes}
-        edges = [e for e in edges if e["source"] in kept and e["target"] in kept][
-            :max_edges
-        ]
-        truncated["nodes"] = {
-            "returned": len(nodes), "total": stats["node_count"], "capped_by": "count"
-        }
-        truncated["edges"] = {
-            "returned": len(edges), "total": stats["edge_count"], "capped_by": "count"
-        }
-        truncated["selection"] = "highest-degree nodes and the edges among them"
 
-    result: dict[str, Any] = {
+    # Order by degree: a caller asking about a pathway wants its hubs.
+    degree: dict[str, int] = {}
+    for e in graph["edges"]:
+        degree[e["source"]] = degree.get(e["source"], 0) + 1
+        degree[e["target"]] = degree.get(e["target"], 0) + 1
+    ordered = sorted(graph["nodes"], key=lambda n: -degree.get(n["id"], 0))
+
+    # Reserve everything that is NOT the graph first — it is already count-capped
+    # and small (gaps + map_links are ~22 KB), so spending it to buy nodes is a
+    # bad trade: metabolic_gaps is this tool's unique answer and vanished from
+    # every organism global map when the budget was computed the other way round.
+    envelope = {
         "pathway": {**graph["pathway"], "id": pathway},
         "signal_quality": _signal_quality(graph),
         "stats": stats,
-        "nodes": nodes,
-        "edges": edges,
         "groups": graph["groups"],
         "map_links": map_links,
         "metabolic_gaps": gaps,
@@ -976,26 +1009,79 @@ async def pathway_graph(
         ),
         "options": graph["options"],
     }
+    reserved = len(json.dumps(envelope, ensure_ascii=False)) + 2_000  # + truncated
+    nodes, edges = _fit_graph_to_budget(
+        ordered,
+        graph["edges"],
+        max_nodes=max_nodes,
+        max_edges=max_edges,
+        budget=max(_MAX_GRAPH_RESPONSE_CHARS - reserved, 10_000),
+    )
+
+    # One decision limits both: how far the node prefix could extend. Edges are
+    # the induced subgraph over it, so they inherit that reason unless their own
+    # count cap bound them first — labelling an induced edge count as
+    # "size_budget" would tell a caller to narrow the question when raising
+    # max_nodes is what actually helps.
+    node_limit = "count" if len(nodes) >= max_nodes else "size_budget"
+    if len(nodes) < stats["node_count"]:
+        truncated["nodes"] = {
+            "returned": len(nodes),
+            "total": stats["node_count"],
+            "capped_by": node_limit,
+        }
+    if len(edges) < stats["edge_count"]:
+        truncated["edges"] = {
+            "returned": len(edges),
+            "total": stats["edge_count"],
+            "capped_by": "count" if len(edges) >= max_edges else node_limit,
+            "note": "induced subgraph over the returned `nodes`",
+        }
     if truncated:
-        truncated["reasons"] = ["map larger than the requested caps"]
+        # What each section would have cost UNREDUCED. This is what answers "why
+        # are there so few edges?" — the section that drove the reduction is
+        # otherwise invisible, because a section that merely occupied the budget
+        # has returned == total and nothing flags it.
+        truncated["section_bytes_if_complete"] = {
+            "nodes": len(json.dumps(graph["nodes"], ensure_ascii=False)),
+            "edges": len(json.dumps(graph["edges"], ensure_ascii=False)),
+            "metabolic_gaps": len(json.dumps(all_gaps, ensure_ascii=False)),
+            "map_links": len(json.dumps(all_map_links, ensure_ascii=False)),
+        }
+        truncated["selection"] = (
+            "highest-degree nodes and the induced subgraph over them — every "
+            "returned edge has both endpoints in `nodes`"
+        )
+
+    result: dict[str, Any] = {**envelope, "nodes": nodes, "edges": edges}
+    if truncated:
+        # Keep the two firing conditions distinguishable: a caller who hit only
+        # the count caps can raise them, whereas one who hit the size budget
+        # cannot and must narrow the question instead.
+        kinds = {
+            v["capped_by"] for v in truncated.values()
+            if isinstance(v, dict) and v.get("capped_by")
+        }
+        truncated["reasons"] = [
+            label for kind, label in (
+                ("count", "map larger than the requested caps"),
+                ("size_budget", "response exceeded the size cap"),
+            ) if kind in kinds
+        ]
         truncated["hint"] = (
             "`stats` still describes the full map. Raise max_nodes/max_edges/"
             "max_gaps, or use kegg_pathway_neighborhood for a focused view."
         )
         result["truncated"] = truncated
-    # Backstop: anything still oversized loses whole sections in this order, so a
-    # global map degrades to a usable answer instead of exceeding the transport
-    # limit and reaching the caller as nothing at all.
+
+    # Backstop only for the supporting sections; nodes/edges are already fitted
+    # AS A PAIR and must not be clipped independently — that is what created
+    # dangling edges. Their invariant is enforced structurally in
+    # _fit_graph_to_budget, so this can never break it.
     return _bounded(
         result,
         note="lower max_nodes/max_edges/max_gaps or use a neighborhood query.",
-        # `nodes`/`edges` ARE the graph — they are what the caller asked for, so
-        # they pay last and keep a floor. Everything else is supporting detail
-        # and is spent first, largest first, so the section actually occupying
-        # the budget is the one that gives it back.
         secondary=("map_links", "groups", "metabolic_gaps"),
-        primary=("edges", "nodes"),
-        primary_floor=_PRIMARY_FLOOR,
         cap=_MAX_GRAPH_RESPONSE_CHARS,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
PATCH release. Four review rounds against the live KEGG API, all on how
`kegg_pathway_graph` reduces an oversized response. Every fix is a case where the tool
returned something that looked like a valid answer and was not.

- **Dangling edges.** Trimming `nodes` and `edges` as two independent lists left edges
  pointing at node ids that had been cut (in one synthetic case all 50 of them), while
  hundreds of returned nodes appeared edgeless on a densely connected map. The unit of
  reduction is now the NODE SET: a binary search finds the largest degree-ordered prefix
  whose INDUCED subgraph fits, so every returned edge resolves by construction.
- **`metabolic_gaps` vanished from every organism global map at default arguments** — the
  budget was computed against unreduced section sizes. It is now computed on what is
  actually being returned.
- **Raised caps starved the graph.** `max_gaps=5000` on hsa01100 took 74% of the payload
  and left 50 nodes, fewer than the 191 the defaults return. `nodes`+`edges` now take half
  the budget before the supporting sections may spend any of it (138/346 in that case),
  and the hint says to *lower* `max_gaps` when they are what the graph is competing with.
- **Diagnostics**: `truncated` gains `reasons`, per-section `capped_by`
  (`count`/`size_budget`) and `section_bytes_if_complete`; a section cut to protect the
  graph's reserve reports `size_budget`, never `count`.
- Plus KEGG docstring corrections (global maps DO have KGML; the glycolysis example was
  measured on the wrong map), enzyme-detour collapsing in `kegg_pathway_paths`, and
  `entry_id` on `kegg_find`.

PATCH, not MINOR: no tool added or renamed, no parameter change, return shape unchanged —
only which rows come back inside it. Affects the stdio + `TOGOMCP_ENABLE_KEGG=1` audience
only; the hosted server does not mount KEGG.

Tests: 395 pass. The three invariants that must hold on every `kegg_pathway_graph` return
(no dangling edge, under the 1 MB transport limit, not overwhelmingly isolated nodes) are
now asserted on all four reduction paths — no cap, count cap, size cap, all caps raised.
No test touches rest.kegg.jp; the global-map cases use a synthetic KGML fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)