### PR TITLE
2.6.0 — ChEMBL targets are findable by the name the tool returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Fixed
+
+- **`search_chembl_target` can now find a target by the name it returns.** It could not: a target's name
+  lives on two different RDF nodes — the protein component's `skos:altLabel` (gene symbols, UniProt
+  recommended names) and the target's own `rdfs:label` — and only the first was searched, while the
+  second is what came back as `name`. So `search_chembl_target("aldehyde dehydrogenase")` returned an
+  empty array although CHEMBL3542434 is named exactly "Aldehyde dehydrogenase"; that target carries no
+  `skos:altLabel` at all, so component synonyms could never reach it, while `"ALDH2"` found it fine.
+  The match block is now a UNION over both, still exact and case-insensitive.
+- **4,894 ChEMBL targets were unreachable by any query at all.** The old WHERE clause required
+  `cco:hasTargetComponent` outside any UNION, and 2,383 ORGANISM, 1,997 CELL-LINE, 294 TISSUE,
+  62 NUCLEIC-ACID and others simply have no protein component — even though the `target_type` parameter
+  advertises CELL-LINE/TISSUE/ORGANISM as valid filter values, so those filters could never match
+  anything. The target-name leg of the UNION requires no component, so `search_chembl_target("CCRF-CEM")`
+  now resolves CHEMBL382 (CELL-LINE) instead of returning nothing.
+- **A single word now finds something.** When the exact pass finds nothing, one substring pass over
+  target names runs as a fallback, labelled `match_mode: "substring"` in the response so a caller knows
+  the results are looser and unranked. Exact-first is still the default and still the reason this module
+  resolves names over SPARQL rather than the EBI REST index (token-OR ranking buries the intended entity
+  — EGFR lands around rank 6 among orthologs and ligands); a pass that runs only on zero results and
+  ranks nothing reintroduces none of that. Breadth is bounded in practice: "dehydrogenase", about as
+  broad as a caller would plausibly type, matches 250 target labels, not thousands.
+- **An empty result now says it is not an outage.** A 0-result is not an error, so a caller could not
+  distinguish "no such target" from "the endpoint is down" — and on 2026-08-12 an empty target search was
+  in fact read as a connectivity failure, because the ebi endpoint really was down that day for unrelated
+  reasons. Empty responses now carry a `hint` that states plainly the query ran and returned nothing,
+  names any `organism`/`target_type` filter that may have removed a real match, and suggests the input
+  forms that resolve deterministically. `match_mode` is `"none"` when both passes came up empty.
+
+Additive only: `match_mode` and `hint` are new keys; no existing key changed meaning, and every input
+that worked before returns at least what it returned before.
+
+Checked and NOT changed: `search_chembl_molecule` shares the same synonym helper but is structurally
+immune — every *named* small molecule carries its own `rdfs:label` among its `skos:altLabel` values
+(verified: zero exceptions), so searching synonyms alone already reaches all of them. The other
+`search_*` wrappers (UniProt, PDB, Reactome, Rhea, MeSH) do not share this code path at all; they are
+REST wrappers over `_rest_get` and never touch SPARQL.
+
 ## [2.5.3] - 2026-08-12
 
 An availability release, written during a live RDF Portal outage and verified against it. Nothing about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-08-12
+
+<!-- whatsnew: 2026-08-12 | Target lookups in ChEMBL now find a target by its <strong>own name</strong> (<em>"aldehyde dehydrogenase"</em> used to return nothing at all), reach the 4,894 targets that have no protein component — cell lines such as <em>CCRF-CEM</em>, plus tissues and organisms — and fall back to a substring match when a single word like <em>"dehydrogenase"</em> finds no exact hit. -->
+
+MINOR rather than PATCH: nothing was removed or renamed and no existing key changed meaning, but two
+response keys are new (`match_mode`, `hint`) and the tool answers queries it used to answer with an
+empty array — a widening of what the tool accepts, which is where the agent-pragmatic policy files
+additive change.
+
 ### Fixed
 
 - **`search_chembl_target` can now find a target by the name it returns.** It could not: a target's name
