### PR TITLE
release: 2.7.3

### DIFF
--- a/.claude/skills/mie-generator/references/query-strategy.md
+++ b/.claude/skills/mie-generator/references/query-strategy.md
@@ -140,34 +140,40 @@ Before using `bif:contains` or `FILTER(CONTAINS())` in any example query, confir
 
 ## Virtuoso-specific pitfalls
 
-### `REGEX()` with two arguments silently drops top-level alternation
+### Two-argument `REGEX()` silently mishandles some metacharacters
 
-**Never ship an example — or a `traps_avoided` line — containing a bare `REGEX(?x, "A|B")`.** The
-two-argument form returns **0 rows with no error** on every endpoint in the registry. Verified
-2026-08-14 on all 10 (`primary`, `sib`, `ebi`, `pubchem`, `pdb`, `ncbi`, `ddbj`, `nims`, `glycosmos`,
-`togovar`) with a query that touches no data at all:
+**Never ship an example with a two-argument `REGEX()`. Always pass the third (flags) argument** —
+`""` is enough, `"i"` also folds case:
 
 ```sparql
-SELECT (COUNT(*) AS ?n) WHERE {
-  VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" }
-  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))     # returns 0 — should be 2. Even "A|A" returns 0.
-}
+FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))
 ```
 
-Two fixes, both verified everywhere — add any third (flags) argument, or parenthesise every branch:
+The two-argument form returns **0 rows with no error** for at least two constructs, on every endpoint
+in the registry. Verified 2026-08-14 on all 10 (`primary`, `sib`, `ebi`, `pubchem`, `pdb`, `ncbi`,
+`ddbj`, `nims`, `glycosmos`, `togovar`) with queries that touch no data at all:
 
 ```sparql
-FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))   # "" is enough; "i" also folds case
-FILTER(REGEX(?label, "(Fentanyl)|(Sufentanil)"))
+VALUES ?s { "Fentanyl" "Sufentanil" }  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))   # 0, want 2
+VALUES ?s { "ab" "aab" "aaab" }        FILTER(REGEX(?s, "a{1,2}b"))               # 0, want 3
 ```
 
