### PR TITLE
release: 2.7.5 — add the MIE v3 report to README and the landing page

### DIFF
--- a/.claude/skills/intro-page-updater/references/make_intro.md
+++ b/.claude/skills/intro-page-updater/references/make_intro.md
@@ -8,7 +8,7 @@ It is developed by DBCLS.
 Create an HTML page for researchers in biology and medicine who are not necessarily familiar with bioinformatics, explaining what TogoMCP is and how it can help their research. It should contain the following.
 - Summary of TogoMCP
 - What's new
-- Publication
+- Publications
 - Usage examples
 - Setup guide
 - List of available databases
@@ -28,12 +28,16 @@ A short, curated list of the most recent **user-facing** updates (new databases,
   Include only what a *user* would notice; skip internal refactors/tests. Then run `python scripts/generate_whatsnew.py`. The `whatsnew.yml` CI + `tests/test_whatsnew_in_sync.py` fail if the page is stale.
 - End with a "Full changelog →" link to `https://github.com/dbcls/togomcp/blob/main/CHANGELOG.md`.
 
-## Publication
-Cite the paper using the reference from the top-level `README.md`:
+## Publications
+Cite the papers using the references from the top-level `README.md`. The **system paper** comes first — it is the one to cite for TogoMCP itself:
 
 > Kinjo, A. R., Yamamoto, Y., Bustamante-Larriet, S., Labra-Gayo, J.-E., & Fujisawa, T. (2026). TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol. *Database* **2026**:baag042. https://doi.org/10.1093/database/baag042
 
-Link the DOI. Include the authors, year, and journal as shown.
+The **MIE v3 report** follows, with a short plain-prose note on what it measured (the ablation result behind the MIE format this server now serves):
+
+> Kinjo, A. R., & Yamamoto, Y. (2026). Measure before you rewrite: ablation-driven redesign of LLM-facing RDF schema documentation in TogoMCP. *BioHackrXiv*. https://doi.org/10.37044/osf.io/6v5ra_v1
+
+Link every DOI. Include the authors, year, and journal as shown.
 
 ## Style
 - Use https://togomcp.rdfportal.org/ as a template.
@@ -154,7 +158,7 @@ The footer should include the following
 - The menu tab should include the pointers to all the sections.
   * Summary
   * What's New
-  * Publication
+  * Publications
   * Examples
   * Setup
   * Databases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.5] - 2026-08-17
