### PR TITLE
release: 2.7.2

### DIFF
--- a/.claude/skills/mie-generator/references/query-strategy.md
+++ b/.claude/skills/mie-generator/references/query-strategy.md
@@ -140,6 +140,35 @@ Before using `bif:contains` or `FILTER(CONTAINS())` in any example query, confir
 
 ## Virtuoso-specific pitfalls
 
+### `REGEX()` with two arguments silently drops top-level alternation
+
+**Never ship an example — or a `traps_avoided` line — containing a bare `REGEX(?x, "A|B")`.** The
+two-argument form returns **0 rows with no error** on every endpoint in the registry. Verified
+2026-08-14 on all 10 (`primary`, `sib`, `ebi`, `pubchem`, `pdb`, `ncbi`, `ddbj`, `nims`, `glycosmos`,
+`togovar`) with a query that touches no data at all:
+
+```sparql
+SELECT (COUNT(*) AS ?n) WHERE {
+  VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" }
+  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))     # returns 0 — should be 2. Even "A|A" returns 0.
+}
+```
+
+Two fixes, both verified everywhere — add any third (flags) argument, or parenthesise every branch:
+
+```sparql
+FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))   # "" is enough; "i" also folds case
+FILTER(REGEX(?label, "(Fentanyl)|(Sufentanil)"))
+```
+
+`LCASE()`/`STR()` do not rescue it. Single terms, character classes (`Fent[a]nyl`) and `.*`-anchored
+patterns are unaffected, which is what makes it dangerous: an example that works with one search term
+starts returning 0 the moment an author widens it to a family, and the empty result reads as "the
+database doesn't have those." A production session concluded MassBank had no fentanyls; it has 44.
+This is engine behaviour, so it belongs in the Usage Guide (SILENT-FAILURE TRAPS #10), not in each
+MIE — do not re-derive it per file. Cite it in a `traps_avoided` line only where a file's own example
+would otherwise tempt an author into the bare form.
+
 ### Check the backend first
 
 RDF Portal endpoints are Virtuoso, so `bif:contains` is normally available. If you don't know, run a minimal `bif:contains` query once and see if it errors. (v3 has no `access.backend` field — the backend is not documented per-file; establish it by probing when it matters.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.2] - 2026-08-14
+
+Promotes 2.7.1's `regex_alternation` finding from one MIE to the Usage Guide, after establishing that it
+is not a MassBank fact — or even an RDF Portal fact. No tool, parameter, or return shape changed.
+
+2.7.1 hedged: "Virtuoso engine behaviour … it plausibly affects every database on the endpoint." That
+hedge is now a measurement. The bug reproduces with a query that touches **no data at all** —
+
+```sparql
+SELECT (COUNT(*) AS ?n) WHERE {
+  VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" }
+  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))     # returns 0. The answer is 2.
+}
+```
+
+— which makes it testable on every endpoint regardless of what each one hosts. All **10 of 10** in the
+registry return 0: `primary`, `sib`, `ebi`, `pubchem`, `pdb`, `ncbi`, `ddbj`, `nims`, `glycosmos`,
+`togovar`. Grouped `(A)|(B)` and three-argument `REGEX(…, "")` return 2 everywhere.
+
+### Added
+
+- **Usage Guide: `REGEX()` alternation is now SILENT-FAILURE TRAPS #10** (`03_workflows.md`). That section
+  is where the endpoint-wide zero-row traps already live — the `^^xsd:string` join that returns 0, the
+  plain-vs-typed literal split — and SPARQL DISCIPLINE already points at it before writing. The entry
+  leads with both copyable fixes rather than the warning, on the ablation result that query content
+  carries the effect and guardrail prose alone does not. It also names the reason the bug survives review:
+  single terms, character classes and `.*`-anchored patterns all work, so it only appears when someone
+  widens a *working* single-term filter into a family — and the empty result reads as "the database
+  doesn't have those."
+- **Usage Guide: a troubleshooting row** (`04_reference.md`) pointing at #10, for the case where the
+  agent already has an empty result and is working backwards. Pointer only, no restatement.
+- **mie-generator skill: the same rule under "Virtuoso-specific pitfalls"** (`references/query-strategy.md`),
+  which until now covered only `bif:contains`. Different audience and different purpose: it stops all 37
+  future MIE revisions from shipping a bare-alternation example or re-deriving the bug per file, and says
+  explicitly that the rule belongs in the guide rather than in each MIE.
+
+### Changed
+
+- **massbank: the `regex_alternation` gotcha is trimmed to its local evidence plus a pointer.** With the
+  universal rule in the guide, the file keeps what is genuinely MassBank's — the 44 matching compound
+  nodes, the session that read 0 as "no fentanyls", and the fact that compound-name search is a common
+  entry point here — and drops the restated general rule. The load-bearing part was always
+  `find_compound_by_name` demonstrating the safe form, which is unchanged.
+
 ## [2.7.1] - 2026-08-14
 
 No tool, parameter, or return shape changed — this is one MIE file. It is the second release driven by
@@ -1356,7 +1400,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.1...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.2...HEAD
+[2.7.2]: https://github.com/dbcls/togomcp/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/dbcls/togomcp/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/dbcls/togomcp/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/dbcls/togomcp/compare/v2.5.3...v2.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.1"
+version = "2.7.2"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/mie/massbank.yaml
+++ b/togo_mcp/data/mie/massbank.yaml
@@ -85,16 +85,14 @@ global_gotchas:                    # the few that bite ANY query on this DB — 
       scan unrelated data — slow, or mixing MeSH/GO/BacDive/TogoID triples into an untyped result.
   - id: regex_alternation
     say: >
-      SILENT 0 ROWS — the two-argument form of REGEX() ignores a top-level alternation on this Virtuoso.
-      Verified 2026-08-14 on rdfs:label in the massbank graph: REGEX(STR(?n), "Fentanyl|Sufentanil") = 0
-      rows, and even REGEX(STR(?n), "Fentanyl|Fentanyl") = 0 — while the SAME pattern matches 30 as
-      REGEX(STR(?n), "(Fentanyl)|(Sufentanil)"), 30 with an empty third argument
-      REGEX(STR(?n), "Fentanyl|Sufentanil", ""), and 44 case-insensitively with
-      REGEX(STR(?n), "Fentanyl|Sufentanil", "i"). LCASE() does not rescue it:
-      REGEX(LCASE(STR(?n)), "fentanyl|sufentanil") is also 0. TWO FIXES, both verified — always pass a
-      third (flags) argument, even "", OR parenthesise every branch. Single-term patterns, character
-      classes (Fent[a]nyl) and .*-anchored patterns are unaffected. This cost a real user the conclusion
-      "MassBank has no fentanyls" (it has 44 matching compound nodes).
+      SILENT 0 ROWS — two-argument REGEX() ignores top-level alternation. This is ENGINE behaviour, not a
+      MassBank fact: it reproduces on all 10 endpoints in the registry, and the rule plus both fixes live
+      in the Usage Guide (SILENT-FAILURE TRAPS #10) — pass a third (flags) argument, even "", or
+      parenthesise every branch. Recorded here because MassBank is where it was caught and compound-name
+      search is a common entry point: verified 2026-08-14 on rdfs:label in the massbank graph,
+      REGEX(STR(?n), "Fentanyl|Sufentanil") returns 0 while REGEX(STR(?n), "(Fentanyl)|(Sufentanil)")
+      returns 30 and the "i"-flagged form returns 44. A real session read the 0 as "MassBank has no
+      fentanyls"; it has 44 matching compound nodes. Example find_compound_by_name uses the safe form.
   - id: spectram_misspelling
     say: >
       The metadata class + predicate are misspelled "Spectram" in the source ontology and are canonical

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -107,6 +107,20 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
    ```
 
    The `^^xsd:string` is mandatory — without it the join silently returns 0.
+10. **Two-argument `REGEX()` ignores top-level alternation — 0 rows, no error.** Verified on
+    **all 10 endpoints** (2026-08-14) by a query that needs no data:
+    `VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" } FILTER(REGEX(?s, "Fentanyl|Sufentanil"))`
+    returns **0**, not 2. Even `"A|A"` returns 0. Either fix works:
+
+    ```sparql
+    FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))   # any third argument; "" is enough
+    FILTER(REGEX(?label, "(Fentanyl)|(Sufentanil)"))   # every branch parenthesised
+    ```
+
+    `LCASE()`/`STR()` do not rescue it. Single terms, character classes (`Fent[a]nyl`) and
+    `.*`-anchored patterns are unaffected — so it only bites when you widen a *working*
+    single-term filter into an alternation, which reads as "the extra terms matched nothing."
+    A real session concluded MassBank had no fentanyls; it has 44.
 
 ---
 

--- a/togo_mcp/data/resources/usage_guide_v6/04_reference.md
+++ b/togo_mcp/data/resources/usage_guide_v6/04_reference.md
@@ -30,6 +30,7 @@
 | 3rd consecutive SPARQL | Stop. Pivot to search / NCBI / TogoID / partial synthesis. |
 | Cross-DB SPARQL fails | Check endpoints; use TogoID or NCBI bridge. |
 | Empty SPARQL results | Use structured predicates from MIE; extract IRIs via search first. Typed literal missing (`^^xsd:string`)? Predicate applied to the wrong node? |
+| `REGEX` filter with `A\|B` returns nothing | Two-arg `REGEX()` drops top-level alternation on **every** endpoint. Add a third argument (`, ""`) or parenthesise each branch: `(A)\|(B)`. See SILENT-FAILURE TRAPS #10. |
 | SPARQL timeout | Add LIMIT; replace `bif:contains` with structured IRIs. |
 | Wrong count | Master reactions only? Correct keyword IRI (not EC prefix)? |
 | **Count inflated** (2×, 4×, 8×) — or right but unproven | Co-tenancy. `GRAPH ?g` the pattern with its subject bound: >1 graph → re-declared; none of yours → foreign predicate, i.e. a silent intersection. Pin **every** pattern. `DISTINCT` hides it, doesn't fix it. |

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.1"
+version = "2.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch release. **No tool, parameter, or return shape changed.** Promotes 2.7.1's `regex_alternation` finding from one MIE to the Usage Guide, after establishing it is not a MassBank fact — or even an RDF Portal fact.

## The hedge became a measurement

2.7.1 said: *"Virtuoso engine behaviour … it plausibly affects every database on the endpoint."* That was an inference from one graph. The bug turns out to reproduce on a query that touches **no data at all**, which makes it testable on every endpoint regardless of what each hosts:

```sparql
SELECT (COUNT(*) AS ?n) WHERE {
  VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" }
  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))     -- returns 0. The answer is 2.
}
```

| endpoint | bare `A\|B` | `(A)\|(B)` | `REGEX(…, "")` |
|---|---|---|---|
| primary, sib, ebi, pubchem, pdb, ncbi, ddbj, nims, glycosmos, togovar | **0** ×10 | 2 ×10 | 2 ×10 |

**10 of 10.** Every endpoint TogoMCP serves.

## Three homes, three audiences

- **`03_workflows.md` → SILENT-FAILURE TRAPS #10** — primary. That section already collects the endpoint-wide zero-row traps (the `^^xsd:string` join returning 0, the plain-vs-typed literal split), and SPARQL DISCIPLINE already points at it before writing. Leads with both copyable fixes rather than the warning, on the ablation result that query content carries the effect while guardrail prose alone does not.
- **`04_reference.md` troubleshooting row** — pointer only, for the agent working backwards from an empty result.
- **`mie-generator/references/query-strategy.md` → Virtuoso-specific pitfalls** — different audience: stops all 37 future MIE revisions from shipping a bare-alternation example or re-deriving the bug per file.

## Why it survives review

Single terms, character classes (`Fent[a]nyl`) and `.*`-anchored patterns all work. It only appears when someone widens a *working* single-term filter into a family — and the empty result reads as "the database doesn't have those." That is exactly how a production session concluded MassBank had no fentanyls; it has 44.

## Changed

- **massbank's `regex_alternation` gotcha trimmed** to its local evidence (the 44 nodes, the session that misread the 0) plus a pointer to the guide. The load-bearing part was always `find_compound_by_name` demonstrating the safe form — unchanged.

## Validation

- Guide assembles at 43,052 bytes; all three probes present in the served text
- `massbank.yaml` parses; 14 examples, 6 gotchas
- `uv run pytest` → 423 passed
- Guide content ships live, so this reaches every client immediately — no tool-list rescan needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)