### PR TITLE
release: 2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,37 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
   filed as a worked example plus `traps_avoided` lines rather than a `global_gotchas` paragraph: it has a
   concrete query that avoids it, and a query an agent can copy is worth more than prose it must translate.
 
+- **`uniprot.yaml`'s `sequence_mass` example was fragile under extension, and the cause was not the one it
+  looked like.** The example selected the canonical isoform with `FILTER(CONTAINS(STR(?seq), "/P01308-1"))`
+  and carried **no `FROM` pin** — so it ran against the union of all 63 graphs on the SIB endpoint, OMA's
+  584M triples included. Alone it returned in 0.19s; bolt on two `OPTIONAL`s and it did not finish. The 2×2
+  measured 2026-08-20 (`OPTIONAL`s on `rdfs:seeAlso`/`up:database` and `up:classifiedWith`/`rdfs:label`):
+  unpinned `FILTER` form **>200s, no result**; unpinned direct-IRI form **>200s** as well; pinned `FILTER`
+  form **5.6s**; pinned direct-IRI form **~1.5s**. So the missing pin — which the file's own
+  `union_inflation` gotcha already prescribes — was the larger half, and naming the IRI removes the
+  remaining ~4×. The example now pins the graph and states `isoforms/P01308-1` directly: no `?seq` variable,
+  no post-filter, 0.4s standalone.
+
+  Three findings from verifying the replacement are recorded as `traps_avoided` rather than left implicit.
+  `isoforms/ACC-1` is **not** universal — 2,985 of 3,000 sampled reviewed human entries have it, and the
+  rest start at `-2`, `-3` or `-5` because the canonical was merged or demoted, so a direct-IRI lookup that
+  returns 0 rows needs the accession-scoped fallback. The cross-accession trap the example already warned
+  about is not a one-off: O94854 hangs five `Q9UPN3-*` isoform nodes off `up:sequence` and has no
+  `O94854-1` node at all. And every sequence node is typed **both** `up:Simple_Sequence` and
+  `up:External_Sequence`, so binding `?seq a ?class` doubles the rows.
+
+- **`search_uniprot_entity`'s docstring never mentioned the `go` field, which reads as a silent failure when
+  it is not one.** A `go:0043202` query returns proteins that look unrelated to lysosomes (keratocan,
+  osteomodulin, syndecan-3), and with `go` absent from the documented field list the natural conclusion is
+  that the tool accepted an unsupported field and fell back to full text. It does not: all three proteins
+  genuinely carry `GO:0043202` in UniProt's own RDF (confirmed by SPARQL), and an unknown field name is
+  rejected upstream with HTTP 400 (`'go_id' is not a valid search field`), surfacing as this tool's
+  documented `"Error:"` string. The docstring now documents `go` along with the two ways it *can* mislead —
+  the ID must be zero-padded to 7 digits (`go:43202` is a valid field with an unmatchable value: 0 rows,
+  HTTP 200), and the match includes GO **descendants** (192 reviewed entries carry GO:0043202 directly, 214
+  once its two children are counted). A new warning at the top of the docstring states the actual failure
+  mode: a bad *field name* errors, a bad *value* is what fails silently.
+
 ## [2.7.7] - 2026-08-20
 
 Logging release: the client IP can now be recorded in the clear, so an abusive caller can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Fixed