+
+<!-- whatsnew: 2026-07-26 | Second paper out: <em>Measure before you rewrite</em> (<a href="https://doi.org/10.37044/osf.io/6v5ra_v1" target="_blank" rel="noopener">BioHackrXiv</a>) — the ablation study behind MIE v3, the schema-documentation format this server serves. -->
+
+Citation-only release. No tool, parameter, or return shape changed — but the landing page is served
+from the wheel (`server.py` mounts `docs/togomcp-intro.html` at `/`), so the second paper does not
+reach <https://togomcp.rdfportal.org/> without a build and deploy. That is the whole reason this
+carries a version bump rather than riding as a docs-only merge.
+
+The whatsnew marker is dated 2026-07-26, the BioHackrXiv publication date, so it sorts *below* the
+five entries the generator renders and does not appear in "What's New". That is deliberate: the
+citation belongs in the Publications section, not the news feed. Redate it to surface it.
+
+### Documentation
+
+- **README + intro page: added the MIE v3 report** (Kinjo & Yamamoto 2026, BioHackrXiv,
+  [doi:10.37044/osf.io/6v5ra_v1](https://doi.org/10.37044/osf.io/6v5ra_v1)) alongside the
+  *Database* system paper. It is the published measurement behind the format `get_MIE_file`
+  currently serves: single-section and group-level MIE ablations are null, whole-MIE removal
+  costs 0.9/20, and the query-construction group alone recovers 99% of that — which is why v3
+  reorganized around the verified executable example. Both surfaces now read "Publications"
+  (plural); the intro page's spec (`make_intro.md`) was updated to match.
+
 ## [2.7.4] - 2026-08-15
 
 Closes the last gap in the 2.7.1–2.7.3 arc: the Usage Guide is served on **every** session and nothing
@@ -1491,7 +1514,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.4...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.5...HEAD
+[2.7.5]: https://github.com/dbcls/togomcp/compare/v2.7.4...v2.7.5
 [2.7.4]: https://github.com/dbcls/togomcp/compare/v2.7.3...v2.7.4
 [2.7.3]: https://github.com/dbcls/togomcp/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/dbcls/togomcp/compare/v2.7.1...v2.7.2

--- a/README.md
+++ b/README.md
@@ -298,9 +298,17 @@ Note that a database *removal* really is just step 1: nothing validates against 
 
 Please open an issue or pull request on GitHub.
 
-## Reference
+## References
+
+**The system paper** — describes TogoMCP as a whole (based on MIE v2):
 
 Kinjo, A. R., Yamamoto, Y., Bustamante-Larriet, S., Labra-Gayo, J.-E., & Fujisawa, T. (2026). TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol. *Database* **2026**:baag042. https://doi.org/10.1093/database/baag042
+
+**The MIE v3 report** — the ablation study behind the current MIE format. Removing any single MIE section (or any whole functional group) turned out to be statistically null, while removing the MIE entirely cost 0.9 points out of 20 — heavy redundancy, with the query-construction content alone recovering 99% of the total effect. MIE v3 reorganizes around that evidence, matching v2 answer quality at n=100 benchmark questions while using 15% fewer input tokens and running 6% faster:
+
+Kinjo, A. R., & Yamamoto, Y. (2026). Measure before you rewrite: ablation-driven redesign of LLM-facing RDF schema documentation in TogoMCP. *BioHackrXiv*. https://doi.org/10.37044/osf.io/6v5ra_v1
+
+The measured version of the server is archived as release v2.0.0: https://doi.org/10.5281/zenodo.21543297
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.4"
+version = "2.7.5"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -691,7 +691,7 @@
   <ul>
     <li><a href="#summary">Summary</a></li>
     <li><a href="#whats-new">What's New</a></li>
-    <li><a href="#publication">Publication</a></li>
+    <li><a href="#publication">Publications</a></li>
     <li><a href="#examples">Examples</a></li>
     <li><a href="#setup">Setup</a></li>
     <li><a href="#databases">Databases</a></li>
@@ -799,8 +799,8 @@
 <section id="publication">
   <div class="container">
     <div class="section-header">
-      <h2 class="section-title">Publication</h2>
-      <p class="section-lead">TogoMCP is described in the following paper. Please cite it if you use TogoMCP in your research.</p>
+      <h2 class="section-title">Publications</h2>
+      <p class="section-lead">TogoMCP is described in the following papers. Please cite the system paper if you use TogoMCP in your research.</p>
     </div>
     <div class="summary-card">
       <p style="font-size:14px;color:#444;line-height:1.8;">
@@ -808,6 +808,19 @@
         <strong>TogoMCP: Natural Language Querying of Life-Science Knowledge Graphs via Schema-Guided LLMs and the Model Context Protocol</strong>.
         <em>Database</em> <strong>2026</strong>:baag042.
         <a href="https://doi.org/10.1093/database/baag042" target="_blank" rel="noopener">https://doi.org/10.1093/database/baag042</a>
+      </p>
+      <p style="font-size:14px;color:#444;line-height:1.8;margin-top:18px;">
+        Kinjo, A. R., &amp; Yamamoto, Y. (2026).
+        <strong>Measure before you rewrite: ablation-driven redesign of LLM-facing RDF schema documentation in TogoMCP</strong>.
+        <em>BioHackrXiv</em>.
+        <a href="https://doi.org/10.37044/osf.io/6v5ra_v1" target="_blank" rel="noopener">https://doi.org/10.37044/osf.io/6v5ra_v1</a>
+      </p>
+      <p style="font-size:13px;color:#666;line-height:1.7;margin-top:10px;">
+        The second report measures what the per-database schema documents (MIE files) actually contribute to answer quality.
+        Removing any single MIE section &mdash; or any whole functional group &mdash; is statistically null, while removing the
+        MIE entirely costs 0.9 points out of 20; the query-construction content alone recovers 99% of that effect.
+        MIE v3, the format now served by this server, was reorganized around that evidence: same answer quality over 100
+        benchmark questions, 15% fewer input tokens, 6% faster.
       </p>
     </div>
   </div>

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.4"
+version = "2.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Citation-only release. **No tool, parameter, or return shape changed.**

Adds the second paper — Kinjo & Yamamoto (2026), *Measure before you rewrite: ablation-driven redesign of LLM-facing RDF schema documentation in TogoMCP*, BioHackrXiv, [doi:10.37044/osf.io/6v5ra_v1](https://doi.org/10.37044/osf.io/6v5ra_v1) — next to the *Database* system paper on both public surfaces.

**Why this carries a version bump instead of riding as a docs-only merge:** `server.py` mounts `docs/togomcp-intro.html` at `/`, so the landing page ships inside the wheel. Without a build and deploy, https://togomcp.rdfportal.org/ keeps showing one paper.

### Changes

- `README.md` — `## Reference` → `## References`; system paper marked as MIE v2-based, MIE v3 report added with a one-paragraph summary of what it measured, plus the Zenodo v2.0.0 snapshot it was measured against.
- `togo_mcp/data/docs/togomcp-intro.html` — Publication section → "Publications" (sticky-nav label too), second citation plus a short plain-prose note on the ablation result.
- `.claude/skills/intro-page-updater/references/make_intro.md` — spec updated to match the now-two-entry section (heading, TOC, menu-tab list).
- `CHANGELOG.md` — dated `[2.7.5]` section + compare link.

### Note on "What's New"

The whatsnew marker is dated `2026-07-26` (the BioHackrXiv publication date), so it sorts below the five entries `generate_whatsnew.py` renders and does **not** appear on the page. Deliberate — the citation belongs in Publications, not the news feed. Redate the marker if we want to announce it there.

### Verification

`uv run pytest` — 471 passed. `generate_whatsnew.py --check` — in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)