-`LCASE()`/`STR()` do not rescue it. Single terms, character classes (`Fent[a]nyl`) and `.*`-anchored
-patterns are unaffected, which is what makes it dangerous: an example that works with one search term
-starts returning 0 the moment an author widens it to a family, and the empty result reads as "the
-database doesn't have those." A production session concluded MassBank had no fentanyls; it has 44.
-This is engine behaviour, so it belongs in the Usage Guide (SILENT-FAILURE TRAPS #10), not in each
-MIE — do not re-derive it per file. Cite it in a `traps_avoided` line only where a file's own example
-would otherwise tempt an author into the bare form.
+Alternation fails in every shape tested (`A|B`, `A|B|C`, one-sided `A|`, and even `A|A`); brace
+quantifiers fail as `{n}`, `{n,}` and `{n,m}`. `LCASE()`/`STR()` rescue neither.
+
+Parenthesising the affected construct also works, but **do not author against that** — it requires
+knowing which metacharacter is affected, and the two above are what has been *tested*, not a proof
+there is nothing else. The flags argument is unconditional and costs three characters.
+
+Unaffected (verified): plain substrings, character classes (`[Ff]entanyl`), `?` `+` `*`, anchors
+`^…$`, `.`, escapes, non-capturing groups `(?:…)`. That asymmetry is exactly what makes it dangerous
+during authoring: a single-term example works, and it starts returning 0 the moment you widen it to a
+family or add a count — read as "the database doesn't have those." A production session concluded
+MassBank had no fentanyls; it has 44.
+
+This is engine behaviour, so the rule belongs in the Usage Guide (SILENT-FAILURE TRAPS #10), not in
+each MIE — do not re-derive it per file. Cite it in a `traps_avoided` line only where a file's own
+example would otherwise tempt an author into the bare form.
 
 ### Check the backend first
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,53 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.3] - 2026-08-14
+
+**2.7.2's rule was too narrow, and one of the two fixes it offered was bad advice.** Asking "is any MIE
+inconsistent with the new rule?" turned up no inconsistency in the corpus — but checking the *mechanism*
+behind the bug, rather than only grepping for it, showed the rule itself was wrong. No tool, parameter,
+or return shape changed.
+
+Alternation is not the only construct the two-argument `REGEX()` mishandles. Brace quantifiers fail
+identically, and on the same 10 of 10 endpoints:
+
+```sparql
+VALUES ?s { "ab" "aab" "aaab" }  FILTER(REGEX(?s, "a{1,2}b"))   -- returns 0. The answer is 3.
+```
+
+Verified across `{n}`, `{n,}` and `{n,m}`, and for alternation across `A|B`, `A|B|C`, one-sided `A|` and
+`A|A`. Both are consistent with Virtuoso taking a "looks literal" fast path that mis-parses certain
+metacharacters — which means the two known-broken constructs are what has been *tested*, not a proof
+that nothing else is affected.
+
+### Changed
+
+- **The rule is now "always pass a third argument", full stop** (guide SILENT-FAILURE TRAPS #10,
+  `04_reference.md`, and the mie-generator skill). 2.7.2 offered parenthesising and the flags argument as
+  equal alternatives. Parenthesising does fix both known cases — but it requires the author to know
+  *which* metacharacter is affected, which is precisely the knowledge the trap denies them, and it does
+  nothing for a construct nobody has tested yet. The flags argument is unconditional and costs three
+  characters. The unaffected list (plain substrings, `[Ff]entanyl`, `? + *`, anchors, `.`, escapes,
+  `(?:…)`) is kept, because that asymmetry is *why* the bug survives review — a single-term filter works
+  until someone widens it to a family or adds a count.
+- **massbank + hco: `REGEX` calls updated** to the three-argument form. hco's `bands_on_arm` (`"^13q"`)
+  and `position_to_band` (`"^13[pq]"`) were **not** broken — anchors and character classes are unaffected,
+  and both re-run to their stored figures exactly (32 rows; 13q14.2 / gpos50 / 46700001 / 50300000, dates
+  re-stamped). They are changed because they were one edit away from `"^13p|^13q"`, which is the latent
+  form this rule exists to prevent.
+
+### Added
+
+- **`tests/test_regex_two_arg_guard.py` — the rule is now enforced, not advised.** It bans the
+  two-argument form outright in any executable `sparql` field across the corpus (37 parametrised cases),
+  and asserts the guide still documents the fix and both broken constructs. Two reasons it is a static
+  test rather than a live one: `check_mie_examples.py` flags zero-ROW results, so it catches a broken
+  `REGEX` only when that filter zeroes the *whole* query — inside an `OPTIONAL` or one `UNION` branch it
+  returns rows, just silently fewer, and nothing notices. And a live test would pass the day an endpoint
+  is patched, which is exactly when the corpus should still be written defensively. It found hco
+  immediately; the ad-hoc grep that preceded it did not, because that grep only looked for patterns
+  containing `|`.
+
 ## [2.7.2] - 2026-08-14
 
 Promotes 2.7.1's `regex_alternation` finding from one MIE to the Usage Guide, after establishing that it
@@ -1400,7 +1447,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.2...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.3...HEAD
+[2.7.3]: https://github.com/dbcls/togomcp/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/dbcls/togomcp/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/dbcls/togomcp/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/dbcls/togomcp/compare/v2.6.0...v2.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.2"
+version = "2.7.3"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_regex_two_arg_guard.py
+++ b/tests/test_regex_two_arg_guard.py
@@ -1,0 +1,156 @@
+"""Drift guard: no shipped SPARQL may use the two-argument form of `REGEX()`.
+
+On every SPARQL endpoint in `endpoints.csv` (all 10, verified 2026-08-14), the
+two-argument `REGEX(?x, "pattern")` form silently mishandles at least two regex
+constructs, returning **0 rows with no error**:
+
+    VALUES ?s { "Fentanyl" "Sufentanil" }  FILTER(REGEX(?s, "Fentanyl|Sufentanil"))  -> 0, want 2
+    VALUES ?s { "ab" "aab" "aaab" }        FILTER(REGEX(?s, "a{1,2}b"))              -> 0, want 3
+
+Alternation fails in every shape tested (`A|B`, `A|B|C`, one-sided `A|`, even
+`A|A`); brace quantifiers fail as `{n}`, `{n,}` and `{n,m}`. Passing any third
+(flags) argument — `""` is enough — fixes both. Plain substrings, character
+classes, `? + *`, anchors, `.`, escapes and `(?:...)` are unaffected.
+
+That asymmetry is what makes this worth a test rather than a note. A single-term
+`REGEX` example works, so it passes review and passes `check_mie_examples.py`;
+it starts returning 0 only when someone later widens the pattern to a family or
+adds a count, and the empty result reads as "the database doesn't have those."
+A production session concluded MassBank had no fentanyls; it has 44.
+
+Worse, `check_mie_examples.py` cannot catch the general case at all: it flags
+zero-ROW results, but a broken `REGEX` inside an `OPTIONAL` or one `UNION` branch
+still returns rows — just silently fewer. So the only reliable guard is static,
+and it is a blanket ban on the two-argument form rather than a hunt for the
+specific metacharacters, because the two known-broken constructs are what has
+been *tested*, not a proof that nothing else is affected.
+
+The rule itself lives in `usage_guide_v6/03_workflows.md` (SILENT-FAILURE TRAPS
+#10) and in the mie-generator skill's `query-strategy.md`; this test enforces it
+against the corpus that ships.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+MIE_DIR = REPO / "togo_mcp" / "data" / "mie"
+GUIDE = REPO / "togo_mcp" / "data" / "resources" / "usage_guide_v6" / "03_workflows.md"
+
+# Field names whose string values are executed as SPARQL (as opposed to prose that
+# may legitimately quote a broken form as a counter-example).
+EXECUTABLE_FIELD = re.compile(r"(^|\.)(sparql|query)(\[\d+\])?$", re.IGNORECASE)
+
+
+def _split_top_level(text: str, sep: str) -> list[str]:
+    """Split on `sep` at paren-depth 0, honouring quoted strings and backslash escapes."""
+    parts: list[str] = []
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    current = ""
+    for ch in text:
+        if escaped:
+            current += ch
+            escaped = False
+            continue
+        if ch == "\\":
+            current += ch
+            escaped = True
+            continue
+        if quote:
+            current += ch
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            current += ch
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == sep and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += ch
+    parts.append(current)
+    return parts
+
+
+def find_regex_calls(text: str) -> list[tuple[str, int]]:
+    """Return (call_source, argument_count) for every REGEX(...) in `text`."""
+    calls: list[tuple[str, int]] = []
+    for match in re.finditer(r"\bREGEX\s*\(", text, re.IGNORECASE):
+        i = match.end()
+        depth = 1
+        start = i
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        if depth:  # unbalanced — not a call we can judge
+            continue
+        inner = text[start : i - 1]
+        calls.append(("REGEX(" + inner + ")", len(_split_top_level(inner, ","))))
+    return calls
+
+
+def walk_strings(node, path: str = ""):
+    """Yield (dotted_path, string) for every string leaf in a parsed YAML document."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from walk_strings(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from walk_strings(value, f"{path}[{index}]")
+    elif isinstance(node, str):
+        yield path, node
+
+
+def mie_files() -> list[Path]:
+    return sorted(MIE_DIR.glob("*.yaml"))
+
+
+def test_mie_dir_is_populated():
+    """Guard the guard: an empty glob would make every test below vacuously pass."""
+    assert len(mie_files()) >= 30, f"expected the full MIE corpus, found {len(mie_files())}"
+
+
+@pytest.mark.parametrize("mie_path", mie_files(), ids=lambda p: p.stem)
+def test_no_two_arg_regex_in_executable_sparql(mie_path: Path):
+    """Every REGEX() inside an executable `sparql` field must pass a flags argument."""
+    document = yaml.safe_load(mie_path.read_text())
+    offenders: list[str] = []
+    for path, text in walk_strings(document):
+        if not EXECUTABLE_FIELD.search(path):
+            continue
+        for call, n_args in find_regex_calls(text):
+            if n_args < 3:
+                offenders.append(f"{mie_path.name}{path}: {call}")
+    assert not offenders, (
+        "Two-argument REGEX() found in executable SPARQL. It silently returns 0 rows for "
+        "alternation and brace quantifiers on every endpoint — pass a third argument "
+        '(REGEX(?x, "pat", "")). See usage_guide_v6/03_workflows.md SILENT-FAILURE TRAPS #10.\n  '
+        + "\n  ".join(offenders)
+    )
+
+
+def test_guide_documents_the_rule():
+    """The corpus rule is only safe to enforce while the guide still explains it."""
+    text = GUIDE.read_text()
+    assert "SILENT-FAILURE TRAPS" in text
+    # The prescription, and both verified-broken constructs, must survive edits.
+    assert "REGEX" in text and 'REGEX(?label, "Fentanyl|Sufentanil", "")' in text, (
+        "the guide must show the three-argument fix verbatim — it is what authors copy"
+    )
+    assert "a{1,2}b" in text, "the brace-quantifier case must stay documented alongside alternation"

--- a/togo_mcp/data/mie/hco.yaml
+++ b/togo_mcp/data/mie/hco.yaml
@@ -80,10 +80,10 @@ examples:
       FROM <http://rdfportal.org/dataset/hco>
       WHERE {
         ?band rdfs:subClassOf hco:Cytoband ; rdfs:label ?label .
-        FILTER(REGEX(?label, "^13q"))     # ISCN: chromosome 13, q arm — the accessible structured handle
+        FILTER(REGEX(?label, "^13q", ""))  # ISCN: chr 13, q arm. 3rd arg is mandatory — see guide TRAPS #10
       }
       ORDER BY ?label
-    verified: {result_rows: 32, date: "2026-07-22"}
+    verified: {result_rows: 32, date: "2026-08-14"}
     teaches: "Band classes are enumerated via rdfs:subClassOf hco:Cytoband; select an arm/chromosome by REGEX on the ISCN rdfs:label (^13q). No coordinates or build needed for the class list."
 
   - id: band_coordinates
@@ -116,11 +116,11 @@ examples:
         ?inst a ?band ; hco:build hco:GRCh38 ; hco:bandtype ?bt ; faldo:location ?loc .
         ?band rdfs:subClassOf hco:Cytoband ; rdfs:label ?bandLabel .
         ?bt rdfs:label ?stain .
-        FILTER(REGEX(?bandLabel, "^13[pq]"))         # restrict to chromosome 13 first
+        FILTER(REGEX(?bandLabel, "^13[pq]", ""))     # chr 13 first. 3rd arg mandatory — see guide TRAPS #10
         ?loc faldo:begin/faldo:position ?begin ; faldo:end/faldo:position ?end .
         FILTER(?begin <= 50000000 && 50000000 <= ?end)
       }
