### PR TITLE
release: 2.7.7 — raw client IP in the tool-call log (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,12 +67,24 @@ TZ=Asia/Tokyo
 # TOGOMCP_STATS_EXCLUDE_CLIENTS=mcp,glyconavi
 # TOGOMCP_STATS_EXCLUDE_CLIENTS_TEST=mcp,glyconavi
 
-# Optional: salt for hashing client IPs in the log (IPs are never stored raw).
-# Set a stable value to hash the same IP identically across restarts within a
-# retention window; unset = randomized per process (hashes not linkable across
-# restarts — strictly more private).
+# Optional: salt for hashing client IPs in the log. Set a stable value to hash
+# the same IP identically across restarts within a retention window; unset =
+# randomized per process (hashes not linkable across restarts — strictly more
+# private). The hash (`ip_hash`) is written whenever logging is on, and is the
+# field /stats aggregates on.
 # TOGOMCP_LOG_HASH_SALT=
 # TOGOMCP_LOG_HASH_SALT_TEST=
+
+# Optional: ALSO record the client IP in the clear, as `ip`, alongside the hash
+# (1/true/yes/on). Off by default. Turn it on only where identifying an abusive
+# caller is the point and a retention/access policy exists to match — the log
+# then holds personal data, and /stats/log streams it verbatim to anyone with
+# the dashboard credentials. `ip` is the peer address as uvicorn resolved it,
+# so it is only the true client when TOGOMCP_FORWARDED_ALLOW_IPS trusts your
+# proxy; the untrusted X-Forwarded-For chain is recorded separately as
+# `forwarded_for` for comparison. Anything other than a truthy value = off.
+# TOGOMCP_LOG_RAW_IP=
+# TOGOMCP_LOG_RAW_IP_TEST=
 
 # Optional: also log full SPARQL query text. Off by default — only the sha256
 # hash and a privacy-safe structural "shape" (literals stripped) are logged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,52 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.7] - 2026-08-20
+
+Logging release: the client IP can now be recorded in the clear, so an abusive caller can be
+identified and blocked rather than merely counted. **No tool, parameter, or return shape changed** —
+this is a patch against the tool surface, which is the contract semver applies to here. The change
+that matters most is the one under *Fixed*: the address the log recorded was caller-supplied and
+therefore spoofable, which was survivable while it was only ever hashed and is not survivable once
+it is meant to identify someone.
+
+### Added
+
+- **`TOGOMCP_LOG_RAW_IP`: record the client IP in the clear, for abuse attribution.** Off by
+  default. When set (`1`/`true`/`yes`/`on`), each tool-call record gains an `ip` field carrying
+  the raw client address alongside the existing `ip_hash`, plus `forwarded_for` — the raw,
+  untrusted `X-Forwarded-For` chain, kept verbatim next to the observed peer so the two can be
+  compared. **This reverses a guarantee `log_file_specs.md` previously made unconditionally**
+  ("client IPs are never stored raw"); that document's privacy model has been rewritten rather
+  than patched, and now states the trade explicitly: with the knob on, the log is personal data
+  and `/stats/log` streams it verbatim to whoever holds the dashboard credentials. The knob is
+  fail-closed — absent, empty, or misspelled all mean off — so a `deploy.sh` env-forwarding miss
+  loses the raw address instead of silently leaking one. Wired into all three places a knob must
+  appear (`compose.yaml`, `.env.example`, `deploy.sh`'s forwarded list).
+
+  `ip_hash` is still written unconditionally and remains what `/stats` aggregates on, so an
+  excerpt can be shared with `ip` stripped and still aggregate identically. The dashboard is
+  unchanged: reach is a *count* of distinct addresses, never a list, and a regression test now
+  pins that no raw address can reach any aggregate.
+
+### Fixed
+
+- **The logged client IP was the caller's `X-Forwarded-For` header, not the peer — i.e. spoofable.**
+  The middleware read the header directly, ahead of `request.client.host`, which skipped uvicorn's
+  `ProxyHeadersMiddleware` entirely: that middleware substitutes the header into the peer address
+  *only* for peers trusted via `forwarded_allow_ips`, walking the chain right-to-left to the first
+  untrusted hop. Reading it ourselves meant anyone able to reach the port could write any address
+  they liked into the log, and that the stored value was a comma-separated *chain* rather than an
+  address. Both were invisible while the field was only ever hashed; neither is survivable once the
+  value is meant to identify someone. The middleware now records the peer as uvicorn resolved it,
+  leaving the trust decision where it is configured. On the production path (rootless podman, peer
+  `10.0.2.100`, inside the default allow list) uvicorn has already substituted the forwarded client
+  into that peer, so this yields a strictly better value than before.
+
+  One consequence for anyone reading logs across the change: `ip_hash` was previously computed over
+  the *header string* and is now computed over the resolved address, so the same client hashes
+  differently on either side of the boundary. Reach counts spanning it can double-count a client.
+
 ## [2.7.6] - 2026-08-19
 
 Usage-analysis release: the `/stats` dashboard was reporting numbers that could not be read
@@ -1602,7 +1648,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.5...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.7...HEAD
+[2.7.7]: https://github.com/dbcls/togomcp/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/dbcls/togomcp/compare/v2.7.5...v2.7.6
 [2.7.5]: https://github.com/dbcls/togomcp/compare/v2.7.4...v2.7.5
 [2.7.4]: https://github.com/dbcls/togomcp/compare/v2.7.3...v2.7.4

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ value for every caller, unless `TOGOMCP_FORWARDED_ALLOW_IPS` lets uvicorn trust
 `X-Forwarded-For`. Useful for benchmarking, MIE iteration,
 and reconstructing multi-tool sequences.
 
+The IP is recorded as a salted hash (`ip_hash`) by default. Set
+`TOGOMCP_LOG_RAW_IP=1` to *also* record it in the clear as `ip`, which is what
+lets an abusive caller be identified and blocked — at the cost of making the log
+personal data (and `/stats/log` serves it verbatim to whoever holds the dashboard
+credentials). Full field-by-field reference, including the privacy model, is in
+[`log_file_specs.md`](togo_mcp/data/docs/log_file_specs.md).
+
 **On/off is a single env var**: `TOGOMCP_QUERY_LOG`. Unset/empty = disabled
 (zero-overhead default). Set to a writable file path to enable.
 Output uses `RotatingFileHandler` (50 MB × 10, ~500 MB cap).

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,8 @@ services:
       # Log privacy knobs (see .env.example). Salt unset = per-process random.
       TOGOMCP_LOG_HASH_SALT: ${TOGOMCP_LOG_HASH_SALT:-}
       TOGOMCP_LOG_QUERY_TEXT: ${TOGOMCP_LOG_QUERY_TEXT:-}
+      # Raw client IP in the log (`ip`). Off by default; on = the log is PII.
+      TOGOMCP_LOG_RAW_IP: ${TOGOMCP_LOG_RAW_IP:-}
       # Client names to drop from /stats (comma-separated). Opt-in; never inferred.
       TOGOMCP_STATS_EXCLUDE_CLIENTS: ${TOGOMCP_STATS_EXCLUDE_CLIENTS:-}
     volumes:
@@ -46,6 +48,7 @@ services:
       # Log privacy knobs (see .env.example). Salt unset = per-process random.
       TOGOMCP_LOG_HASH_SALT: ${TOGOMCP_LOG_HASH_SALT_TEST:-}
       TOGOMCP_LOG_QUERY_TEXT: ${TOGOMCP_LOG_QUERY_TEXT_TEST:-}
+      TOGOMCP_LOG_RAW_IP: ${TOGOMCP_LOG_RAW_IP_TEST:-}
       TOGOMCP_STATS_EXCLUDE_CLIENTS: ${TOGOMCP_STATS_EXCLUDE_CLIENTS_TEST:-}
     volumes:
       - ./logs-test:/var/log/togomcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.6"
+version = "2.7.7"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -71,7 +71,7 @@ PROD_CONFIRM_PHRASE="togomcp.rdfportal.org"
 TOGOMCP_PERSERVICE_VARS=(TOGOMCP_ALLOWED_HOSTS TOGOMCP_FORWARDED_ALLOW_IPS \
                          TOGOMCP_QUERY_LOG TOGOMCP_LOG_QUERY_TEXT \
                          TOGOMCP_STATS_USER TOGOMCP_STATS_PASSWORD TOGOMCP_LOG_HASH_SALT \
-                         TOGOMCP_STATS_EXCLUDE_CLIENTS)
+                         TOGOMCP_LOG_RAW_IP TOGOMCP_STATS_EXCLUDE_CLIENTS)
 TOGOMCP_SHARED_VARS=(NCBI_API_KEY)
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,6 +4,7 @@ Covers privacy (IP hashing) and the session-meta / output-size helpers added to
 _ToolCallLogger. The middleware itself is exercised end-to-end via the in-memory
 FastMCP client during development; here we unit-test the pure helpers.
 """
+import json
 import os
 
 # Logging must be disabled during import (no log path) — the middleware reads
@@ -47,3 +48,129 @@ def test_result_size():
     assert server._result_size(_Result()) == 5          # len("hello")
     # objects with neither content nor structured_content fall back to str()
     assert server._result_size(12345) == len("12345")
+
+
+# --------------------------------------------------------------------------- #
+# Client-IP source and the raw-IP opt-in (TOGOMCP_LOG_RAW_IP).
+# --------------------------------------------------------------------------- #
+
+
+class _FakeClient:
+    def __init__(self, host):
+        self.host = host
+
+
+class _FakeRequest:
+    def __init__(self, peer, headers=None):
+        self.client = _FakeClient(peer) if peer else None
+        self.headers = headers or {}
+
+
+def _with_request(monkeypatch, req):
+    monkeypatch.setattr(server, "get_http_request", lambda: req)
+
+
+def test_client_ip_is_the_peer_not_the_forwarded_for_header(monkeypatch):
+    """X-Forwarded-For is caller-supplied: anyone who can reach the port can
+    name any address. uvicorn's ProxyHeadersMiddleware already substitutes the
+    header into the peer for TRUSTED peers only, so the peer is the value that
+    carries the trust decision — and the only one worth attributing abuse to."""
+    _with_request(
+        monkeypatch,
+        _FakeRequest("10.0.2.100", {"X-Forwarded-For": "1.2.3.4, 5.6.7.8"}),
+    )
+    assert server._ToolCallLogger._client_ip() == "10.0.2.100"
+
+
+def test_client_ip_none_without_http_context(monkeypatch):
+    def _raise():
+        raise RuntimeError("no request")
+
+    monkeypatch.setattr(server, "get_http_request", _raise)
+    assert server._ToolCallLogger._client_ip() is None
+    assert server._ToolCallLogger._forwarded_for() is None
+
+
+def test_forwarded_for_is_verbatim_and_bounded(monkeypatch):
+    _with_request(monkeypatch, _FakeRequest("10.0.2.100", {"X-Forwarded-For": "1.2.3.4, 5.6.7.8"}))
+    assert server._ToolCallLogger._forwarded_for() == "1.2.3.4, 5.6.7.8"
+
+    _with_request(monkeypatch, _FakeRequest("10.0.2.100", {"X-Forwarded-For": "9.9.9.9, " * 100}))
+    assert len(server._ToolCallLogger._forwarded_for()) == 200
+
+    _with_request(monkeypatch, _FakeRequest("10.0.2.100"))
+    assert server._ToolCallLogger._forwarded_for() is None
+
+
+def test_raw_ip_flag_is_off_by_default_and_fail_closed(monkeypatch):
+    """Absent, empty, or misspelled all mean OFF: deploy.sh forwards env vars by
+    a fixed list, so a forwarding miss must lose the raw address rather than
+    silently leak one."""
+    monkeypatch.delenv("TOGOMCP_LOG_RAW_IP", raising=False)
+    assert server._ToolCallLogger()._raw_ip is False
+
+    for off in ("", "  ", "0", "false", "no", "ture", "off"):
+        monkeypatch.setenv("TOGOMCP_LOG_RAW_IP", off)
+        assert server._ToolCallLogger()._raw_ip is False, off
+
+    for on in ("1", "true", "TRUE", " yes ", "On"):
+        monkeypatch.setenv("TOGOMCP_LOG_RAW_IP", on)
+        assert server._ToolCallLogger()._raw_ip is True, on
+
+
+class _FakeMessage:
+    name = "run_sparql"
+    arguments = {"database": "uniprot"}
+
+
+class _FakeContext:
+    fastmcp_context = None
+    message = _FakeMessage()
+
+
+async def _ok(_context):
+    return None
+
+
+def _emit_one(monkeypatch, tmp_path, *, raw_ip, peer="203.0.113.7", headers=None):
+    """Drive the middleware once and return the record it wrote."""
+    import asyncio
+
+    log_path = tmp_path / f"log-{raw_ip}.jsonl"
+    monkeypatch.setenv("TOGOMCP_QUERY_LOG", str(log_path))
+    if raw_ip:
+        monkeypatch.setenv("TOGOMCP_LOG_RAW_IP", "1")
+    else:
+        monkeypatch.delenv("TOGOMCP_LOG_RAW_IP", raising=False)
+    _with_request(monkeypatch, _FakeRequest(peer, headers))
+
+    mw = server._ToolCallLogger()
+    assert mw._enabled
+    try:
+        asyncio.run(mw.on_call_tool(_FakeContext(), _ok))
+    finally:
+        for h in mw._log.handlers:
+            h.close()
+    return json.loads(log_path.read_text().strip())
+
+
+def test_record_omits_raw_ip_by_default(monkeypatch, tmp_path):
+    rec = _emit_one(
+        monkeypatch, tmp_path, raw_ip=False, headers={"X-Forwarded-For": "203.0.113.7"}
+    )
+    assert rec["ip_hash"] == server._hash_ip("203.0.113.7")
+    assert "ip" not in rec and "forwarded_for" not in rec
+    assert "203.0.113.7" not in json.dumps(rec)
+
+
+def test_record_carries_raw_ip_when_opted_in(monkeypatch, tmp_path):
+    rec = _emit_one(
+        monkeypatch,
+        tmp_path,
+        raw_ip=True,
+        headers={"X-Forwarded-For": "203.0.113.7, 10.0.2.100"},
+    )
+    assert rec["ip"] == "203.0.113.7"
+    assert rec["forwarded_for"] == "203.0.113.7, 10.0.2.100"
+    # the hash stays alongside, so stripping `ip` leaves the log aggregatable
+    assert rec["ip_hash"] == server._hash_ip("203.0.113.7")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -557,3 +557,35 @@ def test_trap_section_renders():
     html = stats.render_html(stats.aggregate(recs))
     assert "MIE traps to fix (filtered)" in html
     assert "mesh" in html
+
+
+def test_raw_ip_field_aggregates_like_ip_hash():
+    """Records carrying only the raw `ip` (TOGOMCP_LOG_RAW_IP) must aggregate
+    identically to records carrying only `ip_hash` — the reader unions the two
+    fields, so turning the knob on or off mid-retention does not split reach
+    counts across the boundary."""
+    hashed = [_call("openai-mcp", f"ip{i}", args={"database": "pdb"}) for i in range(3)]
+    raw = []
+    for i in range(3):
+        rec = _call("openai-mcp", None, args={"database": "pdb"})
+        del rec["ip_hash"]
+        rec["ip"] = f"ip{i}"
+        raw.append(rec)
+
+    from_hash = stats.aggregate(hashed)["by_month"]["2026-06"]
+    from_raw = stats.aggregate(raw)["by_month"]["2026-06"]
+    assert from_raw["databases"]["pdb"]["ips"] == from_hash["databases"]["pdb"]["ips"] == 3
+    assert from_raw["clients"][0]["ips"] == from_hash["clients"][0]["ips"] == 3
+
+
+def test_stats_output_never_contains_a_raw_ip():
+    """The dashboard reports reach as a COUNT. A raw address must not survive
+    into any aggregate, whatever the collection layer wrote."""
+    recs = [_call("openai-mcp", None, args={"database": "pdb"}) for _ in range(2)]
+    for i, rec in enumerate(recs):
+        del rec["ip_hash"]
+        rec["ip"] = f"198.51.100.{i}"
+        rec["forwarded_for"] = f"198.51.100.{i}, 10.0.2.100"
+    out = json.dumps(stats.aggregate(recs))
+    assert "198.51.100." not in out
+    assert "forwarded_for" not in out

--- a/togo_mcp/data/docs/log_file_specs.md
+++ b/togo_mcp/data/docs/log_file_specs.md
@@ -29,20 +29,38 @@ variables read at process start:
 | `TOGOMCP_QUERY_LOG` | Filesystem path for the JSONL log. **Setting it (non-empty) enables logging.** Unset/empty = disabled, and `on_call_tool` short-circuits with no measurable overhead. Parent directories are created if needed. | unset (disabled) |
 | `TOGOMCP_LOG_QUERY_TEXT` | When truthy (`1`/`true`/`yes`), the raw SPARQL query text is added to `extra.query_text`. Off by default — normally only the hash and structural shape are stored. | off |
 | `TOGOMCP_LOG_HASH_SALT` | Salt for hashing client IPs. A stable salt hashes the same IP identically across restarts (linkable within a retention window); when unset, a fresh random salt is generated per process, so IP hashes are **not** linkable across restarts (strictly more private). | random per process |
+| `TOGOMCP_LOG_RAW_IP` | When truthy (`1`/`true`/`yes`/`on`), the client IP is **also** recorded in the clear as `ip` (and the raw `X-Forwarded-For` chain as `forwarded_for`). Off by default; `ip_hash` is written either way. Fail-closed: absent, empty, or misspelled all mean off. | off |
 
 ## Privacy model
 
-The format is designed so that raw personal or query-content data does not land
-in the log:
+By default the format keeps raw personal and query-content data out of the log.
+One knob deliberately trades that away, and it is stated first because it
+reverses a guarantee earlier versions of this document made unconditionally:
 
-- **Client IPs are never stored raw.** Only `ip_hash` — `sha256("<salt>:<ip>")`
-  truncated to 16 hex chars — is written. See `TOGOMCP_LOG_HASH_SALT` above.
+- **Client IPs are pseudonymous by default, raw only on request.** `ip_hash` —
+  `sha256("<salt>:<ip>")` truncated to 16 hex chars — is always written; see
+  `TOGOMCP_LOG_HASH_SALT` above. The raw address is written as `ip` **only**
+  under the explicit `TOGOMCP_LOG_RAW_IP` opt-in, whose purpose is identifying
+  an abusive caller well enough to block them. With it on, the log is personal
+  data: it needs a retention and access policy, and note that `/stats/log`
+  streams those records verbatim to anyone holding the dashboard credentials.
+  The hash is kept alongside `ip` precisely so an excerpt can be shared with
+  `ip` stripped and still aggregate identically.
+- **What `ip` actually contains.** The peer address as uvicorn's
+  `ProxyHeadersMiddleware` resolved it — i.e. the real client only when the
+  proxy's address is trusted via `forwarded_allow_ips` (`TOGOMCP_FORWARDED_ALLOW_IPS`,
+  see `main.py`); otherwise it is the proxy. The `X-Forwarded-For` header is
+  never read directly for this field: it is caller-supplied and spoofable by
+  anyone who can reach the port, which would make it worthless for attribution.
+  It is recorded separately and verbatim as `forwarded_for` (truncated to 200
+  chars) so the claimed chain can be compared against the observed peer.
 - **SPARQL query text is not stored by default.** Records carry `query_sha256`
   (an identity/dedup key) and `query_shape` (a structural fingerprint with all
   string-literal *contents* stripped — see [Query shape](#query-shape)). Raw
   text appears only under the explicit `TOGOMCP_LOG_QUERY_TEXT` opt-in.
 - **Aggregation only ever counts.** `stats.py` derives categories and tallies;
-  it never emits `args`, `ip_hash`, or query text in its output.
+  it never emits `args`, `ip`/`ip_hash`, or query text in its output — the
+  per-client "IPs" column is a *count* of distinct addresses, never a list.
 
 ## Record schema
 
@@ -63,7 +81,9 @@ context under stdio transport).
 | `origin_request_id` | string | *(nullable)* | Originating request id (for nested/forwarded calls). |
 | `client_id` | string | *(nullable)* | FastMCP client id. |
 | `transport` | string | *(nullable)* | Transport in use (e.g. `http`, `stdio`). |
-| `ip_hash` | string | *(nullable)* | Salted, truncated SHA-256 of the client IP (from `X-Forwarded-For`, else peer host). `null` when there is no HTTP request context. |
+| `ip_hash` | string | *(nullable)* | Salted, truncated SHA-256 of the client IP. `null` when there is no HTTP request context (e.g. stdio). |
+| `ip` | string | *(nullable)*, opt-in | Raw client IP — present only under `TOGOMCP_LOG_RAW_IP`. Same source as `ip_hash`: the peer address as resolved by uvicorn's proxy-header handling. |
+| `forwarded_for` | string | opt-in, when sent | Raw `X-Forwarded-For` header, verbatim, truncated to 200 chars. **Untrusted** — caller-supplied context for `ip`, not a substitute for it. Present only under `TOGOMCP_LOG_RAW_IP`, and only when the header was sent. |
 | `meta` | object | always | Server/build metadata — see [`meta`](#meta-object). |
 | `error_class` | string | on error only | Exception class name — **in practice almost always `ToolError`**. FastMCP wraps a tool's raised exception before it reaches the logging middleware, so the original class (e.g. `ValueError`) is not preserved here. To distinguish an intentional error from a genuine bug, parse `error_message`, not this field. |
 | `error_message` | string | on error only | Exception message, truncated to 500 chars. Carries the FastMCP wrapper prefix, e.g. `Error calling tool 'run_sparql': …`. |
@@ -134,6 +154,10 @@ This is the signal MIE-improvement analysis needs (e.g. "reactome queries using
 
 A successful SPARQL call:
 
+The first example has `TOGOMCP_LOG_RAW_IP` on, so it carries `ip` /
+`forwarded_for`; the second is the default configuration, where neither field
+exists.
+
 ```json
 {
   "ts": "2026-07-07T00:00:00.123456+00:00",
@@ -145,6 +169,8 @@ A successful SPARQL call:
   "session_id": "…", "request_id": "…", "origin_request_id": null,
   "client_id": "…", "transport": "http",
   "ip_hash": "9f3a1c0b7e2d4a56",
+  "ip": "203.0.113.7",
+  "forwarded_for": "203.0.113.7, 10.0.2.100",
   "meta": {
     "server_version": "2.4.0",
     "usage_guide_version": "v6",

--- a/togo_mcp/main.py
+++ b/togo_mcp/main.py
@@ -34,11 +34,14 @@ def _allowed_hosts() -> list[str]:
 #   172.16.0.0/12  Docker/Compose bridge range (compose.yaml).
 # Getting this wrong is silent: the header is dropped, not rejected.
 #
-# NOTE on why this is not just "*": server.py records the peer address (hashed) in
-# the tool-call log. On the rootless-slirp4netns path that field is ALREADY constant
-# — every client arrives as 10.0.2.100 — so there the tight list buys nothing over
-# "*", and the real protection is that only the proxy can reach the published port.
-# It still matters on the rootful/Compose paths, where the peer is the true client.
+# NOTE on why this is not just "*": server.py records the peer address in the
+# tool-call log — hashed as `ip_hash` always, and in the clear as `ip` under
+# TOGOMCP_LOG_RAW_IP. That address is whatever uvicorn's ProxyHeadersMiddleware
+# resolved, which is the REAL client only when the peer is trusted here; for an
+# untrusted peer the X-Forwarded-For chain is ignored and the proxy itself is
+# recorded. So this list is what decides whether the logged IP can attribute
+# abuse at all — "*" would let any caller able to reach the port write any
+# address it liked into the log.
 # Override via TOGOMCP_FORWARDED_ALLOW_IPS (comma-separated; addresses and CIDR).
 _DEFAULT_FORWARDED_ALLOW_IPS = "127.0.0.1,::1,10.0.2.0/24,10.88.0.0/16,172.16.0.0/12"
 

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -717,7 +717,12 @@ _STATIC_META: dict[str, Any] = {
 # Salt for hashing client IPs (PII). A stable salt (set TOGOMCP_LOG_HASH_SALT)
 # hashes the same IP identically across restarts within a retention window; an
 # unset salt is randomized per process, so hashes are not linkable across
-# restarts — strictly more private. Raw IPs are never written to the log.
+# restarts — strictly more private.
+#
+# `ip_hash` is written unconditionally and is the field stats.py aggregates on.
+# The RAW address is a separate, opt-in field (`ip`, see TOGOMCP_LOG_RAW_IP on
+# _ToolCallLogger) — the hash is kept alongside it so a log excerpt can be
+# shared or exported with `ip` stripped and still aggregate identically.
 _IP_SALT = os.getenv("TOGOMCP_LOG_HASH_SALT", "").strip() or secrets.token_hex(16)
 
 
@@ -769,11 +774,25 @@ class _ToolCallLogger(_Middleware):
     disabled (the default), in which case on_call_tool short-circuits and adds
     no measurable overhead. SPARQL calls enrich their record via
     _sparql_extra_var (set inside execute_sparql).
+
+    TOGOMCP_LOG_RAW_IP additionally records the client address in the clear, as
+    `ip`, so an abusive caller can actually be identified and blocked. It is
+    off by default and fail-closed on purpose: absent, empty or misspelled all
+    mean OFF, so a deploy-time env-forwarding miss (deploy.sh forwards a FIXED
+    list — see CLAUDE.md) loses the raw address rather than silently leaking
+    one. Turning it on makes the log PII, including everything /stats/log
+    streams; `ip_hash` is unaffected and is written either way.
     """
 
     def __init__(self) -> None:
         log_path = os.getenv("TOGOMCP_QUERY_LOG", "").strip()
         self._enabled = bool(log_path)
+        self._raw_ip = os.getenv("TOGOMCP_LOG_RAW_IP", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
         self._log: logging.Logger | None = None
         if self._enabled:
             try:
@@ -799,13 +818,36 @@ class _ToolCallLogger(_Middleware):
 
     @staticmethod
     def _client_ip() -> str | None:
+        """Client address for the log: the peer as *uvicorn* resolved it.
+
+        Deliberately NOT `X-Forwarded-For` read off the request. uvicorn's
+        ProxyHeadersMiddleware already substitutes the client address from that
+        header — but only when the peer is listed in `forwarded_allow_ips`
+        (main.py), and it walks the chain right-to-left to the first untrusted
+        hop. Reading the header here would skip that check entirely: anyone who
+        can reach the port could name any address they like, which is worthless
+        for the one job a raw IP has (attributing abuse). So: peer only, and let
+        the trust decision stay where it is configured.
+        """
         try:
             req: Request = get_http_request()
         except RuntimeError:
             return None
-        return req.headers.get("X-Forwarded-For") or (
-            req.client.host if req.client else None
-        )
+        return req.client.host if req.client else None
+
+    @staticmethod
+    def _forwarded_for() -> str | None:
+        """Raw X-Forwarded-For chain, verbatim — UNTRUSTED forensic context.
+
+        Caller-supplied and therefore spoofable; it is recorded next to `ip` to
+        show what was claimed, never as a substitute for what was observed.
+        """
+        try:
+            req: Request = get_http_request()
+        except RuntimeError:
+            return None
+        xff = req.headers.get("X-Forwarded-For")
+        return xff[:200] if xff else None
 
     async def on_call_tool(self, context, call_next):
         if not self._enabled:
@@ -830,6 +872,7 @@ class _ToolCallLogger(_Middleware):
             extra = _sparql_extra_var.get()
             _sparql_extra_var.reset(token)
             fctx = context.fastmcp_context
+            client_ip = self._client_ip()
             record: dict[str, Any] = {
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "tool": context.message.name,
@@ -844,9 +887,14 @@ class _ToolCallLogger(_Middleware):
                 ),
                 "client_id": getattr(fctx, "client_id", None) if fctx else None,
                 "transport": getattr(fctx, "transport", None) if fctx else None,
-                "ip_hash": _hash_ip(self._client_ip()),
+                "ip_hash": _hash_ip(client_ip),
                 "meta": {**_STATIC_META, "client": _client_info(fctx)},
             }
+            if self._raw_ip:
+                record["ip"] = client_ip
+                fwd = self._forwarded_for()
+                if fwd:
+                    record["forwarded_for"] = fwd
             if error_class is not None:
                 record["error_class"] = error_class
                 record["error_message"] = error_message
@@ -956,6 +1004,10 @@ async def stats_raw_log(request: Request):
     not read-into-memory: this file grows without bound between rotations.
     The path comes from TOGOMCP_QUERY_LOG only; nothing is caller-supplied, so
     there is no traversal surface.
+
+    NOTE: this streams records verbatim, so under TOGOMCP_LOG_RAW_IP it serves
+    raw client IPs (`ip`) to anyone holding the dashboard credentials. The
+    aggregate views never do. Treat the credentials accordingly.
     """
     creds = _stats_configured()
     if creds is None:

--- a/togo_mcp/stats.py
+++ b/togo_mcp/stats.py
@@ -7,10 +7,14 @@ MCP server.
 
 Privacy: aggregation only ever *counts*. Raw ``args``, ``ip``, and query text
 never appear in any output produced here — only derived categories and tallies.
+That holds even when the log itself carries raw client IPs (``TOGOMCP_LOG_RAW_IP``):
+the reach column is ``len(distinct addresses)``, never the addresses. Reading a
+raw address is what ``/stats/log`` is for.
 
 What the collection layer records today (per JSONL line):
   ts, tool, args, status (ok|error), elapsed_ms, session_id/request_id/...,
-  ip, error_class, error_message, and for SPARQL an ``extra`` dict with
+  ip_hash (plus raw ip when opted in), error_class, error_message, and for
+  SPARQL an ``extra`` dict with
   endpoint_url, query_sha256, sparql_status (ok|timeout|endpoint_unresponsive|
   pool_exhausted|network_error|http_4xx|http_5xx|http_gateway), http_code,
   n_bytes, n_rows, and — when the liveness probe ran — liveness_probe

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.6"
+version = "2.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Records the client IP in the clear, behind `TOGOMCP_LOG_RAW_IP` (off by default), so an abusive caller can be identified and blocked rather than only counted.

**No tool, parameter, or return shape changed** — patch against the tool surface, which is the contract semver applies to here.

### The fix that matters most

The middleware read `X-Forwarded-For` off the request, ahead of `request.client.host`. That skipped uvicorn's `ProxyHeadersMiddleware` entirely — which substitutes the header into the peer address *only* for peers trusted via `forwarded_allow_ips`, walking the chain right-to-left to the first untrusted hop. Consequences:

- any caller able to reach the port could write **any** address into the log;
- the stored value was a comma-separated *chain*, not an address.

Both were survivable while the field was only ever hashed. Neither is survivable once the value is meant to identify someone. The middleware now records the peer as uvicorn resolved it, leaving the trust decision where it is configured.

Note for anyone reading logs across the boundary: `ip_hash` was computed over the header string and is now computed over the resolved address, so the same client hashes differently either side. Reach counts spanning the change can double-count.

### The opt-in

`TOGOMCP_LOG_RAW_IP` adds `ip` (raw address) and `forwarded_for` (the untrusted chain, verbatim, capped at 200 chars — what was *claimed*, next to what was *observed*). Fail-closed: absent, empty, or misspelled all mean off, so a `deploy.sh` env-forwarding miss loses the raw address instead of silently leaking one. Wired into all three places a knob must appear (`compose.yaml`, `.env.example`, `deploy.sh`'s forwarded list).

`ip_hash` stays unconditional and remains what `/stats` aggregates on, so an excerpt can be shared with `ip` stripped and still aggregate identically. `stats.py` needed no changes.

### Privacy model

`log_file_specs.md` previously guaranteed "client IPs are never stored raw". That is now conditional, so the document's privacy model was **rewritten rather than patched**: it states what `ip` contains (the peer as uvicorn resolved it — the real client only when the proxy is trusted), and that with the knob on the log is personal data which `/stats/log` streams verbatim to anyone holding the dashboard credentials.

### Tests

498 pass. 8 new: peer-over-header, header truncation, flag fail-closed across `""`/`"0"`/`"ture"`, two end-to-end middleware tests (record omits `ip` by default and contains the address nowhere; carries `ip` + `forwarded_for` when opted in), plus `stats.py` regressions that `ip`-only records aggregate identically to `ip_hash`-only ones and that no raw address reaches any aggregate.

### Deploying

Add `TOGOMCP_LOG_RAW_IP=1` to the `.env` on the host and re-create the container; unset changes nothing but the source fix. Worth confirming after deploy that `ip` is not constant `10.0.2.100` — if it is, the reverse proxy is not setting `X-Forwarded-For` and attribution is dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)