+
+- **`chembl.yaml` did not warn that one UniProt accession maps to SEVERAL ChEMBL targets of different
+  `cco:targetType` — so the obvious `?target a cco:SingleProtein` silently returns a fraction of the
+  answer.** ChEMBL curates a mechanism onto whichever target entity the curator judged right, and that is
+  frequently *not* the single protein: P10253's VOGLIBOSE and CELGOSIVIR hang off the PROTEIN FAMILY
+  "Alpha glucosidase", and P18505 (GABA-A β1) has **no** mechanism on its single-protein target at all —
+  all 69 of its drugs, the benzodiazepines and anaesthetics among them, sit on PROTEIN COMPLEX / PROTEIN
+  COMPLEX GROUP targets. Measured 2026-08-20: SINGLE PROTEIN carries only 4,948 of 6,990 mechanisms
+  (70.8%), so the type pin discards 2,042 of them, and 1,974 of the 12,253 UniProt-linked accessions
+  (16.1%) map to more than one target type. There is no error and no empty result — just a short answer,
+  which is what makes it worth a file entry rather than a docstring line.
+
+  A new verified example, **`moa_target_types`**, carries the positive route: bind `cco:targetType` as a
+  returned column instead of pinning an `rdf:type` class. That works because `cco:targetType` is on all
+  17,803 Target entities and on **zero** TargetComponents, so it admits every target kind while still
+  keeping components out of `?target` — which matters, because simply deleting the type pin is the wrong
+  fix: `cco:hasProteinClassification` and `cco:organismName` are carried by TargetComponents too. There is
+  also no `cco:Target` umbrella class to pin instead (`?t a cco:Target` returns 0 rows), so an `rdf:type`
+  constraint can only ever name one kind. On the example's three accessions the query returns 143 rows /
+  76 molecules; with the pin, 5 rows / 5 molecules.
+
+- **The same trap was live in two existing examples, and both now say so.** `class_enum` returns 29 of the
+  48 typed human phosphodiesterase targets — the families (including "Phosphodiesterase 4"), selectivity
+  groups, protein-protein interactions, the complex and the chimera all carry the same classification IRI
+  and were being dropped. `moa_integration`'s pin is a deliberate narrowing and stays, but now records what
+  it omits and points at `moa_target_types`. Following the placement rule in the MIE spec, the finding is
+  filed as a worked example plus `traps_avoided` lines rather than a `global_gotchas` paragraph: it has a
+  concrete query that avoids it, and a query an agent can copy is worth more than prose it must translate.
+
 ## [2.7.7] - 2026-08-20
 
 Logging release: the client IP can now be recorded in the clear, so an abusive caller can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.7.8] - 2026-08-20
+
+Three field reports, no tool, parameter, or return shape changed — two MIE files and one docstring.
+The common shape is a query that runs, returns rows, and is wrong or fragile in a way nothing signals.
+Worth noting for anyone triaging the next one: **two of the three reports named the wrong cause**, and
+the investigation only found the real one because the claim was reproduced rather than accepted. The
+ChEMBL report was right. The UniProt performance report blamed a `FILTER(CONTAINS())` that turned out to
+be the smaller half of the problem — a missing `FROM` pin was the larger. The `search_uniprot_entity`
+report described a silent full-text fallback that does not exist; the tool was working, its docstring was
+incomplete, and the results that looked wrong were correct. Deliberately no `whatsnew` marker: none of
+this is visible to a user who is not writing SPARQL or tool queries by hand.
+
 ### Fixed
 
 - **`chembl.yaml` did not warn that one UniProt accession maps to SEVERAL ChEMBL targets of different
@@ -1709,7 +1721,8 @@ their own file. No tool-surface change; the served MIE/guide content is correcte
 _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
