### PR TITLE
release: 2.5.1 — tell stale ChatGPT connectors to refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 _Nothing yet._
 
+## [2.5.1] - 2026-08-01
+
+<!-- whatsnew: 2026-08-01 | <strong>ChatGPT users: refresh your connector.</strong> ChatGPT records TogoMCP's tool list when the connector is added and never refetches it, so tools added since then are invisible to it — re-run <em>Scan Tools</em>, or remove and re-add the connector. New databases are unaffected; those arrive through the live usage guide. -->
+
+Documentation only — no tool, parameter, or return shape changed. What prompted it was reading the
+production tool-call log: 28 calls in five days to tools that do not exist, **all** of them from
+ChatGPT connectors (`openai-mcp`), and none from any other client family.
+
+Both names were real once. `ncbi_ncbi_esearch` / `_esummary` / `_efetch` were valid until 2026-04-28,
+when the redundant `ncbi_` prefix was dropped from the raw function names (mounted under `ncbi`, they
+genuinely were `ncbi_ncbi_*`); `find_databases` was valid until the discovery trio was retired on
+2026-07-24. The two caller populations share no IP, so these are two separate cache vintages — one of
+them still in daily use three months after the rename. ChatGPT records the tool list at *Scan Tools*
+time and does not refetch it.
+
+The consequence worth acting on is the inverse of the errors: a client whose list is frozen also
+cannot see tools added *after* it was cached, and there is no runtime channel that can fix that. New
+**databases** are immune — the catalog is delivered by `TogoMCP_Usage_Guide` at query time, and
+`database` is a free-form string validated server-side, so a stale schema neither hides nor blocks a
+new database. New **tools** are not immune. Prefer a new database or a parameter on an existing tool
+over a new tool where reach matters.
+
+This also puts evidence behind the MAJOR-on-rename rule in [CLAUDE.md](CLAUDE.md): an agent cannot
+recover from a rename because its *client* never refetches. Budget months of tail traffic on any name
+that is removed or changed.
+
+### Added
+
+- **Usage Guide troubleshooting row for a stale client tool list.** Fires in both directions — a tool
+  the guide names is missing from the model's tool list (canaries: `togovar_search_variant`,
+  `search_chembl_id_lookup`), or a call returns "unknown tool". It instructs the model to tell the
+  user to re-add the connector rather than retry the name or improvise a substitute, and states that
+  databases are unaffected. The model is the only party that can see the discrepancy; the user is the
+  only one who can fix it.
+- **Connector-refresh note in the ChatGPT setup section of the intro page**, with the symptoms and the
+  fix.
+- **`TogoMCP_Usage_Guide` listed under Database &amp; Information on the intro page.** It had been
+  missing since the tool shipped, despite being the third-most-called tool on the server.
+
 ## [2.5.0] - 2026-07-31
 
 Two fixes found by using the KEGG tools rather than reading them: a seed form the
@@ -1041,7 +1080,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/dbcls/togomcp/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/dbcls/togomcp/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/dbcls/togomcp/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/dbcls/togomcp/compare/v2.3.0...v2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.5.0"
+version = "2.5.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -768,6 +768,10 @@
     <ul class="whatsnew-list">
       <!-- WHATSNEW:START -->
       <li>
+        <span class="whatsnew-date">2026-08-01</span>
+        <span><strong>ChatGPT users: refresh your connector.</strong> ChatGPT records TogoMCP's tool list when the connector is added and never refetches it, so tools added since then are invisible to it — re-run <em>Scan Tools</em>, or remove and re-add the connector. New databases are unaffected; those arrive through the live usage guide.</span>
+      </li>
+      <li>
         <span class="whatsnew-date">2026-07-31</span>
         <span>New database: the <strong>NHGRI-EBI GWAS Catalog</strong> — 955,930 SNP–trait associations across 89,981 studies, with p-values, effect sizes, risk alleles and mapped genes, joinable to EFO trait terms. Ask things like "which variants are associated with QT interval, and how strong is the evidence?"</span>
       </li>
@@ -782,10 +786,6 @@
       <li>
         <span class="whatsnew-date">2026-07-24</span>
         <span>The database knowledge files (MIE) were rewritten to a leaner format — about half the size, with faster and more reliable query construction. The three database-discovery tools (<code>list_databases</code>, <code>find_databases</code>, <code>list_categories</code>) were consolidated into the built-in Usage Guide, which now carries a catalog of all 36 databases.</span>
-      </li>
-      <li>
-        <span class="whatsnew-date">2026-07-17</span>
-        <span>Query results are more trustworthy: <code>get_MIE_file</code> now leads with each database's "traps" (mandatory filters, namespace pitfalls, and shared-graph count inflation), and all 36 databases document cross-graph co-tenancy so counts aren't silently inflated.</span>
       </li>
       <!-- WHATSNEW:END -->
     </ul>
@@ -1013,6 +1013,9 @@
       <div class="setup-note">
         ℹ️ Developer mode shows tool usage explicitly and asks for confirmation before write actions — TogoMCP performs none, and declares itself read-only so ChatGPT need not prompt. See <a href="https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt" target="_blank" rel="noopener">OpenAI's Developer mode and MCP apps</a> for current plan eligibility and admin controls.
       </div>
