### PR TITLE
2.7.0 — the other half of the ChEMBL name bug, and a gateway 5xx that stops blaming your query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Fixed
+
+- **`search_chembl_id_lookup` carried the same target-name bug, and now does not.** Its TARGET branch
+  searched only the protein component's `skos:altLabel` while returning the target's own `rdfs:label` as
+  `name`, so `"Aldehyde dehydrogenase"` returned 0 rows there even after 2.6.0 had made
+  `search_chembl_target` return CHEMBL3542434 for it — two tools disagreeing about the same question.
+  The branch is now an inner UNION over both name locations, with `cco:hasTargetComponent` confined to
+  the synonym leg, so component-less targets are reachable too: `entity_type="TARGET"` on `"CCRF-CEM"`
+  went from 0 rows to CHEMBL382. `cco:targetType` was added to that branch as a guard — without it the
+  new leg would match any labelled entity and stamp it `entity_type="TARGET"`. Worth knowing when
+  reading results: a cell line exists **twice** under different IDs, as a `cco:CellLine` entity
+  (CHEMBL3307641) and as a CELL-LINE *target* (CHEMBL382); finding one is not finding the other.
+- **`search_chembl_id_lookup` empty results now carry a `hint`**, on the same reasoning as 2.6.0's: a
+  0-result is not an error and was indistinguishable from an outage. This tool stays exact on purpose —
+  a predictable cross-entity front door is worth more than a clever one — so instead of a substring
+  fallback the hint names the tools that do fall back (`search_chembl_target`,
+  `search_chembl_molecule(mode='extract')`), and flags a narrowing `entity_type` when one was passed.
+- **A gateway 5xx no longer tells the agent its query is too heavy.** 502/503/504 come from a reverse
+  proxy, not from Virtuoso, so the SPARQL engine may never have seen the query — advising "add LIMIT" is
+  then actively wrong. Observed 2026-08-12 on the ebi endpoint, where `ASK {}` and a one-IRI lookup
+  502'd identically in ~0.1s seconds after the same queries had succeeded. The status code alone cannot
+  say whether the backend is down or just dropped one request, so the liveness probe added in 2.5.3 is
+  now used to ask: probe fails → the endpoint-down message and the circuit breaker, exactly as for a
+  timeout; probe passes → a message saying the endpoint is up, this failure is specific to this request,
+  and the right first move is to **retry once unchanged** rather than rewrite. A plain 500 is Virtuoso's
+  own and is untouched — it keeps the query-weight advice and spends no probe. Logged as
+  `sparql_status: "http_gateway"` (classified `server_error`, so it stays out of the MIE-trap counts).
+
+Also documented, not changed: on a default cross-kind `search_chembl_id_lookup`, `has_more=true` can
+mean an entire `entity_type` is missing from the page — the kinds are UNIONed and the limit applies to
+the whole, so "Liver" at `limit=5` returns 5 TARGET rows and no TISSUE row although both exist. The
+docstring now says so explicitly, since "no tissue named Liver" is exactly the kind of false conclusion
+this release is about.
+
 ## [2.6.0] - 2026-08-12
 
 <!-- whatsnew: 2026-08-12 | Target lookups in ChEMBL now find a target by its <strong>own name</strong> (<em>"aldehyde dehydrogenase"</em> used to return nothing at all), reach the 4,894 targets that have no protein component — cell lines such as <em>CCRF-CEM</em>, plus tissues and organisms — and fall back to a substring match when a single word like <em>"dehydrogenase"</em> finds no exact hit. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-12
+
+The other half of 2.6.0, plus the failure mode that made the original bug hard to read. Deliberately no
+`whatsnew` marker: 2.6.0's entry already tells a user that ChEMBL target lookups now find targets by
+their own name, and they do not know or care which of the two tools they went through — a second
+near-identical line would push a genuinely distinct item off the five-item list for no benefit.
+
 ### Fixed
 
 - **`search_chembl_id_lookup` carried the same target-name bug, and now does not.** Its TARGET branch
@@ -1268,7 +1275,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/dbcls/togomcp/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/dbcls/togomcp/compare/v2.5.3...v2.6.0
 [2.5.3]: https://github.com/dbcls/togomcp/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/dbcls/togomcp/compare/v2.5.1...v2.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.6.0"
