### PR TITLE
release: 2.5.0 — KEGG seed resolution + a quiet shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
   every row of the answer then reads "AKT3" for a question asked about AKT1. `unresolved_note` now
   states that all three routes were tried and suggests retrying with a KEGG gene id.
 
+- **A clean shutdown printed a 38-line traceback into the client's log.** The atexit hooks in
+  `kegg.py` and `togoid.py` fell back to `asyncio.run(_client.aclose())` when no loop was running —
+  which at interpreter shutdown is always — so a fresh loop reached into the already-closed loop that
+  owned the sockets and raised `RuntimeError: Event loop is closed`. Harmless (exit code 0, stdout
+  untouched, emitted after all work) but misleading: it is the first thing anyone debugging KEGG or
+  TogoID would suspect. The hook now leaves the sockets to the OS, which reclaims them anyway. Fires
+  only in a session that made at least one request through those clients.
+
 ## [2.4.1] - 2026-07-31
 
 Four review rounds against the live KEGG API, all on `kegg_pathway_graph`'s response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.5.0] - 2026-07-31
+
+Two fixes found by using the KEGG tools rather than reading them: a seed form the
+docstring itself advertised did not work, and a clean shutdown looked like a crash in
+the client's log. MINOR rather than PATCH because the first adds two return fields.
+
 ### Fixed
 
 - **A paralog-family member could not be used as a seed under its own name.**
@@ -1033,7 +1041,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.4.1...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/dbcls/togomcp/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/dbcls/togomcp/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/dbcls/togomcp/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/dbcls/togomcp/compare/v2.2.1...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,23 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A paralog-family member could not be used as a seed under its own name.**
+  `kegg_pathway_neighborhood(pathway="hsa04151", seeds="AKT1")` returned `unresolved`, while
+  `seeds="hsa:207"` — the same gene — resolved instantly and returned 33 downstream nodes. Box 17 of
+  that map holds hsa:10000, hsa:207 and hsa:208 (AKT3/AKT1/AKT2), but KGML's `graphics/@name` carries
+  only the DRAWN label, "AKT3" and *its* aliases, and seed resolution looked no further. So the
+  paralog-family trap this tool advertises as solved was still open on the way IN, and
+  `unresolved_note` compounded it by suggesting the gene might not be drawn on the map — it is drawn,
+  under a sibling's name. Seeds and path endpoints that KGML cannot match are now looked up against
+  KEGG's gene symbols and intersected with THAT MAP's members: one extra request per unmatched
+  symbol, cached, and only on the path that would otherwise have returned nothing. `/find` is a
+  substring search, so only rows carrying the symbol verbatim in their symbol list count — "AKT1"
+  must not resolve through AKT1S1. When the fallback fires, `seed_resolution` /
+  `endpoint_resolution` says which member matched and what the box is actually labelled, because
+  every row of the answer then reads "AKT3" for a question asked about AKT1. `unresolved_note` now
+  states that all three routes were tried and suggests retrying with a KEGG gene id.
 
 ## [2.4.1] - 2026-07-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.4.1"
+version = "2.5.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -20,6 +20,7 @@ import respx
 from fastmcp import FastMCP
 
 import togo_mcp.kegg as kegg
+import togo_mcp.togoid as togoid
 from togo_mcp.kegg import _MAX_GRAPH_RESPONSE_CHARS as _MAX_GRAPH_CAP
 import togo_mcp.main as main
 from togo_mcp.kegg import (
@@ -1083,6 +1084,30 @@ class TestRateLimit:
             )
             elapsed = time.monotonic() - start
         assert elapsed >= 2 * 0.05