-[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.7...HEAD
+[Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.8...HEAD
+[2.7.8]: https://github.com/dbcls/togomcp/compare/v2.7.7...v2.7.8
 [2.7.7]: https://github.com/dbcls/togomcp/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/dbcls/togomcp/compare/v2.7.5...v2.7.6
 [2.7.5]: https://github.com/dbcls/togomcp/compare/v2.7.4...v2.7.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.7.7"
+version = "2.7.8"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/togo_mcp/api_tools.py
+++ b/togo_mcp/api_tools.py
@@ -197,6 +197,13 @@ async def search_uniprot_entity(
        dropped and have no effect — express such filters inside the Solr
        query string instead (e.g., `organism_id:9606 AND reviewed:true`).
 
+    ⚠️ An unrecognised FIELD NAME *inside* the query string is not silently
+       ignored: UniProt rejects it (HTTP 400, "'taxon' is not a valid search
+       field") and this tool returns the "Error:" string described below.
+       Common wrong guesses that fail this way: `taxon`, `organism`, `species`,
+       `go_id`. What CAN fail silently is a valid field given an ill-formed
+       value — it returns 0 rows, or rows you did not expect, with HTTP 200.
+
     The search string can be passed as any of: `query` (canonical),
     `search`, `term`, `keyword`, `keywords`, `search_term`, or `name`.
 
@@ -246,6 +253,17 @@ async def search_uniprot_entity(
             Functional annotation:
               keyword            UniProt keyword name (e.g., "keyword:Kinase")
               keyword_id         UniProt keyword ID (e.g., "keyword_id:KW-0418")
+              go                 Gene Ontology term, by ID or by term name
+                                 (e.g., "go:0043202", 'go:"lysosomal lumen"').
+                                 TWO behaviours to know: (1) the ID must be
+                                 zero-padded to 7 digits — "go:43202" is a VALID
+                                 field with an unmatchable value, so it returns 0
+                                 rows and no error; (2) the match includes the
+                                 term's GO DESCENDANTS, so "go:0043202" also
+                                 returns proteins annotated only to its children
+                                 (acrosomal lumen, endolysosome lumen) — 192
+                                 reviewed entries carry the term directly, 214
+                                 once descendants are counted (2026-08-20).
               function           Function free-text annotation
               family             Protein family (e.g., "family:globin")
               organelle          Subcellular organelle (e.g., "organelle:chloroplast")

--- a/togo_mcp/data/mie/chembl.yaml
+++ b/togo_mcp/data/mie/chembl.yaml
@@ -101,6 +101,7 @@ examples:
     traps_avoided:
       - "Filter organism with cco:organismName \"Homo sapiens\" (typed predicate). Combining a cco:taxonomy IRI with the classification IRI times out (gotcha taxonomy_classification_timeout)."
       - "The naive route — bif:contains 'phosphodiesterase' on rdfs:label — misses orthologs/renamed entries and mixes non-target entities; the classification IRI is the complete set."
+      - "`a cco:SingleProtein` NARROWS this to single proteins by design — 29 of the 48 typed human PDE targets. Families, complexes, selectivity groups, PPIs and chimeras carry the same classification IRI (PROTEIN FAMILY 8 incl. 'Phosphodiesterase 4', SELECTIVITY GROUP 5, PROTEIN-PROTEIN INTERACTION 4, PROTEIN COMPLEX 1, CHIMERIC PROTEIN 1). For all 48, swap the pin for `cco:targetType ?targetType` — do NOT simply delete it: cco:hasProteinClassification + cco:organismName also sit on TargetComponents, so an unconstrained ?target matches 80 entities, 32 of them components. See example moa_target_types."
 
   - id: disease_drugs
     intent: enumerate ALL drugs indicated for a disease via its MeSH descriptor IRI (the set-level indication route)
@@ -256,6 +257,40 @@ examples:
       - "Do NOT count via ?activity cco:hasAssay/cco:hasMolecule — that fans out over 21M activities and TIMES OUT at 60s even for a COUNT. The Mechanism link is the curated, bounded path."
       - "Do NOT scope a comprehensive count by molecule/target IRIs sampled from an exploratory query (circular reasoning) — scope by the classification IRI."
 
+  - id: moa_target_types          # the TARGET-side twin of molecule_name_resolve's biologic trap
+    intent: every drug with a curated mechanism against a protein — across ALL target entities that protein sits in
+    question: "Which drugs have a curated mechanism of action against the human proteins P10253, P18505 and P47869?"
+    complexity: intermediate
+    sparql: |
+      PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      SELECT ?acc ?targetType ?targetLabel ?moleculeLabel ?actionType
+      FROM <http://rdf.ebi.ac.uk/dataset/chembl>
+      WHERE {
+        VALUES ?up { <http://purl.uniprot.org/uniprot/P10253>     # lysosomal alpha-glucosidase (GAA)
+                     <http://purl.uniprot.org/uniprot/P18505>     # GABA-A receptor subunit beta-1
+                     <http://purl.uniprot.org/uniprot/P47869> }   # GABA-A receptor subunit alpha-2
+        # NO `?target a cco:SingleProtein` pin — it would silently drop most of this answer (traps_avoided).
+        # cco:targetType is the safe discriminator: all 17,803 Target entities carry it and 0 TargetComponents
+        # do, so binding it admits EVERY target kind while still keeping components out of ?target.
+        ?target cco:hasTargetComponent/skos:exactMatch ?up ;
+                rdfs:label ?targetLabel ;
+                cco:targetType ?targetType .
+        ?mech a cco:Mechanism ; cco:hasTarget ?target ;
+              cco:hasMolecule ?mol ; cco:mechanismActionType ?actionType .
+        ?mol rdfs:label ?moleculeLabel .
+        BIND(STRAFTER(STR(?up), "uniprot/") AS ?acc)
+      }
+      ORDER BY ?acc ?targetType ?moleculeLabel
+    verified: {result_rows: 143, distinct_molecules: 76, distinct_targets: 6, date: "2026-08-20",
+               first_row: "P10253 | PROTEIN FAMILY | Alpha glucosidase | CELGOSIVIR | INHIBITOR",
+               pinned_variant: "adding `?target a cco:SingleProtein` returns 5 rows / 5 molecules"}
+    teaches: "ONE UniProt accession maps to SEVERAL ChEMBL target entities of different cco:targetType (SINGLE PROTEIN, PROTEIN FAMILY, PROTEIN COMPLEX, PROTEIN COMPLEX GROUP, SELECTIVITY GROUP, PROTEIN-PROTEIN INTERACTION, CHIMERIC PROTEIN), and the curated cco:Mechanism hangs off whichever entity the curator judged right — frequently NOT the single protein. Bind cco:targetType as a returned COLUMN instead of pinning an rdf:type class, then filter it afterwards only if you genuinely want one kind."
+    traps_avoided:
+      - "`?target a cco:SingleProtein` DROPS the family/complex mechanisms SILENTLY — no error, just a short answer. Verified 2026-08-20: this query returns 143 rows / 76 molecules; with the pin, 5 rows / 5 molecules. P10253 loses VOGLIBOSE and CELGOSIVIR (their MoA target is the PROTEIN FAMILY 'Alpha glucosidase', not the SINGLE PROTEIN 'Lysosomal alpha-glucosidase'), and P18505 collapses to ZERO — all 69 of its drugs (zolpidem, diazepam, propofol, the benzodiazepines …) hang off PROTEIN COMPLEX / PROTEIN COMPLEX GROUP targets. Database-wide the pin discards 2,042 of 6,990 mechanisms: SINGLE PROTEIN carries only 4,948 (70.8%), then PROTEIN FAMILY 755, PROTEIN COMPLEX 371, PROTEIN COMPLEX GROUP 297, NUCLEIC-ACID 231, and 13 rarer kinds. 1,974 of the 12,253 UniProt-linked accessions (16.1%) map to more than one target type."
+      - "There is NO cco:Target umbrella class to pin instead — `?t a cco:Target` returns 0 rows; only the leaf classes (cco:SingleProtein / cco:ProteinFamily / cco:ProteinComplex / …) are asserted, one per target. An rdf:type pin can therefore only ever name ONE kind."
+      - "Do not fix this by deleting the type constraint outright: cco:hasProteinClassification and cco:organismName are ALSO carried by cco:TargetComponent entities, which would then contaminate ?target (see example class_enum for the measured contamination). cco:targetType is what separates Targets from components."
+
   - id: moa_integration
     intent: multi-entity integration — disease indication → molecule → mechanism → target in one query
     question: "For late-stage Parkinson disease drugs, what are their mechanisms and human protein targets?"
@@ -279,6 +314,8 @@ examples:
       LIMIT 50
     verified: {result_rows: 50, date: "2026-07-22", first_row: "AMPRELOXETINE → Sodium-dependent noradrenaline transporter (INHIBITOR, phase 3)"}
     teaches: "Indication (cco:hasMesh) and mechanism (cco:Mechanism → cco:mechanismActionType + cco:hasTarget) join on the shared ?molecule. All four filter dimensions are typed predicates — no text search anywhere."
+    traps_avoided:
+      - "The `a cco:SingleProtein` pin here is a deliberate narrowing to human single proteins, and it silently omits any mechanism curated onto a PROTEIN FAMILY / PROTEIN COMPLEX target. For the complete per-protein drug set, use the cco:targetType idiom in example moa_target_types."
 
   - id: xdb_chebi                  # ELEVATED cross_db
     intent: "cross-DB: ChEMBL approved drugs → ChEBI chemical structure (formula, mass) via moleculeXref + IRI transform"

--- a/togo_mcp/data/mie/uniprot.yaml
+++ b/togo_mcp/data/mie/uniprot.yaml
@@ -90,24 +90,30 @@ global_gotchas:                    # the few that bite ANY query — verified 20
 #    would otherwise be written four times over. `traps_avoided` are the inline, query-specific warnings. ──
 examples:
   - id: sequence_mass
-    intent: amino-acid sequence + mass of a protein (up:sequence -> Simple_Sequence -> rdf:value)
+    intent: amino-acid sequence + mass of a protein, selected by naming the canonical isoform IRI
     question: "What is the canonical amino-acid sequence and mass of human insulin (P01308)?"
     complexity: basic
     sparql: |
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+      PREFIX isoform: <http://purl.uniprot.org/isoforms/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       SELECT ?sequence ?mass (STRLEN(?sequence) AS ?length)
+      FROM <http://sparql.uniprot.org/uniprot>        # load-bearing, not decoration — see traps_avoided
       WHERE {
-        VALUES ?protein { uniprot:P01308 }
-        ?protein up:sequence ?seq .
-        ?seq a up:Simple_Sequence ; rdf:value ?sequence ; up:mass ?mass .
-        FILTER(CONTAINS(STR(?seq), "/P01308-1"))   # pin the canonical isoform — see trap
+        # The canonical sequence node is NAMED <isoforms/ACC-1>. State it as an IRI instead of binding
+        # ?seq and testing the string afterwards: both legs stay index-resolved, nothing is post-filtered.
+        uniprot:P01308 up:sequence isoform:P01308-1 .
+        isoform:P01308-1 rdf:value ?sequence ; up:mass ?mass .
       }
-    verified: {result_rows: 1, mass: 11981, length: 110, date: "2026-07-29"}
-    teaches: "up:sequence -> up:Simple_Sequence -> rdf:value carries the letters; up:mass carries the Da."
+    verified: {result_rows: 1, mass: 11981, length: 110, date: "2026-08-20", runtime: "0.4s",
+               under_extension: "with two OPTIONALs bolted on (rdfs:seeAlso/up:database and up:classifiedWith/rdfs:label) it returns 918 rows in 1.0\u20131.5s; the previous FILTER(CONTAINS)+unpinned form did not finish within 200s"}
+    teaches: "up:sequence \u2192 the isoform node \u2192 rdf:value carries the letters, up:mass the Da. For a known protein, name the isoform IRI: the canonical node for accession ACC is isoforms/ACC-1 in 2,985 of 3,000 sampled reviewed human entries (2026-08-20), so the lookup needs no ?seq variable and no string test at all."
     traps_avoided:
-      - "up:sequence on P01308 ALSO returns the INS-IGF2 readthrough isoform (isoforms/F8WCM5-1, 200 aa) typed Simple_Sequence — the naive query returns 2 sequences. Pin the accession's own -1 isoform IRI to get the canonical."
+      - "up:sequence on P01308 ALSO returns isoforms/F8WCM5-1 \u2014 the 200-aa INS-IGF2 readthrough, which belongs to a DIFFERENT accession \u2014 so a bare `?protein up:sequence ?seq` yields 2 sequences. Not a one-off: O94854 hangs five Q9UPN3-* isoform nodes off up:sequence and has no O94854-1 node at all."
+      - "Do NOT select the isoform with FILTER(CONTAINS(STR(?seq), \"/P01308-1\")). It passes alone (1.1s pinned) but it is a post-filter over whatever ?seq bound, so it does not survive being extended \u2014 and the query it was written in had no FROM. Measured 2026-08-20 with the two OPTIONALs above: unpinned FILTER form >200s (no result), unpinned direct-IRI form >200s too, pinned FILTER form 5.6s, this form ~1.5s. The FROM pin is the larger half of the fix (gotcha union_inflation); naming the IRI is what removes the remaining 4\u00d7."
+      - "isoforms/ACC-1 is not universal: ~0.5% of entries have no -1 node because the canonical was merged or demoted (Q9Y2K2 starts at -5, Q12955 at -3, Q8N7W2 at -2). If a direct-IRI lookup returns 0 rows, run `?p up:sequence ?seq` once and read the real node name, or scope by accession instead of by number: FILTER(STRSTARTS(STR(?seq), \"http://purl.uniprot.org/isoforms/P01308-\"))."
+      - "Every sequence node is typed BOTH up:Simple_Sequence AND up:External_Sequence, so a `?seq a ?class` binding doubles the rows. Naming the IRI avoids the type triple entirely; a fixed `?seq a up:Simple_Sequence` is safe but buys nothing here."
 
   - id: go_function
     intent: proteins by GO molecular-function term (OBO IRI namespace)

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.7.7"
+version = "2.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch release. **No tool, parameter, or return shape changed** — two MIE files and one docstring.

Three field reports, all of the same shape: a query that runs, returns rows, and is wrong or fragile in a way nothing signals. Worth recording for the next one — **two of the three reports named the wrong cause**, and the real cause only surfaced because the claim was reproduced instead of accepted.

### 1. ChEMBL: one UniProt accession → several targets of different `cco:targetType` (report was right)

`?target a cco:SingleProtein` silently returns a fraction of the answer: ChEMBL curates a mechanism onto whichever target entity the curator judged right, frequently not the single protein. Measured 2026-08-20 — SINGLE PROTEIN carries **4,948 of 6,990** mechanisms (70.8%), so the pin discards **2,042**; **1,974 of 12,253** UniProt-linked accessions (16.1%) map to more than one target type. P18505 drops to **zero** (all 69 of its drugs sit on PROTEIN COMPLEX / COMPLEX GROUP targets).

New verified example `moa_target_types` carries the positive route: bind `cco:targetType` as a column — it is on all 17,803 Targets and **0** TargetComponents, so it admits every kind while keeping components out. `class_enum` and `moa_integration` were both narrowed by the same pin and now say so.

### 2. UniProt: `sequence_mass` was fragile — but not for the reported reason

Reported as a `FILTER(CONTAINS())` problem. The 2×2 (2026-08-20, two `OPTIONAL`s added):

| | unpinned | `FROM`-pinned |
|---|---|---|
| `FILTER(CONTAINS(...))` | **>200s, no result** | 5.6s |
| direct isoform IRI | **>200s, no result** | **~1.5s** |

The missing `FROM` pin was the larger half — and the file's own `union_inflation` gotcha already prescribed it. The example now pins the graph and names `isoforms/P01308-1` directly (0.4s standalone). Verifying the replacement turned up three more traps, now recorded: `isoforms/ACC-1` is not universal (2,985/3,000 sampled; the rest start at `-2`/`-3`/`-5`), the cross-accession isoform trap recurs (O94854 → five `Q9UPN3-*` nodes, no `O94854-1`), and every sequence node carries **two** rdf:types.

### 3. `search_uniprot_entity`: the reported silent fallback does not exist

Reported as `go:` being an unsupported field that fell back to full text. It is a supported field doing a real ID lookup (`go:9999999` → 0 rows), unknown field names are rejected upstream with HTTP 400 (`'go_id' is not a valid search field`) and surface as the documented `"Error:"` string, and the "irrelevant" hits — keratocan, osteomodulin, syndecan-3 — genuinely carry `GO:0043202` in UniProt's own RDF (confirmed by SPARQL).

The real gap: `go` was absent from the docstring's field list, so correct behaviour read as a bug. Now documented, with the two ways it *can* mislead — 7-digit zero-padding required (`go:43202` → 0 rows, HTTP 200) and descendant expansion (192 direct → 214 with children) — plus a warning that a bad *field name* errors while a bad *value* fails silently.

### Verification

- `check_mie_examples.py` → chembl 12/12, uniprot 13/13, 0 zero-row / 0 error
- `uv run pytest` → 498 passed
- examples byte share: chembl 76.4% → 80.2%, uniprot 69.6% → 72.0% (corpus mean 64%)
- `discovery` blocks untouched, generated catalog unchanged (`test_catalog_in_sync` passes)
- No `whatsnew` marker: none of this is visible to a user who is not writing SPARQL or tool queries by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)