+version = "2.7.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_chembl.py
+++ b/tests/test_chembl.py
@@ -476,7 +476,11 @@ class TestSearchChemblIdLookup:
             )
             result = await search_chembl_id_lookup("EGFR")
         sent = _sent_query(route)
-        assert sent.count("UNION") == 3  # 4 branches
+        # Four branches are joined by three top-level UNIONs. Count those rather
+        # than every "UNION" token: the TARGET branch now contains one of its own
+        # (a target's name lives on two nodes), so a bare count says 4.
+        assert sent.count("\n  UNION\n") == 3, "four name kinds, three joins"
+        assert sent.count("UNION") == 4, "…plus the TARGET branch's inner UNION"
         for frag in ("cco:SmallMolecule", "cco:hasTargetComponent", "cco:CellLine",
                      "cco:Tissue"):
             assert frag in sent
@@ -484,6 +488,81 @@ class TestSearchChemblIdLookup:
         assert "cco:organismName" in sent  # organism carried for disambiguation
         assert result["results"][0]["entity_type"] == "TARGET"
         assert result["results"][0]["organism"] == "Homo sapiens"
+
+    @pytest.mark.asyncio
+    async def test_target_branch_searches_the_target_own_name_too(self) -> None:
+        """The TARGET branch carried the same two-node bug as search_chembl_target.
+
+        Verified live 2026-08-12 BEFORE the fix: id_lookup("Aldehyde
+        dehydrogenase") returned 0 (both default and entity_type="TARGET") while
+        "ALDH2" returned 3 — and by then search_chembl_target already returned 1,
+        so the two tools disagreed about the same question.
+        """
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200,
+                    text=_csv(
+                        "chembl_id,entity_type,name,organism",
+                        "CHEMBL3542434,TARGET,Aldehyde dehydrogenase,Homo sapiens",
+                    ),
+                )
+            )
+            result = await search_chembl_id_lookup(
+                "Aldehyde dehydrogenase", entity_type="TARGET"
+            )
+        sent = _sent_query(route)
+        assert "?e rdfs:label ?tlabel" in sent
+        assert 'FILTER(LCASE(STR(?tlabel)) = "aldehyde dehydrogenase")' in sent
+        # cco:targetType is what makes ?e a target; without it the second leg
+        # would match ANY labelled entity and stamp it entity_type="TARGET".
+        assert "?e cco:targetType ?target_type" in sent
+        assert result["results"][0]["chembl_id"] == "CHEMBL3542434"
+
+    @pytest.mark.asyncio
+    async def test_target_branch_does_not_require_a_protein_component(self) -> None:
+        """4,894 targets have none (ORGANISM, CELL-LINE, TISSUE, …). A cell line
+        also exists TWICE under different IDs — CCRF-CEM is CHEMBL3307641 as a
+        cco:CellLine and CHEMBL382 as a CELL-LINE target — so the CELL_LINE
+        branch finding one does not mean the TARGET branch found the other.
+        """
+        with respx.mock(using="httpx") as router:
+            route = router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,entity_type,name,organism")
+                )
+            )
+            await search_chembl_id_lookup("CCRF-CEM", entity_type="TARGET")
+        sent = _sent_query(route)
+        _, _, second_leg = sent.partition("} UNION {")
+        assert second_leg, "the TARGET branch must offer a component-free leg"
+        assert "hasTargetComponent" not in second_leg
+
+    @pytest.mark.asyncio
+    async def test_zero_results_say_they_are_not_an_endpoint_failure(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,entity_type,name,organism")
+                )
+            )
+            result = await search_chembl_id_lookup("zzzznotarget")
+        assert result["total_count"] == 0
+        assert "NOT AN ENDPOINT FAILURE" in result["hint"]
+        # This tool stays exact on purpose; the hint names the way out.
+        assert "search_chembl_target" in result["hint"]
+
+    @pytest.mark.asyncio
+    async def test_zero_result_hint_flags_a_narrowing_entity_type(self) -> None:
+        with respx.mock(using="httpx") as router:
+            router.post(CHEMBL_SPARQL_URL).mock(
+                return_value=httpx.Response(
+                    200, text=_csv("chembl_id,entity_type,name,organism")
+                )
+            )
+            result = await search_chembl_id_lookup("aspirin", entity_type="TARGET")
+        assert "'TARGET'" in result["hint"]
+        assert "omit it" in result["hint"]
 
     @pytest.mark.asyncio
     async def test_compound_organism_is_null(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -754,6 +754,96 @@ class TestEndpointLiveness:
         assert "s,p,o" in out
         assert srv._endpoint_down_remaining(url) is None
 
+    @pytest.mark.asyncio
+    async def test_gateway_5xx_with_a_dead_endpoint_reports_the_outage(self, monkeypatch) -> None:
+        """nginx answering 502 in ~0.1s is infrastructure, not a heavy query.
+
+        Observed 2026-08-12 on the ebi endpoint: `ASK {}` and a one-IRI lookup
+        502'd identically, seconds after the same queries had succeeded. The
+        generic 5xx advice ("the query may be too heavy — add LIMIT") is wrong
+        there: the SPARQL engine never saw the query.
+        """
+        from togo_mcp import server as srv
+
+        srv._endpoint_down_until.clear()
+
+        async def _bad_gateway(*a, **k):
+            return httpx.Response(
+                502,
+                text="<html><head><title>502 Bad Gateway</title></head></html>",
+                request=httpx.Request("POST", "https://rdfportal.org/ebi/sparql"),
+            )
+
+        async def _probe_dead(url):
+            return False
+
+        monkeypatch.setattr(srv._sparql_client, "post", _bad_gateway)
+        monkeypatch.setattr(srv, "_probe_endpoint", _probe_dead)
+        with pytest.raises(ValueError) as ei:
+            await srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="chembl")
+        msg = str(ei.value)
+        assert "502" in msg
+        assert "THE PROBLEM IS NOT YOUR QUERY" in msg
+        assert "TOO HEAVY" not in msg
+        assert srv._endpoint_down_remaining(srv.SPARQL_ENDPOINT["chembl"]["url"]) is not None
+
+    @pytest.mark.asyncio
+    async def test_gateway_5xx_with_a_live_endpoint_says_retry_once_first(self, monkeypatch) -> None:
+        """A one-off 502 from a healthy endpoint deserves a retry, not a rewrite.
+
+        The breaker must stay CLOSED here: shutting off an endpoint that answers
+        fine would turn one bad request into a 60s outage of our own making.
+        """
+        from togo_mcp import server as srv
+
+        srv._endpoint_down_until.clear()
+
+        async def _bad_gateway(*a, **k):
+            return httpx.Response(
+                503, text="<html>503</html>",
+                request=httpx.Request("POST", "https://rdfportal.org/ebi/sparql"),
+            )
+
+        async def _probe_alive(url):
+            return True
+
+        monkeypatch.setattr(srv._sparql_client, "post", _bad_gateway)
+        monkeypatch.setattr(srv, "_probe_endpoint", _probe_alive)
+        with pytest.raises(ValueError) as ei:
+            await srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="chembl")
+        msg = str(ei.value)
+        assert "GATEWAY" in msg
+        assert "Retry ONCE, unchanged" in msg
+        assert "Never loop." in msg
+        assert srv._endpoint_down_remaining(srv.SPARQL_ENDPOINT["chembl"]["url"]) is None
+
+    @pytest.mark.asyncio
+    async def test_a_virtuoso_500_still_gets_the_query_weight_advice(self, monkeypatch) -> None:
+        """500 is Virtuoso's own; only 502/503/504 come from a proxy. The engine
+        DID see the query, so 'too heavy' remains the right hint — and no probe
+        should be spent on it."""
+        from togo_mcp import server as srv
+
+        srv._endpoint_down_until.clear()
+        probed = []
+
+        async def _five_hundred(*a, **k):
+            return httpx.Response(
+                500, text="Virtuoso 42000 Error ...",
+                request=httpx.Request("POST", "https://rdfportal.org/ebi/sparql"),
+            )
+
+        async def _probe(url):
+            probed.append(url)
+            return True
+
+        monkeypatch.setattr(srv._sparql_client, "post", _five_hundred)
+        monkeypatch.setattr(srv, "_probe_endpoint", _probe)
+        with pytest.raises(ValueError) as ei:
+            await srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="chembl")
+        assert "too heavy" in str(ei.value)
+        assert probed == [], "a Virtuoso 500 needs no liveness probe"
+
     def test_probe_client_does_not_share_the_sparql_pool(self) -> None:
         """A probe sent through the saturated pool cannot diagnose the saturation.
 

--- a/togo_mcp/chembl.py
+++ b/togo_mcp/chembl.py
@@ -252,6 +252,32 @@ def _target_zero_hint(query: str, *, organism: str, target_type: str) -> str:
     )
 
 
+def _id_lookup_zero_hint(query: str, *, entity_type: str) -> str:
+    """Why a cross-entity lookup came back empty — and that it is not an outage.
+
+    Same reasoning as `_target_zero_hint`, but this tool matches EXACTLY and has
+    no substring fallback: keeping the cross-entity front door predictable is
+    worth more than making it clever, so the hint names the entity-specific tool
+    that does fall back instead.
+    """
+    scoped = (
+        f" You restricted the search to entity_type={entity_type!r}; other kinds "
+        "were not searched at all — omit it to search COMPOUND, TARGET, CELL_LINE "
+        "and TISSUE together."
+        if entity_type
+        else ""
+    )
+    return (
+        f"No ChEMBL entity exactly matched {query!r}. THIS IS NOT AN ENDPOINT FAILURE: "
+        f"the query ran and returned nothing.{scoped} This tool matches whole names "
+        "only, case-insensitively — never a prefix, a single word, or a fuzzy match, so "
+        "check spelling first. For looser matching on a protein/enzyme, call "
+        "search_chembl_target, which falls back to a substring pass over target names; "
+        "for a drug string carrying a dose or several agents, call search_chembl_molecule "
+        "with mode='extract'."
+    )
+
+
 def _containment_match_block(query: str) -> str | None:
     """WHERE-clause fragment matching ``?alt`` synonyms CONTAINED IN ``query``.
 