@@ -1225,7 +1234,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.5.3...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.6.0...HEAD
+[2.6.0]: https://github.com/dbcls/togomcp/compare/v2.5.3...v2.6.0
 [2.5.3]: https://github.com/dbcls/togomcp/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/dbcls/togomcp/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/dbcls/togomcp/compare/v2.5.0...v2.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.5.3"
+version = "2.6.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_chembl.py
+++ b/tests/test_chembl.py
@@ -289,6 +289,151 @@ class TestSearchChemblTarget:
         assert result["results"][0]["chembl_id"] == "CHEMBL203"
 
     @pytest.mark.asyncio
+    async def test_a_target_is_findable_by_its_own_name(self) -> None:
+        """The `name` this tool RETURNS must also be a name it can SEARCH.
+
+        It was not. A target's name lives on two different nodes — the protein
+        component's skos:altLabel, and the target's own rdfs:label — and only the
+        first was searched, while the second is what came back as `name`.
+        Verified live 2026-08-12: CHEMBL3542434 is named "Aldehyde dehydrogenase",
+        carries NO skos:altLabel of its own, and searching that exact string
+        returned 0 rows while "ALDH2" returned it fine.
+        """
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,name,organism,type",
+                        "CHEMBL3542434,Aldehyde dehydrogenase,Homo sapiens,PROTEIN FAMILY",
+                    ),
+                )
+            )
+            result = await search_chembl_target("Aldehyde dehydrogenase")
+        sent = _sent_query(route)
+        assert "UNION" in sent
+        assert "?target rdfs:label ?tlabel" in sent
+        assert 'FILTER(LCASE(STR(?tlabel)) = "aldehyde dehydrogenase")' in sent
+        assert result["results"][0]["chembl_id"] == "CHEMBL3542434"
+        assert result["match_mode"] == "exact"
+        assert len(route.calls) == 1  # an exact hit must not trigger the fallback
+
+    @pytest.mark.asyncio
+    async def test_targets_without_a_protein_component_are_reachable(self) -> None:
+        """4,894 targets have no cco:hasTargetComponent at all (measured
+        2026-08-12): 2,383 ORGANISM, 1,997 CELL-LINE, 294 TISSUE, and more. The
+        old WHERE clause required that predicate outside any UNION, so every one
+        of them was unreachable by ANY query — while `target_type` went on
+        advertising CELL-LINE/TISSUE/ORGANISM as filter values.
+        """
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,name,organism,type",
+                        "CHEMBL382,CCRF-CEM,Homo sapiens,CELL-LINE",
+                    ),
+                )
+            )
+            result = await search_chembl_target("CCRF-CEM")
+        sent = _sent_query(route)
+        head, _, tail = sent.partition("} UNION {")
+        assert "hasTargetComponent" in head, "the synonym leg still needs a component"
+        assert "hasTargetComponent" not in tail, (
+            "the target-name leg must NOT require a component, or component-less "
+            "targets (CELL-LINE, ORGANISM, TISSUE) stay invisible"
+        )
+        assert result["results"][0]["type"] == "CELL-LINE"
+
+    @pytest.mark.asyncio
+    async def test_zero_exact_matches_fall_back_to_substring(self) -> None:
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                side_effect=[
+                    httpx.Response(200, text=_csv("chembl_id,name,organism,type")),
+                    httpx.Response(
+                        200,
+                        text=_csv(
+                            "chembl_id,name,organism,type",
+                            "CHEMBL2931,Aldehyde dehydrogenase 1A1,Homo sapiens,SINGLE PROTEIN",
+                        ),
+                    ),
+                ]
+            )
+            result = await search_chembl_target("dehydrogenase")
+        assert len(route.calls) == 2
+        import urllib.parse
+
+        second = urllib.parse.parse_qs(
+            route.calls[1].request.content.decode()
+        )["query"][0]
+        assert 'CONTAINS(LCASE(STR(?tlabel)), "dehydrogenase")' in second
+        assert result["match_mode"] == "substring"
+        assert result["results"][0]["chembl_id"] == "CHEMBL2931"
+
+    @pytest.mark.asyncio
+    async def test_zero_results_say_they_are_not_an_endpoint_failure(self) -> None:
+        """An empty result is not an error, so a caller cannot tell it from an
+        outage — and on 2026-08-12 one was in fact read as an endpoint problem,
+        because the ebi endpoint really was down that day for unrelated reasons.
+        """
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name,organism,type")
+                )
+            )
+            result = await search_chembl_target("zzzznotarget")
+        assert result["total_count"] == 0
+        assert result["match_mode"] == "none"
+        assert "NOT AN ENDPOINT FAILURE" in result["hint"]
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_zero_result_hint_names_filters_that_could_have_caused_it(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name,organism,type")
+                )
+            )
+            result = await search_chembl_target("EGFR", organism="Homo sapines")
+        assert "Homo sapines" in result["hint"]
+        assert "retry without them" in result["hint"]
+
+    @pytest.mark.asyncio
+    async def test_accession_never_falls_back_to_substring(self) -> None:
+        """An accession either links via skos:exactMatch or it does not; a text
+        pass on the raw string would only invent noise."""
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,name,organism,type")
+                )
+            )
+            result = await search_chembl_target("P00533")
+        assert len(route.calls) == 1
+        assert result["match_mode"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_a_failing_fallback_does_not_mask_a_clean_zero(self) -> None:
+        """The first pass succeeded and legitimately found nothing. Turning that
+        into an 'error' because the optional second pass broke would report an
+        outage that did not happen — the exact confusion this work removes."""
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                side_effect=[
+                    httpx.Response(200, text=_csv("chembl_id,name,organism,type")),
+                    httpx.Response(500, text="boom"),
+                ]
+            )
+            result = await search_chembl_target("nothing here")
+        assert "error" not in result
+        assert result["total_count"] == 0
+        assert "hint" in result
+
+    @pytest.mark.asyncio
     async def test_empty_organism_cell_becomes_none(self) -> None:
         with respx.mock(using="httpx") as router:
             router.post(CHEMBL_SPARQL_URL).mock(

--- a/togo_mcp/chembl.py
+++ b/togo_mcp/chembl.py
@@ -147,6 +147,111 @@ def _altlabel_match_block(query: str) -> str | None:
     )
 
 
