### PR TITLE
release: 2.5.2 — MIE corrections from live debugging and the tool-call log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,18 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Drift guard for the Usage Guide's stale-tool-list row** (`tests/test_usage_guide_canaries.py`).
+  That row names tools in two opposite roles and each can silently go wrong. Its **canaries**
+  (`togovar_search_variant`, `search_chembl_id_lookup`) must exist — rename or remove one and it
+  disappears from *every* client's tool list, so the row fires for everyone and tells healthy users to
+  re-register, inside the document that is supposed to be authoritative. Its **phantom** examples
+  (`find_databases`, `ncbi_ncbi_esearch`) must not exist — re-introduce one, say as a redirect stub,
+  and the row cites a working call as evidence of breakage. Neither fails at build time today; the
+  damage lands in someone else's chat session. Deliberately *not* asserted: that the canaries are the
+  newest tools. A stale canary only under-detects (it catches caches older than itself and never
+  misfires), so sensitivity stays a release-checklist judgement while correctness is enforced here.
 
 ## [2.5.1] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,63 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-08-08
+
+No tool, parameter, or return shape changed — this is entirely MIE content plus one test. What makes
+it worth a release is *how* the three MIE revisions were found, because two of the mechanisms are new
+and neither is visible from inside a single file.
+
+### Fixed
+
+- **glycosmos, jpostdb: the FALDO glycosylation/phosphorylation-site route is now a worked example in
+  both files.** Both described the chain in `schema_delta` prose only, and prose is what an agent has
+  to re-derive under time pressure. Two separate live sessions did exactly that and got it wrong in two
+  different ways. In glycosmos the reconstructed `PREFIX faldo:` lost its trailing `#`, which resolves
+  `faldo:location` into a namespace that exists nowhere: the query parses, executes and returns **zero
+  rows with no error** (116 rows with the `#`, 0 without). FALDO is shared vocabulary — `uniprot`,
+  `ensembl`, `ddbj`, `hco` and `mogplus` all require the identical form, so this is not a per-database
+  convention. In jpostdb the trap is arithmetic rather than syntax: there are **two** FALDO coordinate
+  frames — a PeptideEvidence `faldo:begin` is protein-absolute, a Modification `faldo:position` is
+  relative to its parent Peptide — and the two `ExactPosition` nodes are structurally identical,
+  distinguishable *only* by what `faldo:reference` points at. Reading the modification position as
+  absolute yields plausible small residue numbers that are simply wrong past the first peptide.
+- **glycosmos: two examples had started returning zero rows, and three documented facts were false.**
+  The `geneid` join node moved out of the `glycoprotein` graph into the `Rhea` graph, and `GO:0006486`
+  was obsoleted upstream and vanished with no trace (re-anchored on `GO:0006487`). The `schema_delta`
+  FALDO line was wrong on site IRI pattern, location IRI pattern, and both site figures. Saccharide
+  inflation fell ×4.16 → ×1.52 because two `tmp/*` staging twins were dropped upstream, so the
+  multiplier is now documented as reload-dependent rather than as a constant. The go.owl divergence
+  recorded in 2026-07 has been **repaired** upstream and now agrees exactly with the native `go`
+  database — kept as a dated observation, not deleted, because a snapshot that drifted once can drift
+  again.
+- **jpostdb: the `rdfs:label` trap covered only half the failure.** The file warned about empty-string
+  labels, which a `FILTER` fixes. It did not warn that for the Unimod-typed population the predicate is
+  **absent entirely**, which no `FILTER` can reach — a required (non-`OPTIONAL`) `rdfs:label` pattern
+  silently zeroes the whole query. Measured across 12,518,574 modifications: 5,624,538 (44.9%) carry no
+  label predicate, 5,206,460 (41.6%) carry `""`, 1,687,576 (13.5%) carry a real name. No Unimod-typed
+  modification carries a label at all.
+- **jpostdb: the "single-tenant, ZERO overlap" claim was true only for jPOST's own IRIs.** Re-probing
+  found the endpoint now also carries ~40 `rdf.glycosmos.org/*` graphs, and the **hub** IRIs jPOST
+  points at are re-declared: reading `rdfs:label` off a jPOST-referenced UniProt IRI returns ×2 rows
+  (212 for 106 protein entries). Graph-pinning protects a database's own entities but not the join
+  targets it follows outward — the pin has to go on every leg.
+
 ### Added
 
+- **mogplus: `vep:symbol` and `vep:impact` are documented for the first time**, with two examples. This
+  one came from the production tool-call log rather than a debugging session, and it is the first time
+  that log has been read for *silent* failures instead of errors. Of 2,789 logged mogplus queries, 777
+  (27.9%) returned zero rows — and every one entered through those two predicates, which the file did
+  not mention once. The empties were deterministic per gene symbol (189 always empty, 720 always
+  non-empty, zero overlap) and split into two causes a bare severity filter renders indistinguishable:
+  the symbol is **absent** from VEP (532 queries, 117 symbols — mostly MGI QTL/locus names like `Aod4`
+  and `Idd3` that have no transcript, so VEP never annotates them), or the symbol is **present with no
+  HIGH/MODERATE variant** (245 queries, 72 symbols — a correct answer, not a failure; `Ebf1` carries
+  50,916 annotations, all MODIFIER/LOW). The new `gene_symbol_impact` example returns the impact
+  *distribution* so all three states are told apart in one query. Worse than the empties: the same
+  template never pinned the release, so its ~2,000 **non-empty** results silently merged the disjoint
+  v3/v2.1 cohorts (548 rows/21 variants unpinned vs 61/9 for v3), and never used `DISTINCT` against
+  per-transcript fan-out (61 raw vs 26 distinct). Those results were not empty, they were wrong.
 - **Drift guard for the Usage Guide's stale-tool-list row** (`tests/test_usage_guide_canaries.py`).
   That row names tools in two opposite roles and each can silently go wrong. Its **canaries**
   (`togovar_search_variant`, `search_chembl_id_lookup`) must exist — rename or remove one and it
@@ -1091,7 +1146,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.1...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.2...HEAD
+[2.5.2]: https://github.com/dbcls/togomcp/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/dbcls/togomcp/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/dbcls/togomcp/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/dbcls/togomcp/compare/v2.4.0...v2.4.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,13 @@ The "public contract" of this server is the **tool surface** as a client sees it
 - **MINOR** (`1.x.0`) — new capability, old calls still work: add a tool/database/optional parameter, add a field to a return object, widen accepted input (new alias, case-insensitivity). **Return-shape changes ride here too** (e.g. bare-list → `{total_count, has_more, results}`) — that's why the Reactome (1.1→1.2) and Rhea (1.2→1.3) overhauls were minor despite reshaping returns. Strict semver would call those MAJOR; we don't, deliberately, because agents adapt. (Caveat: a purely programmatic client hitting the endpoint *can* break on a reshape — weigh that if such consumers appear.)
 - **PATCH** (`1.3.x`) — behavior fixed, contract unchanged: a bug fix that makes a tool return what it already promised (the `chebi:CHEBI:` 500, the empty-query guard), docstring/description fixes, a silently-relaxed filter now honored, internal refactors/tests.
 