@@ -536,9 +562,11 @@ async def search_chembl_id_lookup(
     regimes, because the entity kinds carry different searchable text:
 
     • EXACT (case-insensitive) NAME match — COMPOUND (skos:altLabel: brands,
-      generics, synonyms), TARGET (component skos:altLabel: gene symbols, protein
-      names), CELL_LINE and TISSUE (rdfs:label, e.g. "Liver", "CCRF S-180"). Not
-      fuzzy/substring — fix typos before calling. Prefer the entity-specific tools
+      generics, synonyms), TARGET (its own rdfs:label OR its component's
+      skos:altLabel — gene symbols and protein names), CELL_LINE and TISSUE
+      (rdfs:label, e.g. "Liver", "CCRF S-180"). Not fuzzy/substring — fix typos
+      before calling, or use `search_chembl_target`, which falls back to a
+      substring pass. Prefer the entity-specific tools
       (`search_chembl_molecule` / `search_chembl_target`) when you know the kind;
       they carry extra fields (organism/type).
 
@@ -559,13 +587,21 @@ async def search_chembl_id_lookup(
     RETURNS a dict {'total_count', 'has_more', 'results'}. `total_count` is the
     number of rows RETURNED (capped by `limit`), NOT the full match count; check
     `has_more` (true = more results exist beyond this page — relevant mainly for
-    ASSAY, whose keyword search can have many hits). Each result carries
+    ASSAY, whose keyword search can have many hits). ⚠️ On a default (cross-kind)
+    search, `has_more`=true can also mean an entire entity_type is missing from
+    the page: the kinds are UNIONed and the limit is applied to the whole, so
+    e.g. "Liver" at limit=5 returns 5 TARGET rows and no TISSUE row, though both
+    exist. Do NOT conclude a kind is absent from a truncated page — raise `limit`
+    or re-run with `entity_type` set. Each result carries
     'chembl_id', 'entity_type', and 'organism' (null for COMPOUND / where absent —
     use it to tell e.g. human from mouse targets). Name kinds also carry 'name'
     (rdfs:label); ASSAY rows instead carry 'description' (the free-text assay
     description, name=null) and a relevance 'score' (higher = better match).