+
+
+class TestShutdown:
+    def test_atexit_close_does_not_open_a_second_event_loop(self, monkeypatch):
+        """A clean exit must not print a traceback into the client's log.
+
+        At interpreter shutdown there is no running loop, and the loop that OWNS
+        the client's sockets is already closed. Spinning up a fresh one to close
+        them reaches into the dead loop and raises "Event loop is closed", which
+        atexit reports as a 38-line traceback AFTER a successful run — exit code
+        0, stdout untouched, and the next person to debug KEGG suspects it first.
+
+        Sync test on purpose: it must run with NO loop running, which is the
+        state the atexit hook actually sees.
+        """
+        def _no_new_loop(*args, **kwargs):
+            raise AssertionError("shutdown must not start a new event loop")
+
+        # Patch the asyncio module itself: togoid imports it inside the hook, so
+        # patching a module attribute would miss it. Both hooks are the same
+        # three lines and were both wrong.
+        monkeypatch.setattr(asyncio, "run", _no_new_loop)
+        kegg._close_client()  # must be silent, and must not raise
+        togoid._close_client()
 
 
 class TestTransportErrors:

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -115,6 +115,7 @@ def _isolate_module_state(monkeypatch):
     limiter itself is exercised explicitly in TestRateLimit.
     """
     kegg._kgml_cache.clear()
+    kegg._symbol_cache.clear()
     monkeypatch.setattr(kegg, "_MIN_INTERVAL", 0.0)
     monkeypatch.setattr(kegg, "_last_request_at", 0.0)
     monkeypatch.setattr(kegg, "_BACKOFF_BASE", 0.0)
@@ -350,6 +351,16 @@ class TestGetEntry:
 def _mock_kgml(router, body: str = KGML):
     return router.get(f"{BASE}/get/{MAP}/kgml").mock(
         return_value=httpx.Response(200, text=body)
+    )
+
+
+def _mock_symbol_lookup(router, rows: str = ""):
+    """The `/find/<org>/<symbol>` fallback for a seed KGML cannot resolve.
+
+    KEGG answers "no match" with an empty HTTP 200, which is the default here.
+    """
+    return router.get(url__regex=rf"{BASE}/find/xxx/.*").mock(
+        return_value=httpx.Response(200, text=rows)
     )
 
 
@@ -665,6 +676,78 @@ class TestPathwayGraph:
 
 class TestPathwayNeighborhood:
     @pytest.mark.asyncio
+    async def test_paralog_family_member_resolves_though_the_box_is_labelled_otherwise(
+        self,
+    ):
+        """The trap this tool claims to have solved, on the way IN.
+
+        hsa04151's box 17 holds hsa:10000, hsa:207 and hsa:208 (AKT3/AKT1/AKT2)
+        and KGML labels it "AKT3, MPPH, PKB-GAMMA, …" — the drawn member's
+        symbol and ITS aliases. So `seeds="AKT1"`, the most obvious query anyone
+        would type, matched nothing while `seeds="hsa:207"` resolved instantly,
+        and `unresolved_note` said the gene might not be drawn on this map. It
+        is drawn; it is simply drawn under a sibling's name.
+        """
+        akt = (
+            '<?xml version="1.0"?><pathway name="path:xxx00001" org="xxx" '
+            'number="00001" title="Paralog box">'
+            '<entry id="17" name="hsa:10000 hsa:207 hsa:208" type="gene">'
+            '<graphics name="AKT3, MPPH, MPPH2, PKB-GAMMA" type="rectangle"/></entry>'
+            '<entry id="18" name="hsa:2475" type="gene">'
+            '<graphics name="MTOR" type="rectangle"/></entry>'
+            '<relation entry1="17" entry2="18" type="PPrel">'
+            '<subtype name="activation" value="--&gt;"/></relation>'
+            "</pathway>"
+        )
+        with respx.mock(using="httpx") as router:
+            router.get(f"{BASE}/get/xxx00001/kgml").mock(
+                return_value=httpx.Response(200, text=akt)
+            )
+            # /find is a SUBSTRING search: AKT1S1 comes back too and must be
+            # rejected, or a near-miss silently answers for the wrong gene.
+            router.get(f"{BASE}/find/xxx/AKT1").mock(
+                return_value=httpx.Response(
+                    200,
+                    text=(
+                        "hsa:207\tAKT1, AKT, PKB, RAC-ALPHA; AKT serine/threonine "
+                        "kinase 1\n"
+                        "hsa:84335\tAKT1S1, Lobe, PRAS40; AKT1 substrate 1\n"
+                    ),
+                )
+            )
+            out = await pathway_neighborhood(pathway="xxx00001", seeds="AKT1")
+        result = json.loads(out)
+
+        assert result["unresolved"] == []
+        assert result["seeds"] == ["17"]
+        assert [r["label"] for r in result["reached"]] == ["MTOR"]
+        # AKT1S1 is not in this map and must not have been used to resolve it.
+        note = result["seed_resolution"][0]
+        assert note["seed"] == "AKT1"
+        assert note["matched_members"] == ["hsa:207"]
+        # The caller asked for AKT1 and is getting a box drawn as AKT3 — saying
+        # so is the whole point, since every row below is labelled AKT3.
+        assert note["node_labels"] == ["AKT3"]
+        assert "paralog family" in note["note"]
+
+    @pytest.mark.asyncio
+    async def test_symbol_lookup_is_skipped_when_kgml_can_already_resolve(self):
+        """The fallback costs a request against a 3/s budget — only on a miss."""
+        with respx.mock(using="httpx", assert_all_called=False) as router:
+            _mock_kgml(router)
+            lookup = _mock_symbol_lookup(router)
+            for seeds in ("PIK3CA", "hsa:207", "5290", "1"):
+                await pathway_neighborhood(pathway=MAP, seeds=seeds)
+            assert not lookup.called
+            # A compound accession is not a gene symbol either: no lookup, and
+            # no request wasted on a token /find could never match.
+            await pathway_neighborhood(pathway=MAP, seeds="C00031")
+            assert not lookup.called
+            # …and a token that would alter the REST path never reaches it.
+            await pathway_neighborhood(pathway=MAP, seeds="../../get/hsa:207")
+            assert not lookup.called
+
+    @pytest.mark.asyncio
     async def test_resolves_a_gene_symbol_and_reports_net_sign(self):
         with respx.mock(using="httpx") as router:
             _mock_kgml(router)
@@ -689,10 +772,16 @@ class TestPathwayNeighborhood:
         """An absent gene must not read as a biological negative."""
         with respx.mock(using="httpx") as router:
             _mock_kgml(router)
+            lookup = _mock_symbol_lookup(router)  # KEGG knows no such symbol
             out = await pathway_neighborhood(pathway=MAP, seeds="NOTAGENE")
         result = json.loads(out)
+        assert lookup.called, "the symbol fallback must be tried before giving up"
         assert result["unresolved"] == ["NOTAGENE"]
         assert "LOOKUP failure" in result["unresolved_note"]
+        # The advice must not stop at "not drawn on this map" — that was the
+        # misleading half when the seed IS drawn, just under a sibling's label.
+        assert "hsa:207" in result["unresolved_note"]
+        assert "seed_resolution" not in result
 
     @pytest.mark.asyncio
     async def test_signed_only_drops_unsigned_edges(self):
@@ -734,6 +823,7 @@ class TestPathwayPaths:
         """find_paths returns [] for both; the tool must not conflate them."""
         with respx.mock(using="httpx") as router:
             _mock_kgml(router)
+            _mock_symbol_lookup(router)
             missing = json.loads(
                 await pathway_paths(pathway=MAP, source="NOTAGENE", target="MTOR")
             )

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -93,7 +93,12 @@ def _close_client():
         loop = asyncio.get_running_loop()
         loop.create_task(_client.aclose())
     except RuntimeError:
-        asyncio.run(_client.aclose())
+        # No running loop: the interpreter is shutting down and the loop that
+        # OWNS these sockets is already closed. Opening a fresh one to close
+        # them reaches into the dead loop and raises "Event loop is closed",
+        # which atexit prints as a 38-line traceback after a clean exit. The OS
+        # reclaims the sockets either way, so leave them.
+        pass
 
 
 atexit.register(_close_client)

--- a/togo_mcp/kegg.py
+++ b/togo_mcp/kegg.py
@@ -248,6 +248,18 @@ _GRAPH_BUDGET_SHARE = 0.5
 _KGML_CACHE_MAX = 32
 _kgml_cache: OrderedDict[str, str] = OrderedDict()
 
+# (org, lowercased symbol) -> KEGG gene ids. Seeded lazily, one request per
+# symbol KGML itself cannot resolve; see `_genes_for_symbol`.
+_SYMBOL_CACHE_MAX = 256
+_symbol_cache: OrderedDict[tuple[str, str], list[str]] = OrderedDict()
+
+# A token worth spending a KEGG lookup on: not a node id (digits), not an
+# already-qualified id ("hsa:207", "cpd:C00031"), not a bare accession.
+_BARE_ACCESSION = re.compile(r"^[CKDGR]\d{5}$|^\d+\.\d+\.\d+\.\d+$")
+# …and shaped like a gene symbol, which also keeps it from altering the REST
+# path it is interpolated into (cf. `_check_path_token`).
+_SYMBOL_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._@-]*$")
+
 
 def _is_org(token: str) -> bool:
     return bool(_ORG_CODE.match(token) or _T_NUMBER.match(token))
@@ -713,6 +725,98 @@ async def _load_graph(pathway: str, **options: Any) -> tuple[str, dict[str, Any]
         return pathway, parse_kgml(text, **options)
     except KGMLParseError as exc:
         raise ValueError(f"KEGG returned unusable KGML for {pathway}: {exc}") from exc
+
+
+async def _genes_for_symbol(org: str, symbol: str) -> list[str]:
+    """KEGG gene ids whose SYMBOL list contains `symbol` EXACTLY.
+
+    `/find/<org>/<symbol>` is a substring search over names and definitions, so
+    "AKT1" also returns AKT1S1 and anything whose description mentions it. Only
+    rows carrying the symbol verbatim in their comma-separated symbol list (the
+    part before the ';') are kept — a near-miss silently resolving to the wrong
+    gene is worse than not resolving at all.
+    """
+    key = (org, symbol.lower())
+    cached = _symbol_cache.get(key)
+    if cached is not None:
+        _symbol_cache.move_to_end(key)
+        return cached
+
+    text = await _kegg_get(f"/find/{org}/{symbol}", context="KEGG symbol lookup")
+    genes: list[str] = []
+    for entry, definition in _parse_tsv_pairs(text):
+        names = definition.split(";", 1)[0]
+        if any(part.strip().lower() == key[1] for part in names.split(",")):
+            genes.append(entry)
+
+    _symbol_cache[key] = genes
+    _symbol_cache.move_to_end(key)
+    while len(_symbol_cache) > _SYMBOL_CACHE_MAX:
+        _symbol_cache.popitem(last=False)
+    return genes
+
+
+async def _resolve_endpoints(
+    graph: dict[str, Any], tokens: list[str]
+) -> tuple[dict[str, list[str]], list[dict[str, Any]]]:
+    """Map each caller token to node ids, KGML first, KEGG symbol lookup second.
+
+    KGML alone cannot do this. An entry box is a whole paralog family, but
+    `graphics/@name` carries only the DRAWN label — the first member's symbol
+    and its aliases. hsa04151's box 17 holds hsa:10000, hsa:207 and hsa:208
+    (AKT3/AKT1/AKT2) and is labelled "AKT3, MPPH, PKB-GAMMA, …", so the most
+    obvious seed anyone would type — AKT1 — matched nothing, while hsa:207
+    resolved instantly. The tool advertises that it resolves the paralog-family
+    trap, and it did so for the analysis but not for the way in.
+
+    So a token KGML cannot match is looked up against KEGG's gene symbols and
+    the result intersected with THIS MAP's members. That costs one request per
+    unmatched symbol (cached), and only on the path that would otherwise have
+    returned nothing. Returns `{token: [node ids]}` plus a note per token that
+    only the lookup could resolve — the caller must be told, because the box it
+    resolved to is labelled with a DIFFERENT gene's symbol.
+    """
+    org = graph["pathway"].get("org") or ""
+    by_member = graph["index"]["by_member"]
+    by_id = {n["id"]: n for n in graph["nodes"]}
+    resolution: dict[str, list[str]] = {}
+    notes: list[dict[str, Any]] = []
+
+    for token in tokens:
+        hits = resolve_seeds(graph, [token])
+        if hits:
+            resolution[token] = hits
+            continue
+        worth_a_lookup = (
+            _is_org(org)
+            and ":" not in token
+            and not token.isdigit()
+            and not _BARE_ACCESSION.match(token.upper())
+            and bool(_SYMBOL_TOKEN.match(token))
+        )
+        if not worth_a_lookup:
+            resolution[token] = []
+            continue
+
+        genes = await _genes_for_symbol(org, token)
+        matched = [g for g in genes if g in by_member]
+        hits = list(dict.fromkeys(nid for g in matched for nid in by_member[g]))
+        resolution[token] = hits
+        if hits:
+            notes.append({
+                "seed": token,
+                "resolved_to": hits,
+                "matched_members": matched,
+                "node_labels": [by_id[h]["label"] for h in hits],
+                "note": (
+                    f"{token} is not the drawn label of its box — one KEGG entry "
+                    "box is a whole paralog family and KGML labels it with one "
+                    "member's symbol. Resolved via KEGG's gene symbols; results "
+                    "below are for the WHOLE box, i.e. the family, not this gene "
+                    "alone."
+                ),
+            })
+    return resolution, notes
 
 
 def _signal_quality(graph: dict[str, Any]) -> dict[str, Any]:
@@ -1206,7 +1310,9 @@ async def pathway_neighborhood(
     `signal_quality.signed_edge_fraction` before reading signs at all: it is
     0.98 on hsa04151 but 0.40 on hsa04010 and 0 on metabolic maps. An empty
     `reached` with an empty `unresolved` means the seed is in the map but has no
-    edges in that direction.
+    edges in that direction. `seed_resolution` appears when a seed matched a box
+    KGML labels with a DIFFERENT gene's symbol — read it, because the answer is
+    then for the whole paralog family, whose label is not what you asked for.
 
     RAISES ValueError on a malformed map id or direction, when the map has no
     KGML, and on any HTTP error — including HTTP 403/429 for the 3
@@ -1215,9 +1321,11 @@ async def pathway_neighborhood(
     Args:
         pathway: KEGG map id, e.g. "hsa04151". Use the ORGANISM map for a
             question about that organism's genes.
-        seeds: One or more start points. A gene symbol as drawn on the map
-            ("AKT1"), a KEGG gene id ("hsa:5290"), a bare id ("5290"), a
-            compound ("C00031") or a node id all resolve.
+        seeds: One or more start points. A gene symbol ("AKT1"), a KEGG gene id
+            ("hsa:5290"), a bare id ("5290"), a compound ("C00031") or a node id
+            all resolve. A symbol that is NOT the box's drawn label — AKT1 sits
+            in a box KGML labels "AKT3" — costs one extra KEGG lookup and is
+            reported in `seed_resolution`.
         direction: "downstream" (what the seed affects, the default),
             "upstream" (what affects the seed), or "both".
         depth: Maximum number of edges from the seed, in [1, 6]. Default 2.
@@ -1246,15 +1354,20 @@ async def pathway_neighborhood(
         )
 
     pathway, graph = await _load_graph(pathway)
+    # Resolve the seeds HERE, not inside neighborhood(): a symbol that is not its
+    # box's drawn label needs a KEGG lookup, and kgml.py is deliberately pure.
+    resolution, seed_notes = await _resolve_endpoints(graph, starts)
+    unresolved = [token for token in starts if not resolution[token]]
+    node_seeds = list(dict.fromkeys(nid for hits in resolution.values() for nid in hits))
     result = neighborhood(
-        graph, starts, direction=direction, depth=depth, signed_only=signed_only
+        graph, node_seeds, direction=direction, depth=depth, signed_only=signed_only
     )
 
     reached = result["reached"]
     payload: dict[str, Any] = {
         "pathway": {**graph["pathway"], "id": pathway},
         "seeds": result["seeds"],
-        "unresolved": result["unresolved"],
+        "unresolved": unresolved,
         "direction": direction,
         "depth": depth,
         "signed_only": signed_only,
@@ -1270,12 +1383,16 @@ async def pathway_neighborhood(
             "total": len(reached),
             "hint": "lower `depth`, set signed_only=True, or raise `limit`.",
         }
-    if result["unresolved"]:
+    if seed_notes:
+        payload["seed_resolution"] = seed_notes
+    if unresolved:
         payload["unresolved_note"] = (
-            "These seeds matched no node in this map. That is a LOOKUP failure, "
-            "not a biological finding — the gene may simply not be drawn on this "
-            "map. Confirm membership with kegg_link(target=<org>, "
-            "source=<pathway>) or pick a different map."
+            "These seeds matched no node in this map, by drawn label, by member "
+            "gene id, or by KEGG gene symbol. That is a LOOKUP failure, not a "
+            "biological finding — the gene may simply not be drawn on this map. "
+            "Retry with a KEGG gene id (hsa:207) if you have one, confirm "
+            "membership with kegg_link(target=<org>, source=<pathway>), or pick a "
+            "different map."
         )
     return _bounded(payload, note="lower `depth` or `limit`.")
 
@@ -1309,7 +1426,9 @@ async def pathway_paths(
     (phosphorylation, binding) or is metabolic, so KGML never gives a direction.
     Each edge carries its `reaction` accession, which is what tells two parallel
     routes apart: the same node sequence via two different reactions is two
-    genuinely different rows, not a duplicate.
+    genuinely different rows, not a duplicate. `endpoint_resolution` appears when
+    an endpoint matched a box KGML labels with a DIFFERENT gene's symbol (AKT1
+    sits in a box labelled "AKT3"), and the paths are then for the whole box.
 
     AN EMPTY `paths` HAS TWO DIFFERENT MEANINGS — check `unresolved` first. A
     non-empty `unresolved` is a LOOKUP failure (typo, or the molecule is not drawn
@@ -1337,9 +1456,10 @@ async def pathway_paths(
     Args:
         pathway: KEGG map id, e.g. "hsa04151". Use the ORGANISM map for a
             question about that organism's genes.
-        source: Start point. A gene symbol as drawn on the map ("PIK3CA"), a KEGG
-            gene id ("hsa:5290"), a bare id ("5290"), a compound ("C00031") or a
-            node id all resolve.
+        source: Start point. A gene symbol ("PIK3CA"), a KEGG gene id
+            ("hsa:5290"), a bare id ("5290"), a compound ("C00031") or a node id
+            all resolve. A symbol that is not its box's drawn label costs one
+            extra KEGG lookup and is reported in `endpoint_resolution`.
         target: End point, same forms.
         max_length: Maximum edges per path, in [1, 12]. Default 6 — right for
             signaling maps; see the metabolic note above. Cost grows steeply with
@@ -1363,8 +1483,9 @@ async def pathway_paths(
     # find_paths() returns [] both when an endpoint matched nothing and when the
     # endpoints are fine but unconnected. Those need different reactions from the
     # caller, so resolve them here and report the difference explicitly.
-    source_nodes = resolve_seeds(graph, [source])
-    target_nodes = resolve_seeds(graph, [target])
+    resolution, endpoint_notes = await _resolve_endpoints(graph, [source, target])
+    source_nodes = resolution[source]
+    target_nodes = resolution[target]
     unresolved = [
         label
         for label, hits in ((source, source_nodes), (target, target_nodes))
@@ -1372,7 +1493,10 @@ async def pathway_paths(
     ]
 
     paths = (
-        find_paths(graph, source, target, max_length=max_length, max_paths=max_paths)
+        find_paths(
+            graph, source_nodes, target_nodes,
+            max_length=max_length, max_paths=max_paths,
+        )
         if not unresolved
         else []
     )
@@ -1408,12 +1532,16 @@ async def pathway_paths(
         "paths": paths,
         "signal_quality": _signal_quality(graph),
     }
+    if endpoint_notes:
+        payload["endpoint_resolution"] = endpoint_notes
     if unresolved:
         payload["unresolved_note"] = (
-            f"{unresolved} matched no node in this map, so no path could be "
-            "computed. That is a LOOKUP failure, not a biological finding — the "
-            "molecule may simply not be drawn on this map. Confirm membership "
-            "with kegg_link(target=<org>, source=<pathway>) or pick another map."
+            f"{unresolved} matched no node in this map — not by drawn label, not "
+            "by member gene id, not by KEGG gene symbol — so no path could be "
+            "computed. That is a LOOKUP failure, not a biological finding: the "
+            "molecule may simply not be drawn on this map. Retry with a KEGG gene "
+            "id (hsa:207) if you have one, confirm membership with "
+            "kegg_link(target=<org>, source=<pathway>), or pick another map."
         )
     elif not paths:
         # An endpoint with NO edges at all is a different finding from one that is

--- a/togo_mcp/kgml.py
+++ b/togo_mcp/kgml.py
@@ -832,15 +832,21 @@ def neighborhood(
 
 def find_paths(
     graph: dict[str, Any],
-    source: str,
-    target: str,
+    source: str | Iterable[str],
+    target: str | Iterable[str],
     *,
     max_length: int = 4,
     max_paths: int = 20,
 ) -> list[dict[str, Any]]:
-    """Enumerate simple directed paths source -> target, with the net sign of each."""
-    srcs = resolve_seeds(graph, [source])
-    tgts = set(resolve_seeds(graph, [target]))
+    """Enumerate simple directed paths source -> target, with the net sign of each.
+
+    An endpoint may be a single token or an already-resolved list of node ids:
+    a gene symbol can name a box this module cannot match on its own (the box is
+    labelled with one paralog's symbol), so the tool layer resolves such tokens
+    against KEGG and passes the node ids straight in.
+    """
+    srcs = resolve_seeds(graph, [source] if isinstance(source, str) else source)
+    tgts = set(resolve_seeds(graph, [target] if isinstance(target, str) else target))
     if not srcs or not tgts:
         return []
     adj = _adjacency(graph, "downstream")

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -26,7 +26,12 @@ def _close_client():
         loop = asyncio.get_running_loop()
         loop.create_task(_client.aclose())
     except RuntimeError:
-        asyncio.run(_client.aclose())
+        # No running loop: the interpreter is shutting down and the loop that
+        # OWNS these sockets is already closed. Opening a fresh one to close
+        # them reaches into the dead loop and raises "Event loop is closed",
+        # which atexit prints as a 38-line traceback after a clean exit. The OS
+        # reclaims the sockets either way, so leave them.
+        pass
 
 
 atexit.register(_close_client)

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Two fixes found by *using* the KEGG tools rather than reading them.

**A paralog-family member could not be used as a seed under its own name.**
`kegg_pathway_neighborhood(pathway="hsa04151", seeds="AKT1")` returned `unresolved`, while
`seeds="hsa:207"` — the same gene — resolved instantly and returned 33 downstream nodes. Box 17
of that map holds hsa:10000, hsa:207 and hsa:208 (AKT3/AKT1/AKT2), but KGML's `graphics/@name`
carries only the drawn label ("AKT3" and *its* aliases) and seed resolution looked no further.
The paralog-family trap the tool advertises as solved was still open on the way in — and
`unresolved_note` compounded it by suggesting the gene might not be drawn on the map. It is
drawn, under a sibling's name.

Seeds and path endpoints KGML cannot match are now looked up against KEGG's gene symbols and
intersected with that map's members: one request per unmatched symbol, cached, only on the path
that would otherwise have returned nothing. `/find` is a substring search, so only rows carrying
the symbol verbatim in their symbol list count — "AKT1" must not resolve through AKT1S1. When
the fallback fires, `seed_resolution` / `endpoint_resolution` reports which member matched and
what the box is actually labelled, because every row of the answer then reads "AKT3" for a
question asked about AKT1.

**A clean shutdown printed a 38-line traceback into the client's log.** The atexit hooks in
`kegg.py` and `togoid.py` fell back to `asyncio.run(_client.aclose())` when no loop was running —
which at interpreter shutdown is always — so a fresh loop reached into the already-closed loop
that owned the sockets and raised `RuntimeError: Event loop is closed`. Harmless (exit code 0,
stdout untouched, after all work) but it is the first thing anyone debugging KEGG or TogoID would
suspect. The hook now leaves the sockets to the OS.

**MINOR, not PATCH**: both are bug fixes, but the first adds two return fields and widens what a
seed may be. Existing calls are unaffected.

Tests: 398 pass. New regressions cover the AKT-box shape (including rejecting the AKT1S1
near-miss), that a resolvable seed spends no request, that a path-altering token never reaches
the REST path, and — synchronously, since that is the state the hook actually sees — that
shutdown opens no second event loop. Verified live on hsa04151: AKT1, hsa:207 and AKT3 all
resolve to node 17 with 33 reached. No test touches rest.kegg.jp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)