-    verified: {bandLabel: "13q14.2", stain: "gpos50", begin: 46700001, end: 50300000, date: "2026-07-22"}
+    verified: {bandLabel: "13q14.2", stain: "gpos50", begin: 46700001, end: 50300000, date: "2026-08-14"}
     teaches: "faldo:position is xsd:integer, so a base position resolves to a band with a numeric BETWEEN filter (?begin <= P && P <= ?end). Restrict to the chromosome by ISCN label REGEX before the range scan."
 
   - id: stain_enum

--- a/togo_mcp/data/mie/massbank.yaml
+++ b/togo_mcp/data/mie/massbank.yaml
@@ -85,10 +85,10 @@ global_gotchas:                    # the few that bite ANY query on this DB — 
       scan unrelated data — slow, or mixing MeSH/GO/BacDive/TogoID triples into an untyped result.
   - id: regex_alternation
     say: >
-      SILENT 0 ROWS — two-argument REGEX() ignores top-level alternation. This is ENGINE behaviour, not a
-      MassBank fact: it reproduces on all 10 endpoints in the registry, and the rule plus both fixes live
-      in the Usage Guide (SILENT-FAILURE TRAPS #10) — pass a third (flags) argument, even "", or
-      parenthesise every branch. Recorded here because MassBank is where it was caught and compound-name
+      SILENT 0 ROWS — two-argument REGEX() mishandles alternation AND brace quantifiers. This is ENGINE
+      behaviour, not a MassBank fact: both reproduce on all 10 endpoints in the registry, and the rule
+      lives in the Usage Guide (SILENT-FAILURE TRAPS #10) — ALWAYS pass a third (flags) argument, even "".
+      Recorded here because MassBank is where it was caught and compound-name
       search is a common entry point: verified 2026-08-14 on rdfs:label in the massbank graph,
       REGEX(STR(?n), "Fentanyl|Sufentanil") returns 0 while REGEX(STR(?n), "(Fentanyl)|(Sufentanil)")
       returns 30 and the "i"-flagged form returns 44. A real session read the 0 as "MassBank has no

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -107,20 +107,24 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
    ```
 
    The `^^xsd:string` is mandatory — without it the join silently returns 0.
-10. **Two-argument `REGEX()` ignores top-level alternation — 0 rows, no error.** Verified on
-    **all 10 endpoints** (2026-08-14) by a query that needs no data:
-    `VALUES ?s { "Fentanyl" "Sufentanil" "Aspirin" } FILTER(REGEX(?s, "Fentanyl|Sufentanil"))`
-    returns **0**, not 2. Even `"A|A"` returns 0. Either fix works:
+10. **Two-argument `REGEX()` silently mishandles some metacharacters — 0 rows, no error.**
+    **ALWAYS pass a third argument**; `""` is enough, `"i"` also folds case.
 
     ```sparql
-    FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))   # any third argument; "" is enough
-    FILTER(REGEX(?label, "(Fentanyl)|(Sufentanil)"))   # every branch parenthesised
+    FILTER(REGEX(?label, "Fentanyl|Sufentanil", ""))     # <- the fix, every time
     ```
 
-    `LCASE()`/`STR()` do not rescue it. Single terms, character classes (`Fent[a]nyl`) and
-    `.*`-anchored patterns are unaffected — so it only bites when you widen a *working*
-    single-term filter into an alternation, which reads as "the extra terms matched nothing."
-    A real session concluded MassBank had no fentanyls; it has 44.
+    Verified on **all 10 endpoints** (2026-08-14) by queries needing no data. Two constructs are
+    known broken in the 2-argument form, each returning **0** where the answer is not zero:
+    alternation — `VALUES ?s { "Fentanyl" "Sufentanil" } FILTER(REGEX(?s, "Fentanyl|Sufentanil"))`
+    → 0, want 2 (even `"A|A"` → 0); and brace quantifiers —
+    `VALUES ?s { "ab" "aab" "aaab" } FILTER(REGEX(?s, "a{1,2}b"))` → 0, want 3.
+    `LCASE()`/`STR()` do not rescue either. Parenthesising happens to fix both, but it needs you
+    to know *which* construct is affected — and the two above are what has been **tested**, not a
+    proof nothing else is. Unaffected: plain substrings, `[Ff]entanyl`, `? + *`, anchors, `.`,
+    escapes, `(?:…)`. That asymmetry is why it survives review: the filter works until someone
+    widens it to a family or adds a `{n,m}` count, and the empty result reads as "the database
+    doesn't have those." A production session concluded MassBank had no fentanyls; it has 44.
 
 ---
 

--- a/togo_mcp/data/resources/usage_guide_v6/04_reference.md
+++ b/togo_mcp/data/resources/usage_guide_v6/04_reference.md
@@ -30,7 +30,7 @@
 | 3rd consecutive SPARQL | Stop. Pivot to search / NCBI / TogoID / partial synthesis. |
 | Cross-DB SPARQL fails | Check endpoints; use TogoID or NCBI bridge. |
 | Empty SPARQL results | Use structured predicates from MIE; extract IRIs via search first. Typed literal missing (`^^xsd:string`)? Predicate applied to the wrong node? |
-| `REGEX` filter with `A\|B` returns nothing | Two-arg `REGEX()` drops top-level alternation on **every** endpoint. Add a third argument (`, ""`) or parenthesise each branch: `(A)\|(B)`. See SILENT-FAILURE TRAPS #10. |
+| `REGEX` filter returns nothing (pattern uses `A\|B` or `{n,m}`) | Two-arg `REGEX()` mishandles alternation and brace quantifiers on **every** endpoint. Always pass a third argument: `REGEX(?x, "A\|B", "")`. See SILENT-FAILURE TRAPS #10. |
 | SPARQL timeout | Add LIMIT; replace `bif:contains` with structured IRIs. |
 | Wrong count | Master reactions only? Correct keyword IRI (not EC prefix)? |
 | **Count inflated** (2×, 4×, 8×) — or right but unproven | Co-tenancy. `GRAPH ?g` the pattern with its subject bound: >1 graph → re-declared; none of yours → foreign predicate, i.e. a silent intersection. Pin **every** pattern. `DISTINCT` hides it, doesn't fix it. |

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.2"
+version = "2.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch release. **No tool, parameter, or return shape changed.**

Answering "is any MIE inconsistent with 2.7.2's fix?" found **no inconsistency in the corpus** — the only executable `REGEX` alternation anywhere was massbank's already-safe 3-arg form, and the benchmark has none, so no gold answer was at risk. But checking the *mechanism* rather than only grepping for the symptom showed **2.7.2's rule was itself wrong**.

## Alternation was not the only broken construct

```sparql
VALUES ?s { "ab" "aab" "aaab" }  FILTER(REGEX(?s, "a{1,2}b"))   -- returns 0. The answer is 3.
```

Brace quantifiers fail as `{n}`, `{n,}` and `{n,m}`, on the same **10 of 10** endpoints. Alternation fails as `A|B`, `A|B|C`, one-sided `A|`, and `A|A`. Both are consistent with Virtuoso taking a "looks literal" fast path that mis-parses certain metacharacters — so the two known-broken constructs are what has been **tested**, not a proof nothing else is affected.

## The rule is now "always pass a third argument", full stop

2.7.2 offered parenthesising and the flags argument as equal fixes. Parenthesising does fix both known cases, but it requires the author to know *which* metacharacter is affected — precisely the knowledge the trap denies them — and does nothing for an untested construct. The flags argument is unconditional and costs three characters.

The unaffected list (plain substrings, `[Ff]entanyl`, `? + *`, anchors, `.`, escapes, `(?:…)`) stays, because that asymmetry is *why* the bug survives review: a single-term filter works until someone widens it to a family or adds a count.

## Enforced, not advised

`tests/test_regex_two_arg_guard.py` bans the 2-arg form in any executable `sparql` field across all 37 MIEs, and asserts the guide still documents the fix and both broken constructs. Static rather than live, for two reasons:

- `check_mie_examples.py` flags zero-**row** results, so it sees a broken `REGEX` only when that filter zeroes the *whole* query. Inside an `OPTIONAL` or one `UNION` branch it returns rows — just silently fewer — and nothing notices.
- A live test would pass the day an endpoint is patched, which is exactly when the corpus should still be written defensively.

It found **hco** immediately. The ad-hoc grep that preceded it did not, because that grep only looked for patterns containing `|`.

## Changed

- **hco: `bands_on_arm` (`"^13q"`) and `position_to_band` (`"^13[pq]"`)** — these were **not** broken (anchors and character classes are unaffected) and both re-run to their stored figures exactly: 32 rows, and 13q14.2 / gpos50 / 46700001 / 50300000. Dates re-stamped. They change because they are one edit from `"^13p|^13q"`.
- **massbank + guide + skill** updated to the corrected, narrower prescription.

## Validation

- `uv run pytest` → **462 passed** (was 423; +37 parametrised MIE cases +2)
- `check_mie_examples.py hco` → 8 ok / 0 zero-row / 0 error
- Corpus re-scan: zero 2-arg `REGEX` in executable SPARQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)