-    On endpoint failure this tool does NOT raise — it returns a dict with a single
-    'error' key instead; CHECK FOR 'error' BEFORE READING 'results'.
+
+    An EMPTY 'results' additionally carries 'hint'. Read it: an empty result is
+    NOT an endpoint failure, and must not be reported as one. On a real endpoint
+    failure this tool does NOT raise — it returns a dict with a single 'error'
+    key instead; CHECK FOR 'error' BEFORE READING 'results'.
 
     Args:
         entity_type (str, optional): One of COMPOUND, TARGET, CELL_LINE, TISSUE,
@@ -595,7 +631,12 @@ async def search_chembl_id_lookup(
         )
     bif = _bif_and(query)
     if bif is None:
-        return {"total_count": 0, "has_more": False, "results": []}
+        return {
+            "total_count": 0,
+            "has_more": False,
+            "results": [],
+            "hint": _id_lookup_zero_hint(query, entity_type=et),
+        }
     exact = _sparql_literal(query.lower())
 
     def exact_branch(
@@ -625,13 +666,35 @@ async def search_chembl_id_lookup(
             prefilter=True,
             has_organism=False,  # molecules have no organism
         ),
-        "TARGET": exact_branch(
-            "TARGET",
-            "?comp skos:altLabel ?alt .",
-            "?e cco:hasTargetComponent ?comp ; cco:chemblId ?chembl_id ; "
-            "rdfs:label ?name .",
-            prefilter=True,
-            has_organism=True,
+        # TARGET does not fit exact_branch: a target's name lives on TWO nodes,
+        # so it needs an inner UNION. Searching only the component's altLabel
+        # meant a target could not be found by the string this tool returns as
+        # `name` ("Aldehyde dehydrogenase" → 0 rows, while "ALDH2" → 3), and
+        # requiring cco:hasTargetComponent hid the 4,894 targets that have no
+        # protein component. Same fix as search_chembl_target; see
+        # _target_exact_match_block for the full rationale and figures.
+        #
+        # cco:targetType is what makes ?e a TARGET. It is load-bearing on the
+        # second leg: `?e rdfs:label ?tlabel` alone matches ANY labelled entity,
+        # so without it a molecule whose name collided would come back stamped
+        # entity_type="TARGET".
+        "TARGET": (
+            "  {\n"
+            "    {\n"
+            "      ?comp skos:altLabel ?alt .\n"
+            f'      ?alt bif:contains "{bif}" .\n'
+            f'      FILTER(LCASE(STR(?alt)) = "{exact}")\n'
+            "      ?e cco:hasTargetComponent ?comp .\n"
+            "    } UNION {\n"
+            "      ?e rdfs:label ?tlabel .\n"
+            f'      ?tlabel bif:contains "{bif}" .\n'
+            f'      FILTER(LCASE(STR(?tlabel)) = "{exact}")\n'
+            "    }\n"
+            "    ?e cco:targetType ?target_type ; cco:chemblId ?chembl_id ; "
+            "rdfs:label ?name .\n"
+            "    OPTIONAL { ?e cco:organismName ?organism }\n"
+            '    BIND("TARGET" AS ?entity_type)\n'
+            "  }"
         ),
         "CELL_LINE": exact_branch(
             "CELL_LINE",
@@ -713,11 +776,14 @@ async def search_chembl_id_lookup(
             }
             for r in rows
         ]
-    return {
+    out = {
         "total_count": len(parsed_results),
         "has_more": has_more,
         "results": parsed_results,
     }
+    if not parsed_results:
+        out["hint"] = _id_lookup_zero_hint(query, entity_type=et)
+    return out
 
 
 @mcp.tool(annotations=READ_ONLY_TOOL)

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -144,6 +144,11 @@ _probe_client = httpx.AsyncClient(
 _ENDPOINT_DOWN_TTL_SECONDS = 60.0
 _endpoint_down_until: dict[str, float] = {}
 
+# Statuses a reverse proxy emits when it cannot get an answer from the backend.
+# Virtuoso itself never returns these, so they mean "infrastructure", not "your
+# query" — see the gateway branch in execute_sparql.
+_GATEWAY_STATUS = frozenset({502, 503, 504})
+
 
 class _EndpointUnresponsive(Exception):
     """The endpoint failed a liveness probe: it is not answering anything."""
@@ -506,17 +511,52 @@ async def execute_sparql(
             "Other endpoints are unaffected; see get_sparql_endpoints()."
         ) from exc
 
-    # Answered — whatever the status code, the endpoint is alive.
-    _clear_endpoint_down(url)
-
     extra["http_code"] = response.status_code
     extra["n_bytes"] = len(response.content)
     if response.is_success:
+        # Answered with data — the endpoint is demonstrably alive.
+        _clear_endpoint_down(url)
         extra["sparql_status"] = "ok"
         extra["n_rows"] = max(response.text.count("\n") - 1, 0)
     elif 400 <= response.status_code < 500:
+        _clear_endpoint_down(url)
         extra["sparql_status"] = "http_4xx"
+    elif response.status_code in _GATEWAY_STATUS:
+        # A reverse proxy answering for a backend it could not reach. Virtuoso
+        # never emits these; nginx does, in ~0.1s, with an HTML error page. The
+        # generic 5xx advice ("the query may be too heavy — add LIMIT") is then
+        # actively wrong: the SPARQL engine never saw the query. Observed
+        # 2026-08-12 on the ebi endpoint, where `ASK {}` and a one-IRI lookup
+        # 502'd identically while the same queries had succeeded seconds earlier.
+        #
+        # Which of the two it is cannot be read off the status code, so ask the
+        # endpoint: the same liveness probe used for timeouts settles it.
+        if not await _probe_endpoint(url):
+            extra["sparql_status"] = "endpoint_unresponsive"
+            extra["liveness_probe"] = "failed"
+            _mark_endpoint_down(url)
+            raise ValueError(
+                f"SPARQL endpoint at {url} returned HTTP {response.status_code} from "
+                f"its gateway, and is not answering a trivial query either.\n\n"
+                + _endpoint_down_message(url).split("\n\n", 1)[1]
+            )
+        _clear_endpoint_down(url)
+        extra["sparql_status"] = "http_gateway"
+        extra["liveness_probe"] = "passed"
+        raise ValueError(
+            f"SPARQL endpoint at {url} returned HTTP {response.status_code} from its "
+            "GATEWAY (a reverse proxy), not from the SPARQL engine — so the engine may "
+            "never have seen this query.\n\n"
+            "A liveness check right afterwards SUCCEEDED, so the endpoint is up and "
+            "this failure is specific to this request: either the backend dropped this "
+            "one query, or the upstream blipped for a moment.\n\n"
+            "Retry ONCE, unchanged — that is the single most likely fix here, and "
+            "rewriting the query first would be guesswork. If the retry fails the same "
+            "way, THEN treat it as too heavy: lower LIMIT, anchor on specific IRIs, and "
+            "split multi-graph joins. Never loop."
+        )
     else:
+        _clear_endpoint_down(url)
         extra["sparql_status"] = "http_5xx"
 
     raise_for_status_with_body(

--- a/togo_mcp/stats.py
+++ b/togo_mcp/stats.py
@@ -12,8 +12,9 @@ What the collection layer records today (per JSONL line):
   ts, tool, args, status (ok|error), elapsed_ms, session_id/request_id/...,
   ip, error_class, error_message, and for SPARQL an ``extra`` dict with
   endpoint_url, query_sha256, sparql_status (ok|timeout|endpoint_unresponsive|
-  pool_exhausted|network_error|http_4xx|http_5xx), http_code, n_bytes, n_rows,
-  and — when the liveness watchdog ran — liveness_probe (passed|failed).
+  pool_exhausted|network_error|http_4xx|http_5xx|http_gateway), http_code,
+  n_bytes, n_rows, and — when the liveness probe ran — liveness_probe
+  (passed|failed).
 
 This module derives, per calendar month (UTC):
   * per-tool: call count, error count/rate, duration p50/p95/mean
@@ -249,6 +250,10 @@ def sparql_class(rec: dict[str, Any]) -> str | None:
         return "endpoint_down"
     if status == "pool_exhausted":
         return "pool_exhausted"
+    if status == "http_gateway":
+        # A proxy 502/503/504 whose endpoint passed a liveness check right after:
+        # a server-side failure, but not one the query can be blamed for.
+        return "server_error"
     if status == "http_5xx":
         return "server_error"
     if status == "http_4xx":

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Follow-up to #196, from investigating whether `search_chembl_id_lookup` had the same problem. It did.

## 1. The same two-node bug, in the other tool

`search_chembl_id_lookup`'s TARGET branch searched only the protein component's `skos:altLabel` while returning the target's own `rdfs:label` as `name` — identical in shape to what 2.6.0 fixed. So after 2.6.0 shipped, **the two tools disagreed about the same question**:

| query | `entity_type` | before | after |
|---|---|---|---|
| **`Aldehyde dehydrogenase`** | default | **0** | **1 — CHEMBL3542434** |
| **`Aldehyde dehydrogenase`** | `TARGET` | **0** | **1 — same** |
| `ALDH2` | both | 3 | 3 (unchanged) |
| **`CCRF-CEM`** | `TARGET` | **0** | **1 — CHEMBL382** |
| `zzzznotarget` | default | 0 | 0 + `hint` |

Verified live: `id_lookup(entity_type="TARGET")` and `search_chembl_target` now return **identical IDs** for both `Aldehyde dehydrogenase` and `CCRF-CEM`.

`cco:targetType` is a new guard on that branch rather than decoration: the second leg is `?e rdfs:label ?tlabel`, which on its own matches **any** labelled entity — without the guard a molecule whose name collided would come back stamped `entity_type="TARGET"`.

Worth knowing when reading results, and now in the changelog: a cell line exists **twice** under different IDs — CHEMBL3307641 as a `cco:CellLine` entity, CHEMBL382 as a CELL-LINE *target*. The CELL_LINE branch finding one was never a substitute for the TARGET branch finding the other.

Empty results now carry a `hint`, same reasoning as 2.6.0. **No substring fallback here, deliberately** — a predictable cross-entity front door is worth more than a clever one, so the hint names the tools that do fall back (`search_chembl_target`, `search_chembl_molecule(mode='extract')`) and flags a narrowing `entity_type` when one was passed.

## 2. A gateway 5xx is not a heavy query

502/503/504 come from a reverse proxy, not from Virtuoso — the SPARQL engine may never have seen the query, so the generic advice ("this may indicate the query is too heavy; add LIMIT") is actively wrong. Observed on the `ebi` endpoint while doing the work above: `ASK {}` and a one-IRI lookup 502'd identically in ~0.1 s, seconds after the same queries had succeeded.

The status code alone cannot say whether the backend is down or merely dropped one request, so the liveness probe added in 2.5.3 is reused to ask:

- **probe fails** → the endpoint-down message and the circuit breaker, exactly as for a timeout
- **probe passes** → the endpoint is up and this failure is request-specific: **retry once, unchanged**, before rewriting anything
- **a plain 500** is Virtuoso's own — untouched, keeps the query-weight advice, spends no probe (asserted in a test)

Logged as `sparql_status: "http_gateway"`, classified `server_error`, so it stays out of the MIE-trap counts.

## Documented, not changed

On a default cross-kind `search_chembl_id_lookup`, `has_more=true` can mean an **entire `entity_type` is missing from the page**: the kinds are UNIONed and the limit applies to the whole, so `"Liver"` at `limit=5` returns 5 TARGET rows and no TISSUE row although both exist (at `limit=20`: 5 + 5). Pre-existing, but the new TARGET leg makes it easier to hit — and "there is no tissue named Liver" is exactly the kind of false conclusion this whole line of work is about. The docstring now says so. The query is unchanged: `has_more` fires correctly, and that is the honest signal.

## Release notes

- **MINOR**: `hint` is a new key and the tool answers queries it used to answer with an empty array. Nothing removed or renamed, no existing key changed meaning.
- **No whatsnew marker**, deliberately — 2.6.0's entry already tells a user that ChEMBL target lookups now find targets by their own name, and they neither know nor care which of the two tools they went through; a second near-identical line would push a genuinely distinct item off the five-item list. The gateway half is a reliability fix, which 2.5.3 set the precedent for leaving off the page.
- 7 new tests; **423 pass**. One existing test was updated rather than deleted: it counted `UNION` tokens to assert "four branches, three joins", and the TARGET branch now contains one of its own — it now asserts both numbers.

After merge, tag the merge commit: `git tag v2.7.0 <merge-sha> && git push origin v2.7.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)