+**Clients cache the tool list; assume months of lag.** ChatGPT connectors record the tool list at *Scan Tools* time and never refetch — the 2026-07-27→31 production log carried 28 calls to tools that no longer exist, **all** from `openai-mcp`, one cohort still using names retired three months earlier. Two consequences:
+
+- **A rename or removal is MAJOR because the *client* can't recover, not just the agent.** Budget a long tail of calls on the old name, and prefer a deprecation alias over a clean break where the traffic matters.
+- **When you ADD a tool, repoint the canaries** in the stale-tool-list row of `usage_guide_v6/04_reference.md` at it. That row is how a stale client finds out it is stale, and a canary only detects caches older than itself — an out-of-date canary silently under-detects. `tests/test_usage_guide_canaries.py` enforces that the canaries *exist* (a removed one would fire the row for every healthy client) but deliberately cannot check that they are the *newest* tools. That part is this checklist's job.
+
+Reach differs by kind of change, so weigh it when choosing how to ship a capability: a new **database** reaches every client immediately (the catalog ships inside `TogoMCP_Usage_Guide` at query time, and `database` is a free-form string validated server-side), while a new **tool** is invisible to any client that has not re-scanned. Where reach matters, prefer a new database or a parameter on an existing tool over a new tool.
+
 ## Testing
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.5.1"
+version = "2.5.2"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_usage_guide_canaries.py
+++ b/tests/test_usage_guide_canaries.py
@@ -1,0 +1,111 @@
+"""Drift guard: the Usage Guide's stale-tool-list row must stay true to the tool registry.
+
+The TROUBLESHOOTING table in `usage_guide_v6/04_reference.md` carries a row that
+teaches the model to recognise a client whose cached tool list has gone stale —
+the failure mode behind every phantom-tool call in the production log, all of
+them from ChatGPT connectors, which record the list at *Scan Tools* time and
+never refetch it. The row names tools in two opposite roles, and each role has
+its own way of going wrong:
+
+* **Canaries** — tools that DO exist. The model concludes "my list is stale" when
+  one is absent from its own tool list. If a canary is ever renamed or removed,
+  it vanishes from *every* client's list and the row fires for everyone: a
+  universal false positive, telling healthy users to re-register, inside the one
+  document that is supposed to be authoritative. That is the dangerous direction,
+  and it would be self-inflicted by exactly the rename mechanic the row exists to
+  explain.
+
+* **Phantoms** — tools that do NOT exist, quoted as examples of the "unknown
+  tool" error. If one is ever re-introduced (e.g. a `find_databases` redirect
+  stub), the row starts citing a working call as evidence of breakage.
+
+Both are silent in normal use — nothing fails at build time, and the damage lands
+in someone else's chat session. Hence a test.
+
+Note what is deliberately NOT asserted: that the canaries are the *newest* tools.
+A canary added at time T detects every cache older than T, so leaving it alone as
+new tools ship only makes it less sensitive — it under-detects, it never misfires.
+Sensitivity is a judgement call for the release checklist; correctness is here.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from togo_mcp.main import mcp, setup
+
+GUIDE_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "togo_mcp" / "data" / "resources" / "usage_guide_v6"
+)
+
+# The row is identified by this phrase rather than by file or line, so it stays
+# findable if it is reworded or moved to another part file.
+_ROW_MARKER = "cached the tool list"
+
+_CANARIES_RE = re.compile(r"canaries:\s*([^)]*)\)")
+_PHANTOMS_RE = re.compile(r'unknown tool"\s*\(([^)]*)\)')
+_BACKTICKED_RE = re.compile(r"`([^`]+)`")
+
+
+def _stale_list_row() -> str:
+    """The single guide line documenting a stale client tool list."""
+    hits = [
+        line
+        for path in sorted(GUIDE_DIR.glob("*.md"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if _ROW_MARKER in line
+    ]
+    assert hits, (
+        f"no Usage Guide row containing {_ROW_MARKER!r} — the stale-tool-list "
+        "troubleshooting row was removed or reworded past recognition. It is the "
+        "only channel that reaches a client whose cached tool list is stale; "
+        "restore it, or delete this test deliberately."
+    )
+    assert len(hits) == 1, f"expected exactly one stale-tool-list row, found {len(hits)}"
+    return hits[0]
+
+
+def _names(pattern: re.Pattern, row: str, role: str) -> list[str]:
+    match = pattern.search(row)
+    assert match, f"stale-tool-list row no longer declares its {role} in the expected form"
+    found = _BACKTICKED_RE.findall(match.group(1))
+    assert found, f"stale-tool-list row declares no {role}"
+    return found
+
+
+@pytest.fixture(scope="module")
+def registered_tool_names() -> set[str]:
+    """Names of every tool on the fully-assembled public server."""
+    async def _collect():
+        await setup()  # mounts togoid / ncbi / togovar
+        return {t.name for t in await mcp._list_tools()}
+
+    return asyncio.run(_collect())
+
+
+def test_canaries_are_real_tools(registered_tool_names: set[str]) -> None:
+    """Every canary must exist, or the row fires for every healthy client."""
+    row = _stale_list_row()
+    missing = [n for n in _names(_CANARIES_RE, row, "canaries") if n not in registered_tool_names]
+    assert not missing, (
+        f"Usage Guide names canary tool(s) that no longer exist: {missing}. "
+        "Every client would now see them absent from its tool list, so the "
+        "stale-list row would tell healthy users to re-register their connector. "
+        "Point the canaries at currently registered tools (prefer the newest ones — "
+        "a canary only detects caches older than itself)."
+    )
+
+
+def test_phantom_examples_do_not_exist(registered_tool_names: set[str]) -> None:
+    """The quoted 'unknown tool' examples must stay unregistered."""
+    row = _stale_list_row()
+    resurrected = [n for n in _names(_PHANTOMS_RE, row, "phantom examples") if n in registered_tool_names]
+    assert not resurrected, (
+        f"Usage Guide cites {resurrected} as example(s) of an 'unknown tool' error, "
+        "but they are registered now — calling them succeeds, so the row cites a "
+        "working call as evidence of a stale list. Replace the example(s) with names "
+        "that are genuinely retired."
+    )

--- a/togo_mcp/data/mie/glycosmos.yaml
+++ b/togo_mcp/data/mie/glycosmos.yaml
@@ -1,5 +1,5 @@
 # MIE v3 — GlyCosmos (glycoscience portal). AGENT-authored v3 file, 2026-07-22 on `mie-redesign`.
-# Format: togo_mcp/data/docs/MIE_v3_spec.md. Every verified count/result re-run live on the glycosmos endpoint 2026-07-22.
+# Format: togo_mcp/data/docs/MIE_v3_spec.md. Every verified count/result re-run live on the glycosmos endpoint 2026-08-07.
 # Byte count vs the v2 file it replaces (spec §5 item 7): v2 togo_mcp/data/mie/glycosmos.yaml = 88,307 bytes;
 # this v3 file = 33,924 bytes → 61.6% smaller. Exact `wc -c` figures in the footer.
 database: glycosmos
@@ -29,7 +29,8 @@ graphs:
     - glycans/glycosequence   # has_glycosequence (WURCS/IUPAC/GlycoCT) + has_motif links
     - glycans                 # external Resource_entry nodes (lowercase has_resource_entry targets)
     - glycoprotein            # glycan:Glycoprotein + Glycosylation_Site + FALDO location nodes
-    - glycogenes              # glycan:Glycogene + GO-annotation scaffold + geneid protein-join bridge
+    - glycogenes              # glycan:Glycogene + GO-annotation scaffold + the geneid node (gene side of the protein bridge)
+    - Rhea                    # UniProt-derived annotation graph; holds the uniprot->geneid leg of the gene<->protein bridge (moved here 2026-08)
     - disease                 # glycan:Disease + disease→gene association bnodes
     - cazy                    # 821 CAZy families (up:Resource) + ~870k up:Protein enzyme sequences
     - HPA                     # Human Protein Atlas IHC tissue/cell expression (glycodm:tissue/cellType/level)
@@ -44,9 +45,10 @@ graphs:
       entities LACK (gotcha no_entity_labels). Reach by explicit GRAPH pin. They key on their own
       IRI spaces (obo:DOID_*, obo:GO_*) and do NOT re-type glycan:Saccharide/Glycogene/Glycoprotein.
     tmp_staging_graphs: >
-      INFLATION — tmp/glycosequence is a byte-for-byte STAGING TWIN of glycans/glycosequence (both
-      type the SAME 254,097 Saccharide IRIs, 100% overlap); tmp/wurcsrdf, tmp/subsumption are the same.
-      They double every glycan before any join. NEVER let a tmp/* graph into a query — pin GRAPH explicitly.
+      STAGING TWINS — as of 2026-08-07 only tmp/subsumption survives (it types NO Saccharide); the
+      tmp/glycosequence and tmp/wurcsrdf twins documented in 2026-07 have been REMOVED upstream, which
+      is why saccharide inflation fell from x4.16 to x1.52. Twins can reappear on any reload: never let
+      a tmp/* graph into a query — pin GRAPH explicitly rather than trusting the current graph roster.
     genomealliance_gpdb: >
       INFLATION — genomealliance re-types 24,136 of glycogenes' SAME glycan:Glycogene IRIs (100% overlap);
       gpdb re-types 14,103 of glycoprotein's SAME glycan:Glycoprotein IRIs. Pin the backbone graph
@@ -56,23 +58,27 @@ graphs:
       Rhea, pathway_reactome, plus specialist glyco graphs (gpdb, carbogrove, lfdb, sugarbind, ggdb,
       psicquic, matrixdb…). Join targets — probe before use; pin the GRAPH matching your intent.
 
-entity_counts:                     # COUNT(DISTINCT), graph-pinned, live 2026-07-22
-  glycans:                117864   # pinned FROM <http://rdf.glytoucan.org/core> — the authoritative registry
-  glycans_unpinned_rows:  1090748  # unscoped `?s a glycan:Saccharide` = 1,090,748 rows for only 262,477 distinct IRIs (x4.16 — INFLATED, never report)
-  glycoproteins_human:    16604    # taxonomy/9606, pinned FROM <…/glycoprotein>
-  glycogenes_all:         423164   # across all species (has_taxon-keyed); GO annotation covers 97.8%
-  cazy_families:          821      # 430 GH · 135 GT · 107 PL · 102 CBM · 27 AA · 20 CE
-  cazy_enzyme_sequences:  869966   # up:Protein nodes in the cazy graph (41% carry an EC number)
-  glycans_with_chebi:     10598    # via lowercase has_resource_entry -> ChEBI Resource_entry
+entity_counts:                     # COUNT(DISTINCT), graph-pinned. Dates are per-line: re-verified figures carry 2026-08-07.
+  glycans:                117864   # 2026-08-07 · pinned FROM <http://rdf.glytoucan.org/core> — the authoritative registry
+  glycans_unpinned_rows:  400948   # 2026-08-07 · unscoped `?s a glycan:Saccharide` = 400,948 rows for only 263,402 distinct IRIs (x1.52 — INFLATED, never report)
+  glycosylation_sites:    331086   # 2026-08-07 · gc:Glycosylation_Site pinned FROM <…/glycoprotein>
+  sites_with_position:    330794   # 2026-08-07 · 99.9% of sites carry faldo:location/faldo:position — a residue position is effectively always present
+  glycoproteins_human:    16604    # 2026-07-22 · taxonomy/9606, pinned FROM <…/glycoprotein>
+  glycogenes_all:         423164   # 2026-07-22 · across all species (has_taxon-keyed); GO annotation covers 97.8%
+  cazy_families:          821      # 2026-07-22 · 430 GH · 135 GT · 107 PL · 102 CBM · 27 AA · 20 CE
+  cazy_enzyme_sequences:  869966   # 2026-07-22 · up:Protein nodes in the cazy graph (41% carry an EC number)
+  glycans_with_chebi:     10598    # 2026-07-22 · via lowercase has_resource_entry -> ChEBI Resource_entry
 
-global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-07-22
+global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-08-07
   - id: saccharide_inflation
     say: >
       glycan:Saccharide is typed in 13 graphs on this endpoint — the SAME GlyTouCan IRIs re-declared, not
-      parallel ID spaces. An unscoped `?s a glycan:Saccharide` = 1,090,748 rows for only 262,477 distinct
-      IRIs (x4.16), worst offender the STAGING TWIN tmp/glycosequence (100% dup of glycans/glycosequence).
-      FIX: pin GRAPH <http://rdf.glytoucan.org/core> (the authoritative registry, 117,864) to enumerate or
-      count glycans, and always COUNT(DISTINCT ?glycan). Never let a tmp/* graph into a query.
+      parallel ID spaces. An unscoped `?s a glycan:Saccharide` = 400,948 rows for only 263,402 distinct
+      IRIs (x1.52), the bulk from glycans/glycosequence (254,454). FIX: pin GRAPH
+      <http://rdf.glytoucan.org/core> (the authoritative registry, 117,864) to enumerate or count glycans,
+      and always COUNT(DISTINCT ?glycan). The multiplier is NOT stable across reloads — it was x4.16
+      (1,090,748 rows) in 2026-07 when two tmp/* staging twins existed and fell to x1.52 when they were
+      dropped. Pin the graph unconditionally; never budget for a particular inflation factor.
   - id: resource_entry_case
     say: >
       TWO case-sensitive resource-entry predicates with DIFFERENT meaning (the #1 silent-fail trap):
@@ -93,13 +99,17 @@ global_gotchas:                    # the few that bite ANY query on this DB — 
       GRAPH <http://purl.obolibrary.org/obo/go.owl>; a motif's name is on <http://glycoinfo.org/motif/[ID]>
       in the motif_label graph. Reading rdfs:label off the glycosmos.org entity returns nothing — join to the
       ontology graph. (Glycogene rdfs:label IS the gene symbol and IS populated 100%; glycan rdfs:label is <1%.)
-  - id: sio_scaffold_dual
+  - id: sio_scaffold_reuse
     say: >
       sio:SIO_000255 is a shared "has-attribute" scaffold pointing to an UNTYPED bnode (no rdf:type — you
       cannot select it by class; reach it only via parent + sio:SIO_000255, then branch on the inner
-      predicate). It is REUSED for two purposes: in the disease graph the bnode's sio:SIO_000001 = an
-      associated glycogene; in the glycogenes graph the bnode's up:classifiedWith = a GO term. Disambiguate
-      by GRAPH + inner predicate, never by the bnode type.
+      predicate). It is REUSED for at least FOUR different payloads, and the GRAPH alone does not
+      disambiguate — the SUBJECT CLASS does. Disease (disease graph) -> sio:SIO_000001 = associated
+      glycogene. Glycogene (glycogenes graph) -> up:classifiedWith = a GO term. Glycoprotein (glycoprotein
+      graph) -> up:classifiedWith = GO terms + dct:references = PubMed IRIs — annotation, NOT sites, so
+      probing it for glycosylation positions is a dead end. Glycosylation_Site (SAME glycoprotein graph)
+      -> gc:has_saccharide = the attached glycan + dct:references/dct:source. Branch on subject class +
+      inner predicate, never on the bnode type.
 
 # ── examples: verified, executable atoms. GlyCosmos integration is INTRA-ENDPOINT cross-GRAPH (no federation);
 #    the geneid node, the sio scaffold, and the genbank/embl-cds bridge are the load-bearing joins. ──
@@ -116,7 +126,7 @@ examples:
         <http://rdf.glycoinfo.org/glycan/G00051MO> glycan:has_glycosequence ?seqNode .
         ?seqNode glycan:in_carbohydrate_format ?format ; glycan:has_sequence ?seq .
       }
-    verified: {result_rows: 5, date: "2026-07-22", formats: "wurcs, glycoct, iupac_condensed, iupac_extended, glycam_condensed"}
+    verified: {result_rows: 5, date: "2026-08-07", formats: "wurcs, glycoct, iupac_condensed, iupac_extended, glycam_condensed"}
     teaches: "A glycan reaches its sequences via glycan:has_glycosequence -> a named glycosequence node (IRI = <glycan>_<format>, NOT a bnode) carrying glycan:in_carbohydrate_format (the format IRI) + glycan:has_sequence (the string). Pin the glycosequence graph. Glycan IRI = http://rdf.glycoinfo.org/glycan/<GlyTouCanID>."
 
   - id: glycan_xref_chebi
@@ -137,7 +147,7 @@ examples:
         ?res rdfs:label "ChEBI" ; dcterms:identifier ?chebiId .
       }
       LIMIT 20
-    verified: {result_rows: 20, glycans_with_chebi_total: 10598, date: "2026-07-22", first_row: "G00547ZN -> ChEBI 146083 (obo:CHEBI_146083)"}
+    verified: {result_rows: 20, glycans_with_chebi_total: 10598, date: "2026-08-07", first_row: "G00547ZN -> ChEBI 146083 (obo:CHEBI_146083)"}
     teaches: "External xrefs: lowercase glycan:has_resource_entry -> a Resource_entry node with rdfs:label = DB name + dcterms:identifier = the external ID. ChEBI nodes ARE OBO IRIs (obo:CHEBI_<n>) — federation-ready. 10,598 glycans carry a ChEBI ref."
     traps_avoided:
       - "CAPITAL-R glycan:has_Resource_entry returns ONLY the GlyTouCan self-reference (dcterms:identifier = the GlyTouCan ID, no external DB) — it silently yields the wrong IDs (gotcha resource_entry_case)."
@@ -152,10 +162,59 @@ examples:
       SELECT (COUNT(DISTINCT ?glycan) AS ?glycans)
       FROM <http://rdf.glytoucan.org/core>          # pin the authoritative registry — else 13 graphs re-type the same IRIs
       WHERE { ?glycan a glycan:Saccharide . }
-    verified: {glycans: 117864, date: "2026-07-22"}
+    verified: {glycans: 117864, date: "2026-08-07"}
     teaches: "Pin GRAPH/FROM <http://rdf.glytoucan.org/core> (the authoritative registry) and use COUNT(DISTINCT) to count glycans."
     traps_avoided:
-      - "Unscoped `?s a glycan:Saccharide` = 1,090,748 rows for only 262,477 distinct IRIs (x4.16) — 13 graphs re-type the SAME GlyTouCan IRIs, worst the tmp/glycosequence staging twin. Nothing signals the inflation (gotcha saccharide_inflation)."
+      - "Unscoped `?s a glycan:Saccharide` = 400,948 rows for only 263,402 distinct IRIs (x1.52) — 13 graphs re-type the SAME GlyTouCan IRIs, the bulk from glycans/glycosequence (254,454). Nothing signals the inflation, and the multiplier shifts between reloads (it was x4.16 in 2026-07), so pin the graph rather than expecting a fixed factor (gotcha saccharide_inflation)."
+
+  - id: glycosylation_site_position
+    intent: enumerate the residue-level glycosylation sites of a glycoprotein via FALDO
+    question: "At which residue positions is AHNAK (Q09666) glycosylated?"
+    complexity: intermediate
+    sparql: |
+      PREFIX gc: <http://purl.jp/bio/12/glyco/conjugate#>
+      PREFIX faldo: <http://biohackathon.org/resource/faldo#>    # the trailing '#' is MANDATORY — see traps
+      SELECT ?site ?pos
+      FROM <http://rdf.glycosmos.org/glycoprotein>
+      WHERE {
+        <http://glycosmos.org/glycoprotein/Q09666> gc:glycosylated_at ?site .
+        ?site faldo:location ?loc .
+        ?loc faldo:position ?pos .
+      }
+      ORDER BY ?pos
+      LIMIT 10
+    verified: {result_rows: 10, date: "2026-08-07", total_sites: 116, position_range: "146-5851", first_row: "feature/gly00323976 -> position 146"}
+    teaches: "Residue-level glycosylation position is a 3-hop FALDO chain: glycoprotein gc:glycosylated_at -> a gc:Glycosylation_Site -> faldo:location -> a faldo:ExactPosition node -> faldo:position (1-based xsd:integer; 330,794 of 331,086 sites carry one, so OPTIONAL is rarely needed). Site IRI = <http://glycosmos.org/feature/gly[NNNNNNNN]>, and its location node IRI is just that site IRI + '/location'. Glycoprotein IRI = <http://glycosmos.org/glycoprotein/[UniProtAC]>."
+    traps_avoided:
+      - "The faldo: PREFIX MUST end in '#': <http://biohackathon.org/resource/faldo#>, NOT <http://biohackathon.org/resource/faldo>. A PREFIX is concatenated with the local name as a plain string, so the '#'-less form resolves faldo:location to `…/faldolocation` — a URI that exists nowhere. The query PARSES, EXECUTES and returns ZERO ROWS with no error or warning (verified 2026-08-07: 116 rows with the '#', 0 without). This is shared FALDO vocabulary, not a GlyCosmos convention — uniprot, ensembl, ddbj, hco and mogplus all require the identical '#' form, so getting it right on one RDF Portal DB means using the SAME string here."
+      - "Do NOT probe sio:SIO_000255 on the Glycoprotein looking for positions — on a Glycoprotein subject that scaffold carries GO terms + PubMed references, never site locations (gotcha sio_scaffold_reuse)."
+
+  - id: glycosylation_site_glycan
+    intent: which glycan structure is attached at each glycosylation site (site -> sio scaffold -> saccharide)
+    question: "Which glycan structures are attached at AHNAK's (Q09666) glycosylation sites, and at which positions?"
+    complexity: advanced
+    sparql: |
+      PREFIX gc: <http://purl.jp/bio/12/glyco/conjugate#>
+      PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+      PREFIX sio: <http://semanticscience.org/resource/>
+      PREFIX glytoucan: <http://www.glytoucan.org/glyco/owl/glytoucan#>
+      SELECT DISTINCT ?pos ?gtcId
+      FROM <http://rdf.glycosmos.org/glycoprotein>
+      FROM <http://rdf.glytoucan.org/core>
+      WHERE {
+        <http://glycosmos.org/glycoprotein/Q09666> gc:glycosylated_at ?site .
+        ?site faldo:location/faldo:position ?pos ;
+              sio:SIO_000255 ?ev .                 # untyped evidence bnode — the ONLY route to the glycan
+        ?ev gc:has_saccharide ?glycan .
+        ?glycan glytoucan:has_primary_id ?gtcId .
+      }
+      ORDER BY ?pos
+      LIMIT 10
+    verified: {result_rows: 10, date: "2026-08-07", distinct_position_glycan_pairs: 119, distinct_glycans: 4, first_row: "position 146 -> G49108TO"}
+    teaches: "The glycan attached at a site hangs off the site's UNTYPED sio:SIO_000255 evidence bnode (which also carries dct:references = PubMed IRIs and dct:source = the source-DB record), then gc:has_saccharide -> a glycan IRI whose GlyTouCan accession comes from glytoucan:has_primary_id in the glytoucan/core graph. This is the site-level counterpart of the position chain in glycosylation_site_position."
+    traps_avoided:
+      - "gc:has_saccharide is NEVER asserted directly on a gc:Glycosylation_Site — verified 2026-08-07: `?site a gc:Glycosylation_Site ; gc:has_saccharide ?g` returns 0 rows across the whole graph. Skipping the sio:SIO_000255 hop yields silent emptiness, not an error."
+      - "A site can carry SEVERAL evidence bnodes naming the SAME glycan (one per supporting publication), so the join FANS OUT — without DISTINCT, position 230 repeats. Use SELECT DISTINCT or COUNT(DISTINCT)."
 
   - id: disease_human_genes
     intent: human glycogenes associated with a disease + the disease name (the mandatory taxon filter)
@@ -179,7 +238,7 @@ examples:
         GRAPH <http://purl.obolibrary.org/obo/doid> { ?doid rdfs:label ?diseaseName . }
       }
       GROUP BY ?diseaseName
-    verified: {human_genes: 129, all_species: 326, diseaseName: "type 2 diabetes mellitus", date: "2026-07-22"}
+    verified: {human_genes: 129, all_species: 326, diseaseName: "type 2 diabetes mellitus", date: "2026-08-07"}
     teaches: "Disease->gene is sio:SIO_000255/sio:SIO_000001 in the disease graph; the disease NAME is on the obo:DOID_ IRI (rdfs:seeAlso) in the obo/doid graph, NOT on the glycosmos.org disease entity."
     traps_avoided:
       - "Disease->gene links are MULTI-SPECIES (the gene IRI is a numeric NCBI GeneID; species is NOT encoded in it). Omitting the has_taxon 9606 join into the glycogenes graph over-counts ~2.5x: DOID:9352 = 326 genes across all species vs 129 human."
@@ -199,10 +258,10 @@ examples:
         }
         GRAPH <http://purl.obolibrary.org/obo/go.owl> { ?goTerm rdfs:label ?goLabel . }
       }
-    verified: {distinct_go_terms: 110, date: "2026-07-22"}
+    verified: {distinct_go_terms: 87, date: "2026-08-07"}
     teaches: "Gene->GO is sio:SIO_000255/up:classifiedWith in the glycogenes graph (the untyped attribute bnode carries up:classifiedWith = an obo:GO_ IRI); the GO name lives in the go.owl graph. 97.8% of glycogenes carry >=1 GO annotation."
     traps_avoided:
-      - "The SAME sio:SIO_000255 scaffold in the DISEASE graph points to a gene (sio:SIO_000001), not a GO term — the inner predicate + graph disambiguate (gotcha sio_scaffold_dual)."
+      - "The SAME sio:SIO_000255 scaffold points to a gene (sio:SIO_000001) on a Disease subject and to an attached glycan (gc:has_saccharide) on a Glycosylation_Site — the subject class + inner predicate disambiguate, not the graph (gotcha sio_scaffold_reuse)."
 
   - id: gene_protein_bridge
     intent: glycogene -> its GlyCosmos glycoprotein WITHOUT an external ID conversion (the shared geneid node)
@@ -218,16 +277,19 @@ examples:
           <http://glycosmos.org/glycogene/3643> rdfs:seeAlso ?geneidNode .
           FILTER(STRSTARTS(STR(?geneidNode), "http://purl.uniprot.org/geneid/"))
         }
-        GRAPH <http://rdf.glycosmos.org/glycoprotein> {
+        GRAPH <http://rdf.glycosmos.org/Rhea> {          # NOT the glycoprotein graph — see traps
           ?uniprotAC rdfs:seeAlso ?geneidNode .
-          ?glycoprotein a glycan:Glycoprotein ; rdfs:seeAlso ?uniprotAC ; rdfs:label ?gpLabel .
           FILTER(STRSTARTS(STR(?uniprotAC), "http://purl.uniprot.org/uniprot/"))
         }
+        GRAPH <http://rdf.glycosmos.org/glycoprotein> {
+          ?glycoprotein a glycan:Glycoprotein ; rdfs:seeAlso ?uniprotAC ; rdfs:label ?gpLabel .
+        }
       }
-    verified: {result_rows: 1, date: "2026-07-22", first_row: "geneid/3643 -> uniprot/P06213 -> glycoprotein/P06213 'Insulin receptor'"}
-    teaches: "A glycogene and its glycoprotein share <http://purl.uniprot.org/geneid/[GeneID]> as an implicit join node: the glycogene rdfs:seeAlso it, and in the glycoprotein graph the UniProt IRI rdfs:seeAlso the SAME node while the glycoprotein rdfs:seeAlso that UniProt IRI. Traverse entirely inside GlyCosmos."
+    verified: {result_rows: 1, date: "2026-08-07", first_row: "geneid/3643 -> uniprot/P06213 -> glycoprotein/P06213 'Insulin receptor'"}
+    teaches: "A glycogene and its glycoprotein share <http://purl.uniprot.org/geneid/[GeneID]> as an implicit join node, but the two legs live in DIFFERENT graphs: the glycogene rdfs:seeAlso the geneid node in the glycogenes graph, while the UniProt IRI rdfs:seeAlso that same node in the Rhea graph (a UniProt-derived annotation graph); the glycoprotein then rdfs:seeAlso the UniProt IRI in the glycoprotein graph. Traverse entirely inside GlyCosmos."
     traps_avoided:
-      - "Do NOT leave GlyCosmos to convert NCBI GeneID -> UniProt AC via TogoID: it is an extra round-trip and drops the disease/GO context. The geneid node is the internal bridge (anti_pattern in v2)."
+      - "The geneid leg is NOT in the glycoprotein graph. As of 2026-08-07 `purl.uniprot.org/geneid/` appears ZERO times there (it did in 2026-07) — the bridge moved to GRAPH <http://rdf.glycosmos.org/Rhea>. Pinning the intuitive graph returns 0 rows silently. Glycoprotein IRIs are UniProt-AC-keyed (<http://glycosmos.org/glycoprotein/[AC]>), so for a known AC you can skip the bridge entirely."
+      - "Do NOT leave GlyCosmos to convert NCBI GeneID -> UniProt AC via TogoID: it is an extra round-trip and drops the disease/GO context."
 
   - id: cazy_families
     intent: CAZy families of one enzyme class, with their activities
@@ -243,7 +305,7 @@ examples:
         OPTIONAL { ?family dcterms:description ?description }                        # activities + EC list
       }
       ORDER BY ?title
-    verified: {result_rows: 135, date: "2026-07-22", note: "class breakdown 430 GH · 135 GT · 107 PL · 102 CBM · 27 AA · 20 CE"}
+    verified: {result_rows: 135, date: "2026-08-07", note: "class breakdown 430 GH · 135 GT · 107 PL · 102 CBM · 27 AA · 20 CE"}
     teaches: "A CAZy family node (<…/dbid/cazy/[FAM]>) is a up:Resource (NOT a glycan class): dcterms:title = family name, rdfs:label = the CAZy CLASS name (filter it to list a whole class), dcterms:description = activities+EC. Pin the cazy graph."
 
   - id: cazy_family_proteins
@@ -262,7 +324,7 @@ examples:
         ?gb owl:sameAs ?emblcds .                                       # -> UniProt-side embl-cds accession
         ?protein a up:Protein ; rdfs:seeAlso ?emblcds .                 # protein <- same accession
       }
-    verified: {n: 2867, date: "2026-07-22"}
+    verified: {n: 2867, date: "2026-08-07"}
     teaches: "CAZy family<->protein is INDIRECT — no direct predicate. Bridge: family rdfs:seeAlso genbank/[ACC] ; owl:sameAs embl-cds/[ACC] ; protein rdfs:seeAlso that same embl-cds node. Protein name = rdfs:label, EC = up:enzyme (41% coverage)."
     traps_avoided:
       - "There is NO family predicate on the up:Protein and no reverse link — `?protein ?p <…/cazy/GH13>` returns nothing. And CAZy up:Protein nodes carry NO glycan:has_taxon (taxon is on the genbank member node), so a protein taxon filter returns 0 rows."
@@ -288,7 +350,7 @@ examples:
           OPTIONAL { ?exp glycodm:cellType ?cellType }
         }
       }
-    verified: {distinct_medium_tissues: 29, date: "2026-07-22"}
+    verified: {distinct_medium_tissues: 29, date: "2026-08-07"}
     teaches: "GlyCosmos DOES hold HPA IHC expression (in the HPA graph) — the glycoprotein entity does NOT. An HPA gene record (<…/dbid/hpa/ENSG…>) carries glycodm:geneSymbol + rdfs:seeAlso -> untyped expression bnodes (glycodm:tissue/cellType/level, level is xsd:string). Join to a glycogene by SYMBOL (glycodm:geneSymbol == glycogene rdfs:label)."
     traps_avoided:
       - "HPA is Ensembl-keyed, glycogene is NCBI-GeneID-keyed — the ONLY join is the gene SYMBOL, and symbols aren't unique, so anchor the specific glycogene IRI (and taxon-filter) rather than symbol alone. The glycoprotein entity has NO expression predicate; earlier docs wrongly called HPA 'ID cross-references only' — it is real IHC expression."
@@ -308,14 +370,14 @@ examples:
         OPTIONAL { ?lectin rdfs:seeAlso ?xref }
       }
       LIMIT 30
-    verified: {result_rows: 30, date: "2026-07-22", first_row: "GL_002303 'Concanavalin-A' -> uniprot/P02866 + LfDB0170 + carbogrove/P02866 + UniLectin3D"}
+    verified: {result_rows: 16, distinct_lectins: 7, date: "2026-08-07", first_row: "GL_002303 'Concanavalin-A' -> uniprot/P02866 + LfDB0170 + carbogrove/P02866 + UniLectin3D"}
     teaches: "START lectin-name lookups at the GL hub (<http://rdf.glycosmos.org/lectin>, sb:Lectin, GL_###### IRIs): names are on STANDARD rdfs:label (+ skos:altLabel for abbreviations), and rdfs:seeAlso hands off to UniProt (100% of labeled lectins) + UniLectin3D/CarboGrove/LfDB — one lookup grounds the name AND yields every source ID."
     traps_avoided:
       - "The source DBs LfDB and CarboGrove put names on BESPOKE predicates (lfdb:has_lectin_name; cg:LectinName/cg:CommonName), NOT rdfs:label — a naive rdfs:label search over those graphs returns 0. Start at the hub; see schema_delta for direct source-DB grounding."
 
   - id: enum_go_glycogenes
     intent: enumerate ALL human glycogenes carrying a GO term (the reverse-GO set route — Tier A, buried in v2)
-    question: "How many human glycogenes are annotated to 'protein glycosylation' (GO:0006486)?"
+    question: "How many human glycogenes are annotated to 'protein N-linked glycosylation' (GO:0006487)?"
     complexity: aggregation
     sparql: |
       PREFIX sio: <http://semanticscience.org/resource/>
@@ -324,14 +386,15 @@ examples:
       SELECT (COUNT(DISTINCT ?gene) AS ?n)
       WHERE {
         GRAPH <http://rdf.glycosmos.org/glycogenes> {
-          ?gene sio:SIO_000255/up:classifiedWith <http://purl.obolibrary.org/obo/GO_0006486> ;
+          ?gene sio:SIO_000255/up:classifiedWith <http://purl.obolibrary.org/obo/GO_0006487> ;
                 glycan:has_taxon <http://identifiers.org/taxonomy/9606> .
         }
       }
-    verified: {n: 81, date: "2026-07-22", cross_check: "GO:0006487 (protein N-linked glycosylation) = 58; GO:0016757 (glycosyltransferase activity) = 19"}
+    verified: {n: 62, date: "2026-08-07", cross_check: "GO:0006493 (protein O-linked glycosylation) = 79; GO:0016757 (glycosyltransferase activity) = 69"}
     teaches: "REVERSE-GO ENUMERATION — to find EVERY gene with GO term X, drive the sio:SIO_000255/up:classifiedWith path FROM the GO IRI to ?gene (not gene->GO). This is the set-level route for 'all glycogenes with function X'; add has_taxon 9606 for the human subset. The same scaffold used forward (gene_go) runs backward here."
     traps_avoided:
       - "Do NOT text-search glycogene labels/descriptions for the function name — the GO term is a controlled IRI; the typed sio:SIO_000255/up:classifiedWith route is exact, a name match silently undercounts."
+      - "A GO term that is obsoleted upstream vanishes from this graph with NO trace and NO error — the broad parent GO:0006486 ('protein glycosylation') carried 81 human glycogenes in 2026-07 and returns 0 today, while its children GO:0006487/GO:0006493 are well populated. A 0 here means 'check the term is still current in the `go` database', not 'no such genes'."
 
   - id: enum_go_descendants
     intent: enumerate glycogenes for a GO term OR ANY OF ITS DESCENDANTS — the "…or descendant terms" set route (Tier A; needs the AUTHORITATIVE GO hierarchy, NOT the endpoint's own go.owl copy)
@@ -368,11 +431,10 @@ examples:
                 glycan:has_taxon <http://identifiers.org/taxonomy/9606> .
         }
       }
-    verified: {n: 121, date: "2026-07-22", go_db_terms: 16, local_goowl_undercount: 100}
+    verified: {n: 160, date: "2026-08-07", go_db_terms: 16, local_goowl_agrees_today: 160}
     teaches: "A '<GO term> OR ITS DESCENDANTS' enumeration is a TWO-database recipe: (1) expand the term with rdfs:subClassOf* on the authoritative `go` RDF database to get the descendant IRIs, (2) VALUES those IRIs into the glycogenes reverse-GO join (enum_go_glycogenes). The single-term route (enum_go_glycogenes) answers only the exact term and undercounts any '…or descendants' question."
     traps_avoided:
-      - "Do NOT expand descendants with the endpoint's OWN embedded GO graph (GRAPH <http://purl.obolibrary.org/obo/go.owl>) — it is a PARTIAL/stale GO snapshot whose subClassOf* closure diverges from the real ontology, giving a different term set and a wrong gene count (here 100 vs the correct 121). Source descendant IRIs from the native `go` database only."
-      - "glycogenes are annotated to GO IRIs the local go.owl does not connect back to the parent term, so a purely intra-glycosmos subClassOf* traversal misses them no matter how careful the query — the external `go` expansion is mandatory, not an optimization."
+      - "The endpoint's embedded GRAPH <http://purl.obolibrary.org/obo/go.owl> is a SNAPSHOT of GO, not GO itself, and its subClassOf* closure has diverged before: in 2026-07 it yielded 100 genes against the authoritative 121. RE-VERIFIED 2026-08-07 — the snapshot has since been refreshed and now AGREES exactly (16 descendant terms, 160 genes, identical to the native `go` database). Treat the agreement as a fact with a date, not a guarantee: expanding from the native `go` database costs one extra call and cannot drift, so keep it as the default and only trust the local copy after checking it against `go` for the term at hand."
 
   - id: enum_hpa_tissue
     intent: enumerate ALL human glycogenes with High expression in a tissue (the reverse-HPA set route — Tier A, buried in v2)
@@ -392,14 +454,13 @@ examples:
           ?gene rdfs:label ?sym ; glycan:has_taxon <http://identifiers.org/taxonomy/9606> .
         }
       }
-    verified: {n: 1663, date: "2026-07-22"}
+    verified: {n: 1683, date: "2026-08-07"}
     teaches: "REVERSE-HPA ENUMERATION — to find EVERY glycogene expressed at a level in a tissue, filter the HPA expression bnodes by glycodm:tissue + glycodm:level FIRST, collect the symbols, then join back to glycogenes by symbol. This is the set-level 'all genes High in tissue X' route (the forward hpa_tissue example runs gene->tissues; this runs tissue->genes)."
     traps_avoided:
       - "tissue/level are xsd:string literals matched exactly ('High'/'Medium'/'Low'/'Not detected', case-sensitive; tissue names as HPA spells them). The symbol join can map one symbol to multiple glycogene IRIs — COUNT(DISTINCT ?gene), and taxon-filter to stay in the human set."
 
 # ── schema_delta: non-obvious predicates/structure NO example above already demonstrates. ──
 schema_delta:
-  - "GLYCOSYLATION SITES (FALDO): glycoprotein glycoconjugate:glycosylated_at -> a glycoconjugate:Glycosylation_Site (IRI <http://glycosmos.org/glycosylationsite/SITE…>) -> faldo:location -> a faldo:ExactPosition node (<…/location/LOC…>) with faldo:position (1-based, xsd:integer, 98.3% of sites); the site's parent protein is sio:SIO_000772 and its attached glycan is glycoconjugate:has_saccharide. 414,798 sites."
   - "MOTIF DUAL-IRI: a motif has TWO IRIs sharing the GlyTouCan ID suffix. The glycan:has_motif LINK object is <http://rdf.glycoinfo.org/glycan/[ID]> (glycosequence graph); the motif DEFINITION/label is a gn:Motif at <http://glycoinfo.org/motif/[ID]> (motif_label graph, note glycoinfo.org NOT rdf.glycoinfo.org). They do not join directly — carry the ID across. 133 motifs (rdfs:label may be multi-valued)."
   - "LECTIN SOURCE DBs (bespoke name predicates, NO rdfs:label): LfDB (<http://rdf.glycoinfo.org/lfdb>, glycan:Lectin) puts names on lfdb:has_lectin_name (473 over 398, incl. short names like 'RSL'), seeAlso -> PDB/Pfam/INSDC (not UniProt); CarboGrove (<http://rdf.glycosmos.org/carbogrove>, sb:Lectin) on cg:LectinName / cg:CommonName (IRI is UniProt-AC-keyed). Prefer the GL hub (example lectin_grounding); use these for direct source grounding. lfdb: = <http://purl.jp/bio/12/lfdb/2014/7/owl#>, cg: = <http://rdf.glycoinfo.org/carbogrove/Ontology#> (capital O)."
   - "GLYCOEPITOPES: 173 glycan:Glycan_epitope (<http://www.glycoepitope.jp/epitopes/EP…>, glycoepitope graph) with free-text rdfs:label ('Lewis x'), skos:altLabel synonyms, glycoepitope:has_antibody/organism/tissue, glycan:has_glycosequence."
@@ -422,6 +483,7 @@ id_join_map:
     disease_name: "disease rdfs:seeAlso -> obo:DOID_ IRI; name in GRAPH <obo/doid>"
     cazy_family_protein: "family rdfs:seeAlso genbank/[ACC] ; owl:sameAs embl-cds/[ACC] ; up:Protein rdfs:seeAlso same (example cazy_family_proteins)"
     hpa_expression: "join glycogene rdfs:label (symbol) == HPA glycodm:geneSymbol (examples hpa_tissue, enum_hpa_tissue)"
+    glycoprotein_site: "glycoprotein gc:glycosylated_at -> gc:Glycosylation_Site (<http://glycosmos.org/feature/gly[N]>); position via faldo:location/faldo:position, attached glycan via sio:SIO_000255/gc:has_saccharide (examples glycosylation_site_position, glycosylation_site_glycan)"
   xrefs:                          # outbound minted IRIs on the data — federation-ready
     chebi:     "lowercase glycan:has_resource_entry -> obo:CHEBI_<n> (OBO IRI; 10,598 glycans)"
     pubchem:   "lowercase glycan:has_resource_entry -> rdf.glycoinfo.org/pubchem/compound/CID<n> (31,774 glycans)"
@@ -436,3 +498,14 @@ id_join_map:
 # v3: `wc -c benchmark/studies/redesign/mie_v3/glycosmos.yaml` = 33924 bytes → 61.6% smaller than v2.
 # (2026-07-22 canary fix: added example enum_go_descendants — the GO-term-plus-descendants enumeration
 #  route via the native `go` DB; the endpoint's embedded go.owl is a partial/divergent GO snapshot.)
+# (2026-08-07 revision, from a live AHNAK/Q09666 debugging session:
+#   - NEW examples glycosylation_site_position + glycosylation_site_glycan. The FALDO route had been prose
+#     only in schema_delta, so an agent rewrote it from scratch and dropped the '#' off the faldo: PREFIX —
+#     0 rows, no error. That schema_delta line is now DELETED (§4.2: a predicate shown in an example is not
+#     repeated) and its three stale facts corrected: site IRIs are feature/gly[N] not glycosylationsite/SITE,
+#     the location node is <site>/location not …/location/LOC, and there are 331,086 sites at 99.9%
+#     position coverage, not 414,798 at 98.3%.
+#   - sio_scaffold_dual RENAMED sio_scaffold_reuse: four payloads, disambiguated by SUBJECT CLASS (two of
+#     them live in the same glycoprotein graph, so the old "branch on GRAPH" advice was insufficient).
+#   - saccharide_inflation refigured x4.16 -> x1.52 (400,948 rows / 263,402 IRIs): the tmp/glycosequence
+#     and tmp/wurcsrdf staging twins were dropped upstream. Multiplier is reload-dependent — always pin.)

--- a/togo_mcp/data/mie/jpostdb.yaml
+++ b/togo_mcp/data/mie/jpostdb.yaml
@@ -1,6 +1,6 @@
 # MIE v3 — jPOST proteomics (jPOSTdb). Agent-authored 2026-07-22 on `mie-redesign`.
 # Format: togo_mcp/data/docs/MIE_v3_spec.md. Every verified count/result re-run live on the jpostdb
-# endpoint 2026-07-22. Byte count vs the v2 file it replaces (spec §5 item 7):
+# endpoint 2026-08-07. Byte count vs the v2 file it replaces (spec §5 item 7):
 # v2 togo_mcp/data/mie/jpostdb.yaml = 45,716 bytes; this v3 file = 19,563 bytes → 57.2% smaller. See footer.
 database: jpostdb
 
@@ -20,27 +20,42 @@ endpoint: https://rdfportal.org/primary/sparql   # RDF Portal "primary" endpoint
 base_uri: http://rdf.jpostdb.org/
 graphs:
   primary: http://jpost.org/graph/database    # the ONLY graph that declares jpost:Project/Dataset/Peptide/Protein/Modification
-  co_hosted:                       # same endpoint; jPOST IRIs are jPOST-minted throughout → single-tenant, ZERO overlap
-    uniprot_NOT_here: >
-      TRAP, not a join. UniProt lives on the SEPARATE `sib` endpoint (https://rdfportal.org/sib/sparql), NOT on
-      primary. A jpost:hasDatabaseSequence target (purl.uniprot.org/uniprot/*) queried as a same-endpoint GRAPH
-      returns ZERO rows silently. Reach UniProt only via SERVICE federation (example xdb_uniprot).
+  co_hosted:                       # 2g probe re-run 2026-08-07 (reverse probe, ?p unbound, on 2 jPOST entities + 3 hub IRIs)
+    jpost_own_iris_clean: >
+      PROBED CLEAN — jPOST's OWN entity IRIs (entry/JPST*, entry/PRT*) resolve in http://jpost.org/graph/database
+      and NOWHERE else: all 4 rdf:type, 2 dct:identifier, 229 hasPeptideEvidence triples land in that one graph, and
+      no co-tenant re-types a jPOST class. So a graph-pinned COUNT of Project/Dataset/Protein does NOT inflate.
+    hub_iris_ARE_redeclared: >
+      INFLATION, and it is on the JOIN TARGETS, not on jPOST's own nodes — the moment a query follows a hub IRI
+      OUT of the jPOST graph it enters multi-graph territory. Verified 2026-08-07: this endpoint ALSO hosts ~40
+      rdf.glycosmos.org/* graphs, and <purl.uniprot.org/uniprot/P01116> carries rdfs:label "GTPase KRas" in BOTH
+      glycosmos/glycoprotein AND glycosmos/pathway (x2, plus up:classifiedWith x38 and its own rdf:type there);
+      <identifiers.org/taxonomy/9606> is labelled "Homo sapiens" by BOTH ontology/taxonomy and dataset/microbedbjp
+      (x2, values agree here); obo:DOID_* appears across six togoid relation graphs. MEASURED: reading rdfs:label
+      off the UniProt IRI unpinned returned 212 rows for KRAS's 106 protein entries — exactly x2. jPOST itself puts
+      NO label on the UniProt IRI, so this is pure foreign duplication. FIX: GRAPH-pin the graph you actually mean
+      on the hub leg too, or use SERVICE for UniProt (example xdb_uniprot). COUNT(DISTINCT) masks the row count but
+      not a per-graph value disagreement.
+    uniprot_NOT_here: "UniProt itself is NOT a graph here — it is off-endpoint (gotcha uniprot_off_endpoint). Only foreign RE-DECLARATIONS of its IRIs are present, per hub_iris_ARE_redeclared."
     ontology_graphs: >
-      ~30 shared rdfportal.org/ontology/* graphs + mesh + goa co-host here (mondo, taxonomy, go, …). Pure JOIN
-      TARGETS — none re-type or overlap a jPOST entity IRI (probed GROUP BY graph), so they do NOT inflate counts;
-      GRAPH-pin one explicitly to use it (e.g. DOID→MONDO label via oboInOwl:hasDbXref in ontology/mondo).
+      ~30 shared rdfportal.org/ontology/* graphs + mesh + goa co-host here (mondo, taxonomy, go, …). None re-type or
+      overlap a jPOST-minted entity IRI, so they cannot inflate a count of jPOST's OWN entities — but they DO
+      re-declare the shared hub IRIs jPOST points at (see hub_iris_ARE_redeclared). GRAPH-pin one explicitly to use
+      it (e.g. DOID→MONDO label via oboInOwl:hasDbXref in ontology/mondo).
     jpost_owl_schema: >
       http://rdf.jpostdb.org/ontology/jpost.owl is jPOST's SCHEMA graph (class/property definitions only, ZERO
       instance data — no entry/* IRI). Not a data copy, cannot inflate; join to it for class labels if needed.
 
-entity_counts:                     # COUNT(DISTINCT), graph-pinned; verified live 2026-07-22
+entity_counts:                     # COUNT(DISTINCT), graph-pinned; verified live 2026-08-07
   projects:            598         # jpost:Project (JPST ids)
   datasets:            853         # jpost:Dataset (~1.4 per project; Dataset is the central join hub)
   samples:             853         # jpost:Sample (1 per Dataset Profile)
-  samples_with_disease: 6          # only 6 distinct DOID values across all samples — disease annotation is SPARSE (see enum_disease)
-  big_tables_note: "Peptide ~3.7M, PSM ~10M, Modification ~12.5M — NEVER star-scan these without a structural anchor (a Project/Protein IRI or a typed Unimod term); see gotcha hot_tables."
+  samples_with_disease: 86         # 86 of 853 samples (10.1%) carry jpost:disease, spanning only 6 distinct DOID values — SPARSE (see enum_disease)
+  distinct_disease_doids: 6        # the whole disease vocabulary in use across the repository
+  modifications_total:  12518574   # jpost:Modification; only 13.5% carry a real name — the label split is on mod_frequency
+  big_tables_note: "Peptide ~3.7M, PSM ~10M, Modification 12.5M — NEVER star-scan these without a structural anchor (a Project/Protein IRI or a typed Unimod term); see gotcha hot_tables."
 
-global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-07-22
+global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-08-07
   - id: graph_mandatory
     say: >
       GRAPH <http://jpost.org/graph/database> is MANDATORY on every triple block. Bare patterns hit the empty
@@ -53,7 +68,7 @@ global_gotchas:                    # the few that bite ANY query on this DB — 
   - id: unimod_prefix
     say: >
       Modifications are typed with the UNIMOD term under the `http://www.unimod.org/obo/unimod.obo#` prefix
-      (unimod:UNIMOD_35), NOT the common `http://purl.obolibrary.org/obo/UNIMOD_35` (obo:) form. Verified 2026-07-22:
+      (unimod:UNIMOD_35), NOT the common `http://purl.obolibrary.org/obo/UNIMOD_35` (obo:) form. Verified 2026-08-07:
       `a unimod:UNIMOD_35` = 699,291 modifications; `a obo:UNIMOD_35` = 0. PSI-MS terms DO use the obo: PURL
       (obo:MS_*). Mixing the two namespaces returns 0 rows with no error.
   - id: bnode_scaffolds
@@ -62,6 +77,18 @@ global_gotchas:                    # the few that bite ANY query on this DB — 
       `?pep jpost:hasSequence [ a obo:MS_1001344 ; rdf:value ?seq ]` (a direct `?pep ?p "SEQ"` matches nothing);
       (2) every numeric measurement (peptide/PSM count, m/z, RT, charge) is `<entity> sio:SIO_000216 [ a obo:MS_<term> ;
       sio:SIO_000300 ?value ]` — the PSI-MS type says what the number means. Do not assume a single typed value predicate.
+      (3) A blank-node id printed in tool output (`nodeID://b1857439210`) is a DISPLAY LABEL of that one query
+      execution, NOT a stable or re-submittable IRI. `FILTER(?ev = <nodeID://b1857439210>)` in a follow-up query
+      silently matches NOTHING (verified 2026-08-07: 0 rows on a bnode copied verbatim from the previous result) —
+      as an IRI it denotes a different, non-existent resource. jPOST is unusually bnode-heavy (PeptideEvidence,
+      every FALDO begin/end/location node), so this bites often. To drill into ONE instance, re-bind it inside the
+      SAME query with a nested `{ SELECT ?x WHERE { … } LIMIT 1 }` subquery — never carry a nodeID across calls.
+  - id: hub_union_inflation
+    say: >
+      Pinning the jPOST graph protects jPOST's own entities but NOT the hub IRIs a query follows OUT of it
+      (UniProt, taxonomy, DOID) — those are re-declared by co-tenants, measured x2, per graphs.co_hosted. SAFE
+      PATTERN: give EVERY leg its own explicit GRAPH block, the hub leg included; joining k re-declared predicates
+      multiplies as the PRODUCT. SELECT DISTINCT only masks the duplication.
   - id: hot_tables
     say: >
       Peptide/PSM/Modification are 3.7M/10M/12.5M rows. A star pattern or COUNT over them without a structural
@@ -86,7 +113,7 @@ examples:
         }
       }
       LIMIT 10
-    verified: {result_rows: 1, date: "2026-07-22", first_row: "'JPST000349-12 Mouse liver and kidney proteome with antibiotics treatment' (2023-04-01) → RPXD034320"}
+    verified: {result_rows: 1, date: "2026-08-07", first_row: "'JPST000349-12 Mouse liver and kidney proteome with antibiotics treatment' (2023-04-01) → RPXD034320"}
     teaches: "A Project IRI is http://rdf.jpostdb.org/entry/JPST<6-digit>; rdfs:seeAlso carries BOTH the jPOSTrepo page and the ProteomeXchange RPXD id — prefix-filter to pick one."
 
   - id: protein_evidence
@@ -102,7 +129,7 @@ examples:
           ?prot jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/P01116> .
         }
       }
-    verified: {nEntries: 106, nProjects: 87, date: "2026-07-22"}
+    verified: {nEntries: 106, nProjects: 87, date: "2026-08-07"}
     teaches: "The SAME UniProt protein gets a distinct Protein IRI (entry/PRT<proj>_<ds>_<acc>) in every project that detected it. To find ALL evidence, filter by jpost:hasDatabaseSequence <purl.uniprot.org/uniprot/ACC> — the typed, indexed cross-ref — never by PRT IRI substring."
     traps_avoided:
       - "There is NO reverse `jpost:isDetectedIn` predicate (silent 0 rows). Reach proteins top-down through Dataset (jpost:hasDataset/jpost:hasProtein) or, for peptide coordinates, via jpost:hasPeptideEvidence."
@@ -126,7 +153,7 @@ examples:
       GROUP BY ?seq
       ORDER BY DESC(?nPsms)
       LIMIT 10
-    verified: {result_rows: 10, date: "2026-07-22", first_row: "KVPQVSTPTLVEVSR (616 PSMs)"}
+    verified: {result_rows: 10, date: "2026-08-07", first_row: "KVPQVSTPTLVEVSR (616 PSMs)"}
     teaches: "The AA string is on a child blank node typed obo:MS_1001344, reached via jpost:hasSequence [ … rdf:value ?seq ]. Protein→peptide runs through the jpost:hasPeptideEvidence bnode (jpost:hasPeptideEvidence/jpost:hasPeptide), which also carries FALDO start/end coordinates."
     traps_avoided:
       - "A direct `?pep rdf:value ?seq` (or `?pep ?p 'SEQ'`) matches nothing — the sequence is never a direct object of the Peptide (gotcha bnode_scaffolds). This is the single most common jPOST silent failure."
@@ -147,7 +174,7 @@ examples:
         }
       }
       LIMIT 25
-    verified: {result_rows: 16, date: "2026-07-22", first_row: "JPST001775 — SARS-CoV-2 proteomics reanalysis"}
+    verified: {result_rows: 16, date: "2026-08-07", first_row: "JPST001775 — SARS-CoV-2 proteomics reanalysis"}
     teaches: "Sample annotations are pre-typed ontology IRIs, so 'all projects/samples with property X' is an EXACT set enumeration — jpost:disease → obo:DOID_*, jpost:sampleType → NCIt/CLO/BTO, jpost:organ → NCIt/BTO, jpost:species → identifiers.org/taxonomy/*. Filter by the IRI, never bif:contains a name."
     traps_avoided:
       - "Disease is SPARSE (only 6 distinct DOID values across 853 samples, ~10% of samples annotated). An empty result for a disease usually means it was never curated, not a query bug — sampleType (98.9%) and species (100%) are the dense annotations."
@@ -163,10 +190,40 @@ examples:
           ?mod a unimod:UNIMOD_35 .    # UNIMOD_35 = Oxidation; swap the number for any PTM (4=carbamidomethyl, 1=acetyl, …)
         }
       }
-    verified: {nOxidation: 699291, date: "2026-07-22"}
+    verified: {nOxidation: 699291, date: "2026-08-07"}
     teaches: "To enumerate/count a specific PTM, type-filter on the Unimod IRI: ?mod a unimod:UNIMOD_<n>. This is THE set-level modification route — exact, no text match. A Modification also chains up via ^jpost:hasModification to its PSM/Peptide/Project when you need to scope the count."
     traps_avoided:
       - "MUST use the unimod: prefix http://www.unimod.org/obo/unimod.obo# — `a obo:UNIMOD_35` (the obo PURL) returns 0 silently (gotcha unimod_prefix). Verified: unimod: = 699,291 vs obo: = 0."
+
+  - id: ptm_absolute_position
+    intent: translate a Modification's peptide-relative FALDO position into a UniProt-absolute residue number
+    question: "At which UniProt residue positions is AHNAK (Q09666) phosphorylated (Unimod 21)?"
+    complexity: advanced
+    sparql: |
+      PREFIX jpost: <http://rdf.jpostdb.org/ontology/jpost.owl#>
+      PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+      PREFIX unimod: <http://www.unimod.org/obo/unimod.obo#>
+      SELECT DISTINCT ?modSite (?peptBegin + ?modPos - 1 AS ?protPos)
+      WHERE {
+        GRAPH <http://jpost.org/graph/database> {
+          ?prot jpost:hasDatabaseSequence <http://purl.uniprot.org/uniprot/Q09666> ;
+                jpost:hasPeptideEvidence ?ev .
+          ?ev jpost:hasPeptide ?pep ;
+              faldo:location [ faldo:begin [ faldo:position ?peptBegin ] ] .   # PROTEIN-absolute
+          ?pep jpost:hasPsm ?psm .
+          ?psm jpost:hasModification ?mod .
+          ?mod a unimod:UNIMOD_21 ;                                            # Phospho
+               jpost:modificationSite ?modSite ;
+               faldo:location [ faldo:position ?modPos ] .                     # PEPTIDE-relative
+        }
+      }
+      ORDER BY ?protPos
+      LIMIT 20
+    verified: {result_rows: 20, total_distinct_rows: 177, date: "2026-08-07", first_rows: "S@18, S@20, T@38, S@41"}
+    teaches: "jPOST carries TWO FALDO coordinate frames and a residue-level PTM question needs BOTH. A PeptideEvidence's faldo:location/faldo:begin/faldo:position is PROTEIN-absolute (its faldo:reference is the Protein IRI, e.g. entry/PRT1615_1_Q09666); a Modification's faldo:location/faldo:position is relative to its PARENT PEPTIDE (faldo:reference is a Peptide IRI, e.g. entry/PEP1616_1_354). Compose them: protein_position = peptide_begin + modification_relative_position - 1. faldo:location is near-universal on Unimod-typed mods (1,727,200 of 1,728,710 UNIMOD_21 = 99.9%), so no OPTIONAL is needed."
+    traps_avoided:
+      - "Treating a Modification's faldo:position as protein-absolute is the silent killer: it yields plausible-looking small residue numbers (here 21 instead of 2431) that are simply wrong for every peptide after the first. Nothing errors. The two ExactPosition nodes are structurally IDENTICAL — same predicate, same rdf:type faldo:ExactPosition — and differ ONLY in what faldo:reference points at, so read faldo:reference to know which frame you are in before doing arithmetic."
+      - "Do NOT add `?mod rdfs:label ?name` to this query to name the PTM. NO Unimod-typed Modification carries rdfs:label — verified 2026-08-07: UNIMOD_1/4/21/35 all return 0 labelled instances out of 274 / 1,810,303 / 1,728,710 / 699,291. As a required pattern it zeroes the whole query (see mod_frequency for the label-bearing population, and schema_delta for the modificationClass naming route)."
 
   - id: mod_frequency
     intent: rank modification types across the whole repository by occurrence (label-based aggregation)
@@ -184,10 +241,11 @@ examples:
       GROUP BY ?label
       ORDER BY DESC(?n)
       LIMIT 10
-    verified: {result_rows: 10, date: "2026-07-22", first_row: "'TMT6plex (N-term)' = 444,696; then 'TMTpro (N-term)' 398,192"}
+    verified: {result_rows: 10, date: "2026-08-07", first_row: "'TMT6plex (N-term)' = 444,696; then 'TMTpro (N-term)' 398,192"}
     teaches: "jpost:Modification carries a denormalised human-readable rdfs:label (the Unimod name); GROUP BY it as-is to rank PTMs. Labels ARE the vocabulary — no join to Unimod needed for the name; use the unimod: type (mod_by_unimod) only to FILTER a specific PTM."
     traps_avoided:
-      - "~5.2M of the ~12.5M Modification instances have an empty-string rdfs:label — FILTER(?label != '') or the empty bucket dominates the ranking."
+      - "rdfs:label fails on Modification in TWO different ways, and only one is fixable with a FILTER. Of 12,518,574 Modification instances (verified 2026-08-07): 5,624,538 (44.9%) have NO rdfs:label PREDICATE AT ALL, 5,206,460 (41.6%) have rdfs:label \"\", and only 1,687,576 (13.5%) carry a real name. FILTER(?label != '') fixes the empty bucket — it CANNOT help with the absent bucket, because a required (non-OPTIONAL) rdfs:label pattern drops those 5.6M rows before any FILTER runs. Wrap rdfs:label in OPTIONAL whenever the query is not already restricted to the label-bearing population."
+      - "The absent-label population is not random: it is the Unimod-TYPED one. Type-filtering (`?mod a unimod:UNIMOD_21`) and joining rdfs:label as a required pattern returns ZERO rows total even though each condition alone matches millions — the two populations are effectively disjoint (example ptm_absolute_position)."
 
   - id: datasets_per_project
     intent: aggregate the Project→Dataset 1:N relation (project scope sanity check)
@@ -204,7 +262,7 @@ examples:
       GROUP BY ?id
       ORDER BY DESC(?nDatasets)
       LIMIT 5
-    verified: {result_rows: 5, date: "2026-07-22", first_row: "JPST001781 = 30 datasets", totals: "598 projects / 853 datasets"}
+    verified: {result_rows: 5, date: "2026-08-07", first_row: "JPST001781 = 30 datasets", totals: "598 projects / 853 datasets"}
     teaches: "Project ↔ Dataset is 1:N (598 → 853, ~1.4/project); a few mega-projects bundle dozens of runs. Dataset is the hub that connects DOWN to Profile, Protein, and Peptide via three parallel direct predicates."
 
   - id: xdb_uniprot
@@ -226,7 +284,7 @@ examples:
         }
       }
       LIMIT 5
-    verified: {result_rows: 1, date: "2026-07-22", first_row: "P02768 → 'Albumin' / 'Homo sapiens'"}
+    verified: {result_rows: 1, date: "2026-08-07", first_row: "P02768 → 'Albumin' / 'Homo sapiens'"}
     teaches: "jPOST and UniProt are on SEPARATE endpoints (primary vs sib), so the join MUST be SPARQL 1.1 SERVICE federation, not a same-endpoint GRAPH block. jpost:hasDatabaseSequence yields the exact purl.uniprot.org/uniprot IRI that UniProt keys on — a clean bridge, no TogoID, no text match."
     traps_avoided:
       - "Querying purl.uniprot.org/uniprot/* as a co-hosted GRAPH on primary returns 0 rows silently (gotcha uniprot_off_endpoint). SELECT DISTINCT because a protein recurs across many projects' PRT IRIs, all sharing one hasDatabaseSequence target."
@@ -235,7 +293,8 @@ examples:
 schema_delta:
   - "Protein is MULTI-TYPED: every jpost:Protein also carries obo:MS_1001591 (anchor) + obo:MS_1002401 (representative), and ~66% carry jpost:RepresentativeIsoform. `?p a jpost:Protein` is the correct filter; don't assume it's the only type on a DESCRIBE."
   - "rdfs:label on a Protein IS the bare UniProt accession string (e.g. 'P02768'); dct:identifier is the PRT id. For the structured UniProt link use jpost:hasDatabaseSequence (typed purl, 100%), not the label."
-  - "Modification POSITION: jpost:modificationSite (single-letter AA) + faldo:location → faldo:ExactPosition (faldo:position int, faldo:reference → parent Peptide) are present IFF the Modification has a Unimod type. Label-only N-term mods (e.g. 'TMTpro (N-term)') carry no position triple by design."
+  - "TWO DISJOINT Modification populations, and which one you are in decides what is queryable (the composition is worked in example ptm_absolute_position): UNIMOD-TYPED mods carry a position (faldo:location, 99.9%) and jpost:modificationSite but NO rdfs:label; LABEL-BEARING mods (e.g. 'TMTpro (N-term)') carry the human-readable Unimod name but no position triple, by design. There is no single Modification query that yields both a name and a residue position."
+  - "NAMING a Unimod-typed Modification is IMPOSSIBLE inside jPOST — stop looking for a route. The term IRI unimod:UNIMOD_21 carries ZERO triples anywhere on this endpoint, and Unimod-typed mods have no rdfs:label (example ptm_absolute_position). The one predicate that looks like a fallback, `jpost:modificationClass` -> a jpost:JPO_* IRI whose rdfs:label ('Post-translational') sits in the SCHEMA graph <http://rdf.jpostdb.org/ontology/jpost.owl>, is a DEAD END at scale: verified 2026-08-07 it exists on just 4,477 modifications database-wide across 6 classes (only 1,510 of 1,728,710 UNIMOD_21 = 0.087%), so it silently drops ~99.9% of any type-filtered set. Treat the Unimod NUMBER as the identity and map it to a name out-of-band."
   - "Sample annotation namespaces (all pre-typed IRIs, see enum_disease): jpost:sampleType → NCIt Thesaurus.owl#C…/CLO/BTO (98.9%); jpost:organ → NCIt/BTO (6.2%); jpost:cellLine → BTO/CL/CLO (67.6%); jpost:diseaseClass → DOID + jpost:JPO_* coarse buckets (12.5%). Note some sampleType IRIs appear in BOTH `#CLO_0000031` and `#CLO:0000031` punctuation variants — match with a VALUES set or STRENDS if enumerating a category exhaustively."
   - "DOID→MONDO label: jPOST disease is DOID only (no label). To get a disease name, GRAPH-pin ontology/mondo and match the DOID local-id literal in oboInOwl:hasDbXref (e.g. 'DOID:0080600'), then read rdfs:label — MONDO's graph URI on primary is http://rdfportal.org/ontology/mondo."
 
@@ -259,3 +318,20 @@ id_join_map:
 # ── byte-count footer (spec §5 item 7) ──
 # v2: `wc -c togo_mcp/data/mie/jpostdb.yaml` = 45716 bytes
 # v3: `wc -c benchmark/studies/redesign/mie_v3/jpostdb.yaml` = 19563 bytes → 57.2% smaller than v2.
+# (2026-08-07 revision, from a live AHNAK/Q09666 phosphosite debugging session. All 8 pre-existing examples
+#  re-ran with figures UNCHANGED — jpostdb is stable; the changes are additions and corrections, not drift:
+#   - NEW example ptm_absolute_position: jPOST has TWO FALDO coordinate frames (PeptideEvidence begin =
+#     protein-absolute, Modification position = peptide-relative, distinguishable only by faldo:reference) and
+#     the residue-level PTM question needs both composed. The old schema_delta line stated the pieces but no
+#     example composed them, so the arithmetic had to be rediscovered; that line is now rewritten around the
+#     two-disjoint-populations fact the example does NOT show.
+#   - mod_frequency: the label trap had only the empty-string case. Measured the real split — 5,624,538 mods
+#     have NO rdfs:label PREDICATE (44.9%), 5,206,460 have "" (41.6%), 1,687,576 have a name (13.5%). FILTER
+#     fixes only the second; the first needs OPTIONAL. No Unimod-typed mod carries a label at all.
+#   - global_gotchas bnode_scaffolds (3): a nodeID:// from tool output is an execution-local display label —
+#     FILTER(?x = <nodeID://…>) silently matches nothing.
+#   - CORRECTED the 2g claim. The old "single-tenant, ZERO overlap" held only for jPOST-MINTED IRIs (still true,
+#     re-probed). The endpoint now also carries ~40 rdf.glycosmos.org/* graphs, and the HUB IRIs jPOST points at
+#     ARE re-declared: an unpinned rdfs:label on a jPOST-referenced UniProt IRI is x2 (212 rows for 106 entries).
+#     New gotcha hub_union_inflation + graphs.co_hosted split into jpost_own_iris_clean / hub_iris_ARE_redeclared.
+#   - entity_counts: samples_with_disease was 6, which was the distinct-DOID count, not the sample count (86).)

--- a/togo_mcp/data/mie/mogplus.yaml
+++ b/togo_mcp/data/mie/mogplus.yaml
@@ -264,6 +264,65 @@ examples:
       - "A variant with the consequence on N transcripts fans out to N annotation rows — COUNT(DISTINCT ?variant), not raw rows, for a variant-level total (116 distinct variants; row count is higher)."
       - "Removing the gene anchor to count missense genome-wide TIMES OUT / 503s (gotcha billion_triple_anchor). The SO-consequence route is a positive enumeration route, but it is only tractable when co-anchored."
 
+  - id: gene_symbol_impact
+    intent: resolve a GENE SYMBOL and read its VEP impact distribution — the diagnostic that makes an empty severity result interpretable
+    question: "Does the mouse gene Adam17 have any high- or moderate-impact variants in MoG+, and how severe are its variants overall?"
+    complexity: intermediate
+    sparql: |
+      PREFIX vep: <http://genome-variation.org/resource/vep#>
+      SELECT ?impact (COUNT(*) AS ?annotations)
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          ?ann vep:symbol "Adam17" ; vep:impact ?impact .    # symbol is a PLAIN STRING (MGI nomenclature)
+        }
+      }
+      GROUP BY ?impact
+      ORDER BY DESC(?annotations)
+    verified: {result_rows: 4, date: "2026-08-08", distribution: "MODIFIER 20464, LOW 205, MODERATE 54, HIGH 2"}
+    teaches: >
+      RUN THIS BEFORE filtering on severity. vep:impact is VEP's 4-level severity band (HIGH / MODERATE / LOW /
+      MODIFIER) and it is MASSIVELY skewed to MODIFIER (non-coding/regulatory): for Adam17, 20,464 MODIFIER vs 2 HIGH.
+      Asking for the distribution instead of pre-filtering distinguishes the three states a bare
+      `FILTER(?impact IN ("HIGH","MODERATE"))` collapses into one indistinguishable empty result: NO ROWS = the symbol
+      is not in VEP at all; rows with ONLY MODIFIER/LOW = the gene is present and simply has no severe variants (a real
+      answer, not a failure); HIGH/MODERATE present = proceed to the strain-level query. The annotation also carries
+      vep:gene (an ENSMUSG Ensembl IRI) alongside the symbol, so use vep:symbol to ENTER from a human gene name and
+      vep:gene / mogplus:overlaps_gene to anchor heavier queries.
+    traps_avoided:
+      - "vep:symbol is a FREE STRING (vep:symbol_source = \"MGI\"), not a controlled IRI — nothing validates it, so a symbol MoG+ has never heard of returns 0 rows exactly like a gene with no severe variants. Many MGI symbols are QTL / locus / phenotype names (Aod4, Asp3, Bdln3, Bwq5, Idd3, Obrq15, Mhdakta20…) that have NO transcript, so VEP never annotates them: of 189 symbols sampled from real failing traffic, 117 (62%) were absent from vep:symbol entirely. Confirm presence with this query before concluding a gene 'has no severe variants'."
+      - "Case matters: mouse symbols are Xxxx-cased (\"Adam17\"), not human ALL-CAPS (\"ADAM17\"). A human-style symbol silently returns 0 rows."
+
+  - id: symbol_severe_variants_by_strain
+    intent: which strains carry the HIGH/MODERATE variants of a gene named by symbol (the full symbol->severity->genotype route)
+    question: "Which mouse strains carry high- or moderate-impact Adam17 variants in the v3 cohort, and with what genotype?"
+    complexity: advanced
+    sparql: |
+      PREFIX vep:     <http://genome-variation.org/resource/vep#>
+      PREFIX vcf:     <http://genome-variation.org/resource/vcf#>
+      PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
+      PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT DISTINCT ?strainLabel ?v ?impact ?geno          # DISTINCT: VEP annotates once PER TRANSCRIPT
+      WHERE {
+        GRAPH <http://rdfportal.org/dataset/mogplus> {
+          ?ann vep:symbol "Adam17" ; vep:impact ?impact .
+          FILTER(?impact IN ("HIGH","MODERATE"))
+          ?v vep:has_consequence ?ann .
+          FILTER(STRSTARTS(STR(?v), "http://identifiers.org/mogplus/v3/"))   # MANDATORY release pin
+          ?v vcf:has_genotype_call ?gt .
+          ?gt med2rdf:sample ?strain ; vcf:genotype ?geno .
+          FILTER(?geno != "0/0")
+          ?strain rdfs:label ?strainLabel .
+        }
+      }
+      ORDER BY ?strainLabel ?v
+      LIMIT 10
+    verified: {result_rows: 10, date: "2026-08-08", totals: "26 distinct rows, 6 strains, 9 variants (v3)", first_row: "BFM | v3/12/GRCm39#21374190-T-C | MODERATE | 1/1"}
+    teaches: "The full route: annotation (vep:symbol + vep:impact) -> its variant via vep:has_consequence -> vcf:has_genotype_call -> GenotypeCall -> med2rdf:sample -> strain label. Filter impact on the ANNOTATION and pin the release on the VARIANT IRI. Lead with the symbol+impact pattern (a few dozen annotations) so the 600M-row genotype table is only ever touched through those few variants."
+    traps_avoided:
+      - "WITHOUT the release FILTER this merges the two DISJOINT cohorts: 548 rows / 21 variants unpinned vs 61 rows / 9 variants for v3 alone. The extra variants are v2.1's different strain panel, NOT extra evidence for the same mice (gotchas release_in_iri, disjoint_cohorts). Nothing signals the merge."
+      - "WITHOUT DISTINCT the same variant repeats once per annotated TRANSCRIPT (61 raw rows vs 26 distinct here — one Adam17 variant carries 5 transcript annotations, incl. NMD_transcript_variant alongside missense_variant). Never read the row count as a variant or strain count."
+      - "FILTER(?geno != \"0/0\") is nearly redundant and is NOT a way to find reference strains: the call list holds only strains with a RECORDED call, so a strain absent from the result is not necessarily homozygous-reference (gotcha in variant_genotypes). Absence != reference."
+
   - id: xdb_so_label
     intent: "cross-DB (intra-primary): VEP consequence SO IRI → Sequence Ontology human-readable label"
     question: "What are the human-readable consequence types (with SO labels) for MoG+ v3 variants in Xkr4?"
@@ -296,6 +355,7 @@ examples:
 schema_delta:
   - "gvo:SNV (131,856,375) and gvo:Variation (14,265,786, indels/MNVs) are DISJOINT and mutually exclusive — a variant is exactly one. For 'all variants' use FILTER(?t IN (gvo:SNV, gvo:Variation)); gvo:SNV alone omits 14M indels."
   - "VEP vs SnpEff are two INDEPENDENT annotation systems: vep:has_consequence → vep:ConsequenceAnnotation (279M; vep:gene / vep:feature ARE Ensembl IRIs, joinable) and snpeff:has_annotation → snpeff:Annotation (158M; snpeff:gene_id / snpeff:gene_name are STRINGS like \"CHR_START-ENSMUSG...\", NOT joinable to Ensembl). Both expose an SO-IRI field (vep:consequence / snpeff:normalized_consequence) + raw text."
+  - "Remaining fields on a vep:ConsequenceAnnotation beyond those the examples use: vep:allele (the ALT this row describes), vep:biotype (\"protein_coding\"…), vep:feature_type (\"Transcript\"), vep:strand (±1, xsd:integer), vep:symbol_source (\"MGI\"), vep:intron/exon (\"3/3\" rank strings), and rdfs:label + vep:consequence_label, which BOTH duplicate the SO term as display text — filter on the obo:SO_* IRI instead (enum_missense)."
   - "vcf:has_info_field carries ONLY a handful of keys per variant (LOF, NMD, rarely ReverseComplementedAlleles) — NOT the GATK QC metrics (AC/AF/AN/DP/MQ/QD/FS/SOR): those exist only as header definitions (vcf:InfoFieldDefinition, 39 rows), never attached per-variant. Liftover flags (SwappedAlleles/ReverseComplementedAlleles) are almost never populated, so REF/ALT-swap artifacts cannot be reliably detected from the RDF."
   - "VCF header definitions are per-release: vcf:InfoFieldDefinition (39) + vcf:FormatFieldDefinition (16) at IRI .../<release>/GRCm39/vcf/header/{info|format}/<KEY>; each has vcf:id, vcf:number, vcf:type, dct:description."
   - "mogbs:NA (bioresource/NA) is a POLYMORPHIC node collapsing ≥4 strains (KK/HiJ, NON/LtJ, QSi3, QSi5) under one label \"NA\"; dct:identifier is multi-valued on some strains (JF1_Ms, MSM_Ms). Use DISTINCT when counting strains by identifier, and do not treat mogbs:NA as one strain."
@@ -319,3 +379,18 @@ id_join_map:
 # ── byte-count footer (spec §5 item 7) ──
 # v2: `wc -c togo_mcp/data/mie/mogplus.yaml` = 53097 bytes
 # v3: `wc -c benchmark/studies/redesign/mie_v3/mogplus.yaml` = 24376 bytes → 54.1% smaller than v2.
+# (2026-08-08 revision, driven by production tool-call logs rather than a debugging session. 2,789 logged
+#  mogplus run_sparql calls: 777 (27.9%) returned ZERO rows, and every one of them entered through
+#  `vep:symbol` + `vep:impact` — two predicates this file did not mention even once. Added examples
+#  gene_symbol_impact + symbol_severe_variants_by_strain to cover that entry path.
+#  The 777 empties were deterministic per symbol (189 symbols always empty, 720 always non-empty, ZERO
+#  overlap) and split into two causes that a bare severity FILTER makes indistinguishable:
+#    A (532 queries / 117 symbols) the symbol is ABSENT from vep:symbol — mostly MGI QTL/locus names
+#      (Aod4, Idd3, Obrq15, Mhdakta20) that have no transcript, so VEP never annotates them;
+#    B (245 queries /  72 symbols) the symbol is PRESENT but has no HIGH/MODERATE variant — a correct
+#      answer, not a failure. Ebf1 carries 50,916 annotations, all MODIFIER/LOW.
+#  gene_symbol_impact returns the impact DISTRIBUTION so these three states are told apart in one query.
+#  Also found: the logged template never pinned the release, so even its ~2,000 NON-empty results silently
+#  merged the disjoint v3/v2.1 cohorts (548 rows/21 variants unpinned vs 61/9 for v3) and never used
+#  DISTINCT against per-transcript fan-out (61 raw vs 26 distinct) — both now traps on the new example.
+#  All 9 pre-existing examples re-verified UNCHANGED (enum_missense 116, count_gene_variants 4125).)

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
PATCH under the [agent-pragmatic policy](CLAUDE.md): **no tool, parameter, or return shape changed.** Entirely MIE content across three databases, plus one drift-guard test.

## What's in it

**glycosmos + jpostdb — the FALDO site-position route.** Both files carried the chain as `schema_delta` prose only, and two separate live sessions had to re-derive it, failing in two different ways. In glycosmos the rebuilt `PREFIX faldo:` lost its trailing `#`, resolving `faldo:location` into a namespace that exists nowhere — the query parses, runs, and returns **zero rows with no error** (116 with the `#`, 0 without). In jpostdb the trap is arithmetic: two coordinate frames (PeptideEvidence `faldo:begin` is protein-absolute, Modification `faldo:position` is peptide-relative) whose `ExactPosition` nodes are structurally identical and distinguishable only by `faldo:reference`. Both now ship as verified examples.

**glycosmos — real regressions.** Two examples had started returning zero rows: the `geneid` bridge moved from the `glycoprotein` graph to the `Rhea` graph, and `GO:0006486` was obsoleted upstream. Three `schema_delta` facts were false (site IRI pattern, location IRI pattern, both site figures). Saccharide inflation ×4.16 → ×1.52 after two `tmp/*` staging twins were dropped upstream. The go.owl divergence recorded in 2026-07 has been **repaired** upstream — kept as a dated observation rather than deleted.

**jpostdb — two half-truths corrected.** The `rdfs:label` warning covered empty-string labels (fixable with `FILTER`) but not the Unimod-typed population where the predicate is **absent entirely** (needs `OPTIONAL`; 44.9% of 12.5M modifications). And "single-tenant, ZERO overlap" held only for jPOST's own IRIs — the endpoint now carries ~40 glycosmos graphs, and the hub IRIs jPOST points at are ×2 re-declared.

**mogplus — `vep:symbol` / `vep:impact` documented for the first time.** This one came from the production tool-call log, read for *silent* failures rather than errors. 777 of 2,789 mogplus queries (27.9%) returned zero rows, every one entering through two predicates the file never mentioned. Deterministic per symbol (189 always empty, 720 always non-empty, zero overlap), splitting into two causes a bare severity filter cannot tell apart: symbol absent from VEP (532 queries — mostly MGI QTL names with no transcript), or present with no HIGH/MODERATE variant (245 queries — a correct answer; `Ebf1` has 50,916 annotations, all MODIFIER/LOW). Worse than the empties: the same template never pinned the release, so its ~2,000 **non-empty** results silently merged the disjoint v3/v2.1 cohorts, and lacked `DISTINCT` against per-transcript fan-out.

## Verification

- 35/35 examples across the three files re-run live and dated; `check_mie_examples.py` clean for each (0 zero-row, 0 error)
- All pre-existing example figures re-verified — jpostdb and mogplus reproduced unchanged; glycosmos had the drift listed above
- Cross-graph inflation (2g) re-probed on all three; `graphs.co_hosted` updated where it had gone stale
- No benchmark leakage (§4.6) for any new example subject
- Catalog regenerated (no diff — no `discovery` block changed); 400/400 tests pass

No `whatsnew:` marker: no new database or tool and no format change a user would notice, so the intro page should not advertise this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)