### PR TITLE
release: 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.4] - 2026-08-15
+
+Closes the last gap in the 2.7.1–2.7.3 arc: the Usage Guide is served on **every** session and nothing
+ever checked what it asserts. No tool, parameter, or return shape changed.
+
+The literal task — "test the SPARQL queries in the Usage Guide" — turned out to be nearly empty. The
+guide contains exactly **two** fenced `sparql` blocks and neither is a runnable query; both are
+fragments (a triple pattern, a `FILTER`). The guide's testable surface is not queries but **empirical
+claims**: *"without `^^xsd:string` the join silently returns 0"*, *"pinning only `.../uniprot` returns
+empty for a taxon-name leg"*, *"two-argument `REGEX()` returns 0 for alternation"*. Each is a statement
+about live endpoint behaviour, each is what the surrounding advice rests on, and each rots silently
+when an endpoint is reloaded. (The one hand-written table, ENDPOINTS, was already drift-guarded by
+`test_server.py` — no second copy added.)
+
+### Added
+
+- **`scripts/check_guide_claims.py` — 6 claims, all passing.** Each is encoded as a *pair* of queries
+  plus the expected relationship, almost always "the documented-broken form returns 0 **and** the
+  documented-good form does not". That is stronger than either half: it fails loudly both when a trap
+  disappears (endpoint patched → the guide now scares readers off a working pattern) and when a
+  workaround stops working (→ the guide's fix is wrong). Covers guide items 1, 7, 9 and 10. A script
+  rather than a pytest test, for the same reason `check_mie_examples.py` is: these endpoints returned
+  502s, 503s and 90 s timeouts repeatedly across a single afternoon, so a live test in the suite would
+  go red for reasons unrelated to any change.
+- **`tests/test_guide_claims_in_sync.py`** — offline, 9 cases. Every claim carries an `anchor`: the
+  load-bearing phrase that must still appear in the served guide. This closes the drift in *both*
+  directions, both otherwise silent — guide rewritten and the checker keeps happily verifying a
+  sentence nobody ships (still reporting "6 ok"), or a claim quietly dropped from the checker while the
+  guide keeps asserting it. It caught a defect on its first run: an anchor written from memory that
+  spanned a hard-wrapped line. Anchors must now stay within one source line, and that is noted where
+  they are defined.
+
+### Fixed
+
+- **Guide item 7 cited two examples that no longer show what it said they showed.** It claimed
+  `GO_0005183` and `CHEBI:29108` carry labels "twice — plain and `xsd:string`". Live, both carry
+  **only** `xsd:string`: `GO_0005183` in 2 graphs (efo, go) and `CHEBI_29108` in 5 (Rhea, efo, uberon,
+  pro, pro-reasoned), same value and same datatype every time. That is cross-graph *duplication* —
+  item 1's co-tenancy trap — not a datatype split, so the two IRIs were illustrating the wrong lesson.
+  The rule itself is sound and stays: the item is re-anchored on a case that is live and checked,
+  `ontology/fma`'s `rdfs:label` at **104,919 `@en` + 17 `xsd:string`** in one graph on one predicate,
+  and widened past plain-vs-typed to the forms the corpus actually contains (`@en`, `^^xsd:anyURI`,
+  `^^rr:Literal`).
+
 ## [2.7.3] - 2026-08-14
 
 **2.7.2's rule was too narrow, and one of the two fixes it offered was bad advice.** Asking "is any MIE
@@ -1447,7 +1491,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.3...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.4...HEAD
+[2.7.4]: https://github.com/dbcls/togomcp/compare/v2.7.3...v2.7.4
 [2.7.3]: https://github.com/dbcls/togomcp/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/dbcls/togomcp/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/dbcls/togomcp/compare/v2.7.0...v2.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.3"
+version = "2.7.4"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/scripts/check_guide_claims.py
+++ b/scripts/check_guide_claims.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Live claim-checker for the TogoMCP Usage Guide.
+
+`check_mie_examples.py` runs the queries agents copy out of MIE files. Nothing ran
+the assertions the *Usage Guide* makes — and the guide is the one document served
+on every session, so a stale claim there is repeated to every client until someone
+notices by hand.
+
+Grepping the guide for ```sparql blocks finds almost nothing (two fragments, neither
+runnable). The guide's testable surface is not queries but **empirical claims**:
+"without `^^xsd:string` the join silently returns 0", "pinning only .../uniprot
+returns empty for a taxon-name leg", "two-argument REGEX() returns 0 for alternation".
+Each is a statement about live endpoint behaviour, each is what the surrounding advice
+rests on, and each rots silently when an endpoint is reloaded or patched.
+
+So each claim below is encoded as a pair of queries and an expected relationship
+between them — usually "the documented-broken form returns 0 AND the documented-good
+form does not", which is stronger than either half alone: it fails loudly both when a
+trap disappears (endpoint fixed → the guide now scares people off a working pattern)
+and when a workaround stops working (→ the guide's fix is wrong).
+
+Two deliberate design choices:
+
+  * **A script, not a pytest test.** These endpoints are genuinely unreliable — a
+    single afternoon's work hit 502s, 503s and 90 s timeouts repeatedly — so a live
+    test in the suite would go red for reasons unrelated to any change. Same reason
+    `check_mie_examples.py` is a script. Run it at release time.
+  * **Anchored to the guide text.** Every claim carries an `anchor` — a substring that
+    must still appear in the guide. `tests/test_guide_claims_in_sync.py` enforces it
+    offline, so a rewrite of the guide cannot leave this script confidently verifying
+    a claim the guide no longer makes.
+
+Usage:
+    uv run python scripts/check_guide_claims.py            # all claims
+    uv run python scripts/check_guide_claims.py --id regex_2arg_alternation
+    uv run python scripts/check_guide_claims.py --list
+
+Exit status is the number of failed claims (0 = all good). NET-FAIL (endpoint
+unreachable) is reported separately and does NOT count as a failure — same
+convention as check_mie_examples.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ENDPOINTS_CSV = REPO / "togo_mcp" / "data" / "resources" / "endpoints.csv"
+
+XSD = "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
+RDFS = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
+
+
+def endpoint_url(name: str) -> str:
+    """Resolve an endpoint_name (primary, sib, ebi, …) to its URL from the registry."""
+    with open(ENDPOINTS_CSV, encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            if row["endpoint_name"] == name:
+                return row["endpoint_url"]
+    raise SystemExit(f"unknown endpoint_name {name!r} in {ENDPOINTS_CSV}")
+
+
+def _count(body: str) -> int | None:
+    """Parse a single-column, single-row CSV count."""
+    rows = [r for r in body.strip().split("\n") if r.strip()]
+    if len(rows) < 2:
+        return None
+    try:
+        return int(rows[1].strip().strip('"'))
+    except ValueError:
+        return None
+
+
+def run(url: str, query: str, tries: int = 4, timeout: int = 90) -> tuple[str | None, str]:
+    """Return (body, error). Retries gateway blips, which are endemic on these hosts."""
+    last = ""
+    for attempt in range(tries):
+        data = urllib.parse.urlencode({"query": query}).encode()
+        req = urllib.request.Request(url, data=data, headers={"Accept": "text/csv"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read().decode("utf-8", "replace")
+            if "502 Bad Gateway" in body[:300] or "503 Service" in body[:300]:
+                raise RuntimeError("gateway 5xx")
+            return body, ""
+        except urllib.error.HTTPError as exc:
+            last = f"HTTP {exc.code}"
+        except Exception as exc:  # noqa: BLE001 — network layer, any failure is a retry
+            last = f"{type(exc).__name__}: {exc}"
+        if attempt < tries - 1:
+            time.sleep(15)
+    return None, last
+
+
+# ---------------------------------------------------------------------------
+# The claims. Each `check` receives a callable `q(query) -> body` and returns
+# (ok: bool, detail: str). All figures verified live 2026-08-14.
+# ---------------------------------------------------------------------------
+
+VALS_ALT = '"Fentanyl" "Sufentanil" "Aspirin"'
+VALS_BRACE = '"ab" "aab" "aaab" "xyz"'
+
+
+def _regex_pair(q, values: str, pattern: str, expected: int):
+    two = q(f'SELECT (COUNT(*) AS ?n) WHERE {{ VALUES ?s {{ {values} }} '
+            f'FILTER(REGEX(?s, "{pattern}")) }}')
+    three = q(f'SELECT (COUNT(*) AS ?n) WHERE {{ VALUES ?s {{ {values} }} '
+              f'FILTER(REGEX(?s, "{pattern}", "")) }}')
+    a, b = _count(two), _count(three)
+    ok = a == 0 and b == expected
+    return ok, f"2-arg={a} (guide: 0), 3-arg={b} (guide: {expected})"
+
+
+CLAIMS: list[dict] = [
+    {
+        "id": "regex_2arg_alternation",
+        "endpoint": "primary",
+        "anchor": 'FILTER(REGEX(?s, "Fentanyl|Sufentanil"))',
+        "says": "two-argument REGEX() returns 0 for alternation; a third argument fixes it",
+        "check": lambda q: _regex_pair(q, VALS_ALT, "Fentanyl|Sufentanil", 2),
+    },
+    {
+        "id": "regex_2arg_brace",
+        "endpoint": "primary",
+        "anchor": "a{1,2}b",
+        "says": "two-argument REGEX() returns 0 for brace quantifiers; a third argument fixes it",
+        "check": lambda q: _regex_pair(q, VALS_BRACE, "a{1,2}b", 3),
+    },
+    {
+        "id": "regex_unaffected_constructs",
+        "endpoint": "primary",
+        "anchor": "Unaffected: plain substrings",
+        "says": "character classes and anchors are NOT affected by the two-argument form",
+        "check": lambda q: (
+            lambda cls, anc: (
+                cls == 1 and anc == 1,
+                f"[Ff]entanyl={cls} (want 1), ^Aspirin$={anc} (want 1)",
+            )
+        )(
+            _count(q(f'SELECT (COUNT(*) AS ?n) WHERE {{ VALUES ?s {{ {VALS_ALT} }} '
+                     f'FILTER(REGEX(?s, "[Ff]entanyl")) }}')),
+            _count(q(f'SELECT (COUNT(*) AS ?n) WHERE {{ VALUES ?s {{ {VALS_ALT} }} '
+                     f'FILTER(REGEX(?s, "^Aspirin$")) }}')),
+        ),
+    },
+    {
+        "id": "reactome_typed_literal",
+        "endpoint": "ebi",
+        "anchor": "The `^^xsd:string` is mandatory",
+        "says": "the Reactome BioPAX xref join needs ^^xsd:string; the plain form returns 0",
+        "check": lambda q: (
+            lambda typed, plain: (
+                typed == 1 and plain == 0,
+                f"typed={typed} (want 1), plain={plain} (guide: 0)",
+            )
+        )(
+            _count(q(f'''{XSD}
+                PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+                SELECT (COUNT(*) AS ?n) FROM <http://rdf.ebi.ac.uk/dataset/reactome>
+                WHERE {{ ?p bp:xref [ bp:db "Reactome"^^xsd:string ;
+                                      bp:id "R-HSA-196807"^^xsd:string ] }}''')),
+            _count(q(f'''{XSD}
+                PREFIX bp: <http://www.biopax.org/release/biopax-level3.owl#>
+                SELECT (COUNT(*) AS ?n) FROM <http://rdf.ebi.ac.uk/dataset/reactome>
+                WHERE {{ ?p bp:xref [ bp:db "Reactome" ; bp:id "R-HSA-196807" ] }}''')),
+        ),
+    },
+    {
+        "id": "uniprot_taxon_needs_taxonomy_graph",
+        "endpoint": "sib",
+        # NB: anchors are matched against the raw markdown, which is hard-wrapped —
+        # keep every anchor within a single source line.
+        "anchor": "`scientificName`/`rank` live in `.../taxonomy`",
+        "says": "pinning only .../uniprot returns empty for a taxon-name leg; .../taxonomy has it",
+        "check": lambda q: (
+            lambda up, tax: (
+                up == 0 and tax >= 1,
+                f"pinned-uniprot={up} (guide: 0), pinned-taxonomy={tax} (want >=1)",
+            )
+        )(
+            _count(q('''PREFIX up: <http://purl.uniprot.org/core/>
+                SELECT (COUNT(*) AS ?n) FROM <http://sparql.uniprot.org/uniprot>
+                WHERE { <http://purl.uniprot.org/taxonomy/9606> up:scientificName ?x }''')),
+            _count(q('''PREFIX up: <http://purl.uniprot.org/core/>
+                SELECT (COUNT(*) AS ?n) FROM <http://sparql.uniprot.org/taxonomy>
+                WHERE { <http://purl.uniprot.org/taxonomy/9606> up:scientificName ?x }''')),
+        ),
+    },
+    {
+        "id": "mixed_literal_forms_need_str",
+        "endpoint": "primary",
+        "anchor": "Normalize literals with `STR(?label)`",
+        "says": "one predicate in one graph carries mixed literal forms, so GROUP BY splits it "
+                "(ontology/fma rdfs:label: ~104,919 @en + 17 xsd:string)",
+        "check": lambda q: (
+            lambda tagged, typed: (
+                tagged > 1000 and typed > 0,
+                f"@en={tagged} (want >1000), xsd:string={typed} (want >0) — both forms must coexist",
+            )
+        )(
+            _count(q(f'''{RDFS}
+                SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/ontology/fma>
+                WHERE {{ ?s rdfs:label ?l . FILTER(LANG(?l) = "en") }}''')),
+            _count(q(f'''{XSD}
+                {RDFS}
+                SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/ontology/fma>
+                WHERE {{ ?s rdfs:label ?l . FILTER(DATATYPE(?l) = xsd:string) }}''')),
+        ),
+    },
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--id", action="append", help="check only these claim ids (repeatable)")
+    ap.add_argument("--list", action="store_true", help="list claim ids and exit")
+    args = ap.parse_args()
+
+    if args.list:
+        for claim in CLAIMS:
+            print(f"{claim['id']:34} [{claim['endpoint']:8}] {claim['says']}")
+        return 0
+
+    selected = [c for c in CLAIMS if not args.id or c["id"] in args.id]
+    if not selected:
+        print(f"no claim matched {args.id}", file=sys.stderr)
+        return 2
+
+    ok_n = fail_n = net_n = 0
+    failures: list[str] = []
+    for claim in selected:
+        url = endpoint_url(claim["endpoint"])
+        net_error: list[str] = []
+
+        def q(query: str) -> str:
+            body, err = run(url, query)
+            if body is None:
+                net_error.append(err)
+                return ""
+            return body
+
+        try:
+            passed, detail = claim["check"](q)
+        except Exception as exc:  # noqa: BLE001 — a malformed claim is a claim failure
+            passed, detail = False, f"checker raised {type(exc).__name__}: {exc}"
+
+        if net_error:
+            net_n += 1
+            print(f"  ~  {claim['id']:34} NET-FAIL ({net_error[0]}) — endpoint unreachable")
+        elif passed:
+            ok_n += 1
+            print(f"  ok {claim['id']:34} {detail}")
+        else:
+            fail_n += 1
+            print(f"  XX {claim['id']:34} {detail}")
+            failures.append(f"{claim['id']}: {claim['says']}\n      observed: {detail}")
+
+    print("\n" + "=" * 70)
+    print(f"GUIDE CLAIM CHECK — {ok_n} ok, {fail_n} failed, {net_n} net-fail")
+    print("=" * 70)
+    if failures:
+        print("\nFAILED — the guide asserts something the endpoint no longer does:")
+        for line in failures:
+            print(f"    {line}")
+        print("\n  Fix the guide (usage_guide_v6/), not this script — unless the claim was "
+              "always wrong, in which case fix both.")
+    return min(fail_n, 125)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_guide_claims_in_sync.py
+++ b/tests/test_guide_claims_in_sync.py
@@ -1,0 +1,86 @@
+"""Drift guard: `scripts/check_guide_claims.py` must keep checking what the guide says.
+
+The claim-checker is a live script (endpoints are too unreliable for CI), so it runs
+at release time — which leaves a gap this test fills. Each claim in that script names
+an `anchor`: a substring that must still appear in the served Usage Guide. Without
+this test the two can drift apart in both directions, and both are silent:
+
+* **Guide edited, script not.** Someone rewrites the co-tenancy section; the checker
+  keeps verifying a sentence nobody ships any more and keeps reporting "6 ok". The
+  release passes while the guide's actual claims go unchecked.
+* **Script edited, guide not.** A claim is dropped from the checker because it was
+  awkward to run; the guide keeps asserting it to every client with nothing watching.
+
+Anchoring is deliberately textual rather than structural. The guide is prose — there
+is no id to key on — and the anchor is chosen to be the load-bearing phrase of the
+claim, so an edit that changes the *meaning* almost always changes the anchor, while
+reflowing a paragraph does not.
+
+This test is offline and never touches the network. Whether the claims are still TRUE
+is the script's job: `uv run python scripts/check_guide_claims.py`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+GUIDE_DIR = REPO / "togo_mcp" / "data" / "resources" / "usage_guide_v6"
+CHECKER = REPO / "scripts" / "check_guide_claims.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_guide_claims", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def checker():
+    assert CHECKER.exists(), f"missing {CHECKER}"
+    return _load_checker()
+
+
+@pytest.fixture(scope="module")
+def guide_text() -> str:
+    parts = [p.read_text(encoding="utf-8") for p in sorted(GUIDE_DIR.glob("*.md"))]
+    assert parts, f"no guide sections found in {GUIDE_DIR}"
+    return "\n".join(parts)
+
+
+def test_checker_has_claims(checker):
+    """Guard the guard: an empty CLAIMS list would make the anchor test vacuous."""
+    assert len(checker.CLAIMS) >= 5, f"expected the full claim set, got {len(checker.CLAIMS)}"
+
+
+def test_claim_ids_are_unique(checker):
+    ids = [c["id"] for c in checker.CLAIMS]
+    assert len(ids) == len(set(ids)), f"duplicate claim ids: {ids}"
+
+
+def test_every_claim_endpoint_is_registered(checker):
+    """A claim pointed at an endpoint that left the registry can never run."""
+    for claim in checker.CLAIMS:
+        # raises SystemExit if the endpoint_name is unknown
+        assert checker.endpoint_url(claim["endpoint"]).startswith("http"), claim["id"]
+
+
+@pytest.mark.parametrize(
+    "claim_id,anchor",
+    [(c["id"], c["anchor"]) for c in _load_checker().CLAIMS],
+)
+def test_claim_anchor_still_in_guide(claim_id: str, anchor: str, guide_text: str):
+    """The guide must still make the claim the checker verifies."""
+    assert anchor in guide_text, (
+        f"claim {claim_id!r} anchors on text that is no longer in the Usage Guide:\n"
+        f"    {anchor!r}\n"
+        "  Either the guide was edited and the claim needs updating/removing in "
+        "scripts/check_guide_claims.py, or the anchor needs re-pointing at the "
+        "rewritten sentence. Do not just delete the claim — first check whether the "
+        "guide still asserts it in different words."
+    )

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -88,11 +88,14 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
    an **older nomenclature vintage** (Proteobacteria *and* Pseudomonadota), and
    "Superkingdom Bacteria" survives **only** there — the authoritative graph has an empty
    rank IRI since NCBI retired "superkingdom". Blind pinning turns correct answers wrong.
-7. **Normalize literals with `STR(?label)`.** Some labels exist twice — plain and
-   `xsd:string`. Distinct RDF terms, so `DISTINCT` won't collapse them and `GROUP BY`
-   splits the group (`GO_0005183`, `CHEBI:29108`). Scan every quoted literal against the
-   MIE's `global_gotchas` and the chosen example's `traps_avoided`; `VALUES` blocks are
-   the worst spot.
+7. **Normalize literals with `STR(?label)`.** One predicate in one graph can carry
+   **mixed literal forms** — plain, `^^xsd:string`, `@en`, or something rarer
+   (`^^xsd:anyURI`, `^^rr:Literal`). They are distinct RDF terms, so `DISTINCT` won't
+   collapse them, `GROUP BY` splits the group, and an exact match on the wrong form
+   returns 0 with no error. Live: `ontology/fma`'s `rdfs:label` is **104,919 `@en` +
+   17 `xsd:string`** — a bare `?s rdfs:label "…"` match reaches at most one of those
+   populations. Scan every quoted literal against the MIE's `global_gotchas` and the
+   chosen example's `traps_avoided`; `VALUES` blocks are the worst spot.
 8. **Never write a `VALUES` block you did not populate from a query you ran.** An
    **empty** one is *valid SPARQL* — it returns one row of `0` instead of erroring. An
    abridged one ("representative", "…") computes a well-shaped number from the wrong set.

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.3"
+version = "2.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch release. **No tool, parameter, or return shape changed.** Closes the last gap in the 2.7.1–2.7.3 arc: the Usage Guide is served on **every** session and nothing ever checked what it asserts.

## The literal task was nearly empty

The guide contains exactly **two** fenced `sparql` blocks, and neither is a runnable query — both are fragments (a triple pattern, a `FILTER`). Its testable surface is not queries but **empirical claims**:

- *"The `^^xsd:string` is mandatory — without it the join silently returns 0"*
- *"pinning only `.../uniprot` returns **empty** for a taxon-name leg (silent)"*
- *"two-argument `REGEX()` returns 0 for alternation / brace quantifiers"*

Each is a statement about live endpoint behaviour, each is what the surrounding advice rests on, and each rots silently when an endpoint is reloaded. The one hand-written table (ENDPOINTS) was **already** drift-guarded by `test_server.py:413` — no second copy added.

## Added

**`scripts/check_guide_claims.py` — 6 claims, all passing** (guide items 1, 7, 9, 10):

```
ok regex_2arg_alternation             2-arg=0 (guide: 0), 3-arg=2 (guide: 2)
ok regex_2arg_brace                   2-arg=0 (guide: 0), 3-arg=3 (guide: 3)
ok regex_unaffected_constructs        [Ff]entanyl=1 (want 1), ^Aspirin$=1 (want 1)
ok reactome_typed_literal             typed=1 (want 1), plain=0 (guide: 0)
ok uniprot_taxon_needs_taxonomy_graph pinned-uniprot=0 (guide: 0), pinned-taxonomy=1 (want >=1)
ok mixed_literal_forms_need_str       @en=104919 (want >1000), xsd:string=17 (want >0)
```

Each claim is a **pair** of queries plus the expected relationship — almost always "the documented-broken form returns 0 **and** the documented-good form does not". That is stronger than either half: it fails loudly both when a trap disappears (endpoint patched → the guide now scares readers off a working pattern) **and** when a workaround stops working (→ the guide's fix is wrong).

A script rather than a pytest test, for the same reason `check_mie_examples.py` is one: these endpoints returned 502s, 503s and 90 s timeouts repeatedly across a single afternoon, so a live test in the suite would go red for reasons unrelated to any change.

**`tests/test_guide_claims_in_sync.py`** — offline, 9 cases. Every claim carries an `anchor`: the load-bearing phrase that must still appear in the served guide. This closes drift in *both* directions, both otherwise silent — guide rewritten while the checker keeps verifying a sentence nobody ships (still reporting "6 ok"), or a claim quietly dropped while the guide keeps asserting it. **It caught a defect on its first run**: an anchor written from memory that spanned a hard-wrapped line.

## Fixed

**Guide item 7 cited two examples that no longer show what it said they showed.** It claimed `GO_0005183` and `CHEBI:29108` carry labels "twice — plain and `xsd:string`". Live, both carry **only** `xsd:string` — `GO_0005183` in 2 graphs (efo, go), `CHEBI_29108` in 5 (Rhea, efo, uberon, pro, pro-reasoned), same value and same datatype every time. That is cross-graph *duplication*, i.e. item 1's co-tenancy trap, not a datatype split: the two IRIs were illustrating the wrong lesson.

The rule itself is sound and stays. The item is re-anchored on a case that is live **and now checked** — `ontology/fma`'s `rdfs:label` at **104,919 `@en` + 17 `xsd:string`**, one graph, one predicate — and widened past plain-vs-typed to the forms the corpus actually contains (`@en`, `^^xsd:anyURI`, `^^rr:Literal`).

## Validation

- `uv run python scripts/check_guide_claims.py` → **6 ok, 0 failed, 0 net-fail**
- `uv run pytest` → **471 passed** (was 462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)