+def _target_exact_match_block(query: str) -> str | None:
+    """WHERE fragment binding ?target by exact (case-insensitive) name.
+
+    A target's name lives in TWO places, on two different nodes, and searching
+    only the first is why `search_chembl_target("aldehyde dehydrogenase")`
+    returned nothing while CHEMBL3542434 is literally named "Aldehyde
+    dehydrogenase" (verified live 2026-08-12):
+
+    * ``?comp skos:altLabel`` — synonyms of the target's protein COMPONENT
+      (gene symbols, UniProt recommended names). The only leg that used to exist.
+    * ``?target rdfs:label`` — the target's OWN name, i.e. the exact string this
+      tool returns as `name`. CHEMBL3542434 carries no skos:altLabel at all, so
+      component synonyms could never reach it.
+
+    The second leg also un-hides the 4,894 targets with no protein component at
+    all (2,383 ORGANISM, 1,997 CELL-LINE, 294 TISSUE, …). Those were unreachable
+    by ANY query, even though `target_type` advertises CELL-LINE/TISSUE/ORGANISM
+    as filter values — the old WHERE clause required cco:hasTargetComponent.
+
+    Returns None when the query has no searchable token.
+    """
+    bif = _bif_and(query)
+    if bif is None:
+        return None
+    q = _sparql_literal(query.lower())
+    return (
+        "  {\n"
+        "    ?comp skos:altLabel ?alt .\n"
+        f'    ?alt bif:contains "{bif}" .\n'
+        f'    FILTER(LCASE(STR(?alt)) = "{q}")\n'
+        "    ?target cco:hasTargetComponent ?comp .\n"
+        "  } UNION {\n"
+        "    ?target rdfs:label ?tlabel .\n"
+        f'    ?tlabel bif:contains "{bif}" .\n'
+        f'    FILTER(LCASE(STR(?tlabel)) = "{q}")\n'
+        "  }"
+    )
+
+
+def _target_substring_match_block(query: str) -> str | None:
+    """WHERE fragment binding ?target whose OWN name CONTAINS ``query``.
+
+    Second pass only, and only when the exact pass found nothing. Exact-first is
+    still the right default — the reason this module resolves names over SPARQL
+    rather than the EBI REST index is that token-OR ranking buries the intended
+    entity (EGFR lands at rank ~6 among orthologs and ligands). A substring pass
+    that runs ONLY on zero results, returns everything it finds unranked, and
+    labels itself `match_mode: "substring"` reintroduces none of that: there is
+    no ranking for the caller to second-guess, and nothing displaces an exact hit
+    that never existed.
+
+    Breadth is bounded in practice — 'dehydrogenase', one of the broadest tokens
+    a caller would plausibly type, matches 250 target labels (measured
+    2026-08-12, 0.35s), not thousands. bif:contains does the index work; the
+    FILTER makes it a real substring rather than a token bag.
+    """
+    bif = _bif_and(query)
+    if bif is None:
+        return None
+    q = _sparql_literal(query.lower())
+    return (
+        "  ?target rdfs:label ?tlabel .\n"
+        f'  ?tlabel bif:contains "{bif}" .\n'
+        f'  FILTER(CONTAINS(LCASE(STR(?tlabel)), "{q}"))'
+    )
+
+
+def _target_sparql(match_block: str, filters: str, limit: int) -> str:
+    """Assemble a target query around a ?target-binding match block."""
+    return (
+        f"{_CHEMBL_PREFIXES}\n"
+        f"SELECT DISTINCT ?chembl_id ?name ?organism ?type "
+        f"FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
+        f"{match_block}\n"
+        f"  ?target cco:chemblId ?chembl_id ; rdfs:label ?name ; cco:targetType ?type .\n"
+        f"  OPTIONAL {{ ?target cco:organismName ?organism . }}{filters}\n"
+        f"}} LIMIT {int(limit) + 1}"
+    )
+
+
+def _target_zero_hint(query: str, *, organism: str, target_type: str) -> str:
+    """Why a target search came back empty — and that it is not an outage.
+
+    A 0-result is not an error, so a caller cannot tell it from a connectivity
+    failure. That confusion is not hypothetical: on 2026-08-12 an empty target
+    search was read as an endpoint problem, because the ebi endpoint really was
+    down that day for unrelated reasons.
+    """
+    narrowed = [f"{k}={v!r}" for k, v in (("organism", organism), ("target_type", target_type)) if v]
+    filter_note = (
+        f" NOTE: you also passed {' and '.join(narrowed)} — a match may exist that "
+        "those filters removed; retry without them to find out."
+        if narrowed
+        else ""
+    )
+    return (
+        f"No ChEMBL target matched {query!r} — not by exact name or synonym, and not "
+        "by substring of a target name. THIS IS NOT AN ENDPOINT FAILURE: the query "
+        f"ran and returned nothing.{filter_note} Matching is literal, never fuzzy, so "
+        "check spelling first. Then try a UniProt accession ('P00533'), a gene symbol "
+        "('ALDH2'), or the full official name ('Aldehyde dehydrogenase, mitochondrial') "
+        "— any of which resolves deterministically."
+    )
+
+
 def _containment_match_block(query: str) -> str | None:
     """WHERE-clause fragment matching ``?alt`` synonyms CONTAINED IN ``query``.
 
@@ -642,8 +747,10 @@ async def search_chembl_target(
         complex/family/chimera it participates in) — filter `target_type` to get
         just one.
       • GENE SYMBOL / PROTEIN NAME (e.g. "EGFR", "epidermal growth factor
-        receptor") → EXACT (case-insensitive) match on the target component's
-        skos:altLabel synonyms. Not fuzzy/substring — fix typos before calling.
+        receptor") → EXACT (case-insensitive) match, tried against BOTH the
+        target's own name and its protein component's skos:altLabel synonyms.
+      • If that finds nothing, ONE substring pass over target names runs as a
+        fallback (e.g. "dehydrogenase"). Still never fuzzy — fix typos.
 
     Every result carries `organism` and `type`, so a symbol shared across species
     or complexes is disambiguated by inspecting those fields (or by passing the
@@ -658,12 +765,18 @@ async def search_chembl_target(
     The search string can be passed as any of: `query` (canonical), `search`,
     `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
-    RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is rows
-    RETURNED (capped by `limit`), not the full match count; `has_more` is true if
-    more exist beyond this page. Each result has 'chembl_id', 'name' (rdfs:label),
-    'organism', and 'type'. On endpoint failure this tool does NOT raise — it
-    returns a dict with a single 'error' key instead; CHECK FOR 'error' BEFORE
-    READING 'results'.
+    RETURNS a dict {'total_count', 'has_more', 'results', 'match_mode'}.
+    `total_count` is rows RETURNED (capped by `limit`), not the full match count;
+    `has_more` is true if more exist beyond this page. Each result has
+    'chembl_id', 'name' (rdfs:label), 'organism', and 'type'. `match_mode` is
+    'exact', 'substring', or 'none' — 'substring' means the exact pass found
+    nothing and these are looser, UNRANKED matches, so verify 'name' before using
+    them; 'none' means both passes ran and neither matched.
+
+    An EMPTY 'results' additionally carries 'hint'. Read it: an empty result is
+    NOT an endpoint failure, and must not be reported as one. On a real endpoint
+    failure this tool does NOT raise — it returns a dict with a single 'error'
+    key instead; CHECK FOR 'error' BEFORE READING 'results'.
 
     Args:
         query (str): UniProt accession (preferred), gene symbol, or exact protein
@@ -695,19 +808,6 @@ async def search_chembl_target(
             f"target-type vocabulary: {', '.join(sorted(_CHEMBL_TARGET_TYPES))}. "
             "(An unrecognized value would otherwise silently match nothing.)"
         )
-    # Route: UniProt accession → structured skos:exactMatch; else exact altLabel.
-    acc = query.strip().upper()
-    if _UNIPROT_ACCESSION_RE.match(acc):
-        match_block = (
-            f"  ?comp skos:exactMatch "
-            f"<http://purl.uniprot.org/uniprot/{acc}> ."
-        )
-    else:
-        alt = _altlabel_match_block(query)
-        if alt is None:
-            return {"total_count": 0, "has_more": False, "results": []}
-        match_block = f"  ?comp skos:altLabel ?alt .\n{alt}"
-
     filters = ""
     if organism.strip():
         filters += (
@@ -719,19 +819,43 @@ async def search_chembl_target(
             f'\n  FILTER(LCASE(STR(?type)) = '
             f'"{_sparql_literal(target_type.strip().lower())}")'
         )
-    sparql = (
-        f"{_CHEMBL_PREFIXES}\n"
-        f"SELECT DISTINCT ?chembl_id ?name ?organism ?type "
-        f"FROM <{_CHEMBL_GRAPH}> WHERE {{\n"
-        f"{match_block}\n"
-        f"  ?target cco:hasTargetComponent ?comp ;\n"
-        f"          cco:chemblId ?chembl_id ; rdfs:label ?name ; cco:targetType ?type .\n"
-        f"  OPTIONAL {{ ?target cco:organismName ?organism . }}{filters}\n"
-        f"}} LIMIT {int(limit) + 1}"
-    )
-    rows = await _run_chembl_sparql(sparql)
+    # Route: UniProt accession → structured skos:exactMatch (no text search, and
+    # no substring fallback — an accession either links or it does not).
+    acc = query.strip().upper()
+    is_accession = bool(_UNIPROT_ACCESSION_RE.match(acc))
+    if is_accession:
+        match_block: str | None = (
+            f"  ?comp skos:exactMatch <http://purl.uniprot.org/uniprot/{acc}> .\n"
+            f"  ?target cco:hasTargetComponent ?comp ."
+        )
+    else:
+        match_block = _target_exact_match_block(query)
+    if match_block is None:
+        return {
+            "total_count": 0,
+            "has_more": False,
+            "results": [],
+            "match_mode": "exact",
+            "hint": _target_zero_hint(query, organism=organism, target_type=target_type),
+        }
+
+    rows = await _run_chembl_sparql(_target_sparql(match_block, filters, int(limit)))
     if isinstance(rows, dict):
         return rows  # {"error": ...}
+
+    match_mode = "exact"
+    if not rows and not is_accession:
+        fallback = _target_substring_match_block(query)
+        if fallback is not None:
+            fb_rows = await _run_chembl_sparql(
+                _target_sparql(fallback, filters, int(limit))
+            )
+            # A failing fallback must not turn a clean "0 exact matches" into an
+            # error: the first pass already succeeded, and its emptiness is the
+            # real answer.
+            if not isinstance(fb_rows, dict) and fb_rows:
+                rows, match_mode = fb_rows, "substring"
+
     rows, has_more = _paginate(rows, int(limit))
     parsed_results = [
         {
@@ -742,11 +866,20 @@ async def search_chembl_target(
         }
         for r in rows
     ]
-    return {
+    out = {
         "total_count": len(parsed_results),
         "has_more": has_more,
         "results": parsed_results,
+        "match_mode": match_mode,
     }
+    if not parsed_results:
+        # Both passes ran and both found nothing; reporting "exact" here would
+        # imply a looser pass was still available to try.
+        out["match_mode"] = "none"
+        out["hint"] = _target_zero_hint(
+            query, organism=organism, target_type=target_type
+        )
+    return out
 
 
 async def _extract_chembl_molecules(query: str, limit: int) -> dict:

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -768,6 +768,10 @@
     <ul class="whatsnew-list">
       <!-- WHATSNEW:START -->
       <li>
+        <span class="whatsnew-date">2026-08-12</span>
+        <span>Target lookups in ChEMBL now find a target by its <strong>own name</strong> (<em>"aldehyde dehydrogenase"</em> used to return nothing at all), reach the 4,894 targets that have no protein component — cell lines such as <em>CCRF-CEM</em>, plus tissues and organisms — and fall back to a substring match when a single word like <em>"dehydrogenase"</em> finds no exact hit.</span>
+      </li>
+      <li>
         <span class="whatsnew-date">2026-08-01</span>
         <span><strong>ChatGPT users: refresh your connector.</strong> ChatGPT records TogoMCP's tool list when the connector is added and never refetches it, so tools added since then are invisible to it — re-run <em>Scan Tools</em>, or remove and re-add the connector. New databases are unaffected; those arrive through the live usage guide.</span>
       </li>
@@ -782,10 +786,6 @@
       <li>
         <span class="whatsnew-date">2026-07-29</span>
         <span>All tools now declare themselves <strong>read-only</strong> in the MCP protocol, so clients such as ChatGPT no longer treat every query as a write action needing confirmation.</span>
-      </li>
-      <li>
-        <span class="whatsnew-date">2026-07-24</span>
-        <span>The database knowledge files (MIE) were rewritten to a leaner format — about half the size, with faster and more reliable query construction. The three database-discovery tools (<code>list_databases</code>, <code>find_databases</code>, <code>list_categories</code>) were consolidated into the built-in Usage Guide, which now carries a catalog of all 36 databases.</span>
       </li>
       <!-- WHATSNEW:END -->
     </ul>

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.5.3"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
From a black-box bug report; the diagnosis was verified against the source and against the live `ebi` endpoint, which turned up a second, larger problem.

## The reported bug

```
search_chembl_target("aldehyde dehydrogenase")  →  {"total_count":0, "results":[]}
search_chembl_target("ALDH2")                   →  3 results, one of them:
   CHEMBL3542434   "Aldehyde dehydrogenase"   Homo sapiens   PROTEIN FAMILY
```

**CHEMBL3542434's `name` is literally "Aldehyde dehydrogenase", and that string found nothing.**

The cause is that a target's name lives on **two different RDF nodes**, and only one was searched:

```sparql
?comp skos:altLabel ?alt .              ← searched (the protein COMPONENT)
FILTER(LCASE(STR(?alt)) = "…")          ← exact; bif:contains is only a prefilter
?target cco:hasTargetComponent ?comp ;
        rdfs:label ?name .              ← RETURNED as `name` (the TARGET — never searched)
```

Confirmed live: CHEMBL3542434 carries **no `skos:altLabel` at all** — only `rdfs:label` and `targetType` — so component synonyms could never reach it, while `ALDH2` (a synonym on its component) found it fine. That accounts for every one of the six reported observations, including why `dehydrogenase` matched nothing (the equality FILTER kills what the `bif:contains` prefilter admits).

## The larger problem found while verifying

`cco:hasTargetComponent` was required **outside any UNION**, so targets with no protein component were unreachable by *any* query:

| target type | count |
|---|---|
| ORGANISM | 2,383 |
| CELL-LINE | 1,997 |
| TISSUE | 294 |
| NUCLEIC-ACID | 62 |
| others | 158 |
| **total** | **4,894** |

Meanwhile the `target_type` parameter advertised CELL-LINE / TISSUE / ORGANISM as valid filter values — filters that could never match anything.

## The fix

- **UNION over both name locations**, still exact and case-insensitive. The target-name leg requires no component, which un-hides all 4,894.
- **One substring pass as a fallback**, only when the exact pass returns nothing, labelled `match_mode: "substring"` so the caller knows the rows are looser and unranked. Exact-first remains the default — the reason this module resolves names over SPARQL rather than the EBI REST index is that token-OR ranking buries the intended entity (EGFR lands around rank 6 among orthologs and ligands), and a pass that runs only on zero results and ranks nothing reintroduces none of that. Bounded in practice: `dehydrogenase`, about as broad as a caller would plausibly type, matches **250** target labels, not thousands.
- **`hint` on an empty result**, stating plainly that the query ran and returned nothing and that this is **not** an endpoint failure — the confusion that prompted the report, since `ebi` genuinely was down that day for unrelated reasons. It also names any `organism`/`target_type` filter that may have removed a real match. `match_mode` is `"none"` when both passes came up empty.

## Regression table, run live

| query | n | match_mode |
|---|---|---|
| `ALDH2` / `aldh2` | 3 / 3 (identical) | exact |
| `Aldehyde dehydrogenase, mitochondrial` | 3 | exact |
| **`Aldehyde dehydrogenase`** | **1 — CHEMBL3542434** | exact |
| **`aldehyde dehydrogenase`** | **1 — same** | exact |
| **`dehydrogenase`** | **5 (limit honored)** | substring |
| `zzzznotarget` | 0 + `hint` | none |
| `P00533` / `EGFR` | 5 / 5 | exact |
| **`CCRF-CEM`** (CELL-LINE) | **1 — CHEMBL382** | exact |

7 new unit tests; **416 pass**.

## Checked and deliberately not changed

- **`search_chembl_molecule`** shares the same synonym helper but is structurally immune: every *named* small molecule carries its own `rdfs:label` among its `skos:altLabel` values — **zero exceptions**. (A raw count returns 1,795,632 "misses", but all of them are unnamed compounds whose label is just the ChEMBL ID.)
- **The other `search_*` wrappers** (UniProt, PDB, Reactome, Rhea, MeSH) do not share this code path at all — they are REST wrappers over `_rest_get` and never touch SPARQL.

## Release notes

- **MINOR**: `match_mode` and `hint` are new keys, no existing key changed meaning, and every input that worked before returns at least what it returned before.
- Carries a whatsnew marker (precedent: the 2026-07-30 ChEMBL biologics entry); intro page regenerated.

After merge, tag the merge commit: `git tag v2.6.0 <merge-sha> && git push origin v2.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)