+      <div class="setup-note">
+        ⚠️ <strong>Refresh the connector after TogoMCP adds tools.</strong> ChatGPT records the tool list at <strong>Scan Tools</strong> time and does not refetch it on its own, so tools added later stay invisible to it — we still see connectors running lists several months old. Symptoms: ChatGPT reports that a tool documented here is unavailable, or it calls a tool that no longer exists (<code>find_databases</code>, <code>ncbi_ncbi_esearch</code>) and the call fails. Fix: re-run <strong>Scan Tools</strong> on the connector, or remove and re-add it. <strong>New databases need no refresh</strong> — the database catalog is delivered by <code>TogoMCP_Usage_Guide</code> at query time, so it is always current.
+      </div>
     </div>
 
     <div id="tab-gemini" class="setup-panel">
@@ -1201,6 +1204,10 @@
     <div class="tools-section-grid">
       <div class="tool-group">
         <div class="tool-group-header">📋 Database &amp; Information</div>
+        <div class="tool-item">
+          <div class="tool-item-name">TogoMCP_Usage_Guide</div>
+          <div class="tool-item-desc">Get the usage guide with the database catalog and the recommended query workflow. Call this first, before any other tool.</div>
+        </div>
         <div class="tool-item">
           <div class="tool-item-name">get_MIE_file</div>
           <div class="tool-item-desc">Get metadata file containing ShEx schema and SPARQL examples for a specific database. Use this first before writing queries.</div>

--- a/togo_mcp/data/resources/usage_guide_v6/04_reference.md
+++ b/togo_mcp/data/resources/usage_guide_v6/04_reference.md
@@ -40,3 +40,4 @@
 | ≥15 tool calls, no answer | Synthesize from partial data. Partial + honest > wrong + exhaustive. |
 | Repetitive answer | Remove any sentence restating an earlier point. |
 | OLS4 / PubMed unavailable | → `search_mesh_descriptor` / `ncbi_esearch`. |
+| **A tool named in this guide is absent from your tool list** (canaries: `togovar_search_variant`, `search_chembl_id_lookup`) — or a tool you call returns "unknown tool" (`find_databases`, `ncbi_ncbi_esearch`) | Your MCP client cached the tool list when the connector was added and has not refetched it. **Tell the user in your answer**: remove and re-add the TogoMCP connector. Common with ChatGPT connectors — some are running lists months stale. Do not retry the missing name or invent a substitute. **Databases are unaffected**: the catalog in this guide is served live, so any database key listed there works even when your cached tool schema does not name it. |

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Documentation only — no tool, parameter, or return shape changed. PATCH under the agent-pragmatic policy.

## What prompted it

The production tool-call log (2026-07-27 → 07-31, 19,642 calls) carries **28 calls to tools that do not exist, all of them from ChatGPT connectors** (`openai-mcp`), none from any other client family. That is 76% of that client's errors; its error rate is 15.7% vs 1.6% for `Anthropic/ClaudeAI` and 0% for `claude-code`, and drops to 4.3% once the phantom calls are excluded.

Both names were real once:

| phantom tool | valid until | callers | IPs |
|---|---|---|---|
| `ncbi_ncbi_esearch` / `_esummary` / `_efetch` | 2026-04-28 (`72f407b` dropped the redundant `ncbi_` prefix) | ChatGPT | 10 |
| `find_databases` | 2026-07-24 (`7855e87` retired the discovery trio) | ChatGPT | 16 |
| **overlap** | | | **0** |

Zero shared IPs — two separate cache vintages, one still in daily use three months after the rename. ChatGPT records the tool list at *Scan Tools* time and does not refetch it.

## Why it matters beyond the errors

A frozen list also hides tools added *after* it was cached, and no runtime channel can fix that.

- **New databases are immune** — the catalog is delivered by `TogoMCP_Usage_Guide` at query time, and `database` is a free-form string validated server-side, so a stale schema neither hides nor blocks a new database.
- **New tools are not.** Prefer a new database or a parameter on an existing tool over a new tool where reach matters.

This also puts evidence behind the MAJOR-on-rename rule in CLAUDE.md: an agent cannot recover from a rename because its *client* never refetches.

## Changes

- **Usage Guide** — troubleshooting row firing in both directions: a tool the guide names is absent from the model's list (canaries `togovar_search_variant`, `search_chembl_id_lookup`), or a call returns "unknown tool". Instructs the model to tell the user to re-add the connector rather than retry the name or improvise a substitute. The model is the only party that can see the discrepancy; the user is the only one who can fix it.
- **Intro page** — connector-refresh note in the ChatGPT setup section, plus a What's New entry so it reaches affected users on the landing page.
- **Intro page** — `TogoMCP_Usage_Guide` added to the tool list. Missing since the tool shipped, despite being the third-most-called tool on the server.

## Verification

- `uv run pytest` — 398 passed
- Guide assembles: 5 parts, 41,998 chars; new table row well-formed
- `generate_whatsnew.py` regenerated; `test_whatsnew_in_sync.py` passes
- Intro page div balance 294/294

🤖 Generated with [Claude Code](https://claude.com/claude-code)