### PR TITLE
release: 2.10.0 — name the empty result, and the fork behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-29
+
+<!-- whatsnew: 2026-08-29 | When a SPARQL query comes back <strong>empty</strong>, the server now says so and explains why. An empty result has two causes that need opposite answers — the data is genuinely absent, or one line of the query is wrong and the real answer is not zero — and the reply now names the fork and the one probe that settles it. In a month of production logs, empty results outnumbered errors <strong>7.6 to 1</strong> and were mostly going unnoticed. -->
+
+A release about the failures that do not look like failures. Across 2026-07-27..08-29,
+`run_sparql` raised 163 times and returned HTTP 200 with an empty result **1,237 times** —
+and agents treated the second like a success, abandoning the task at 50.0% after a zero-row
+result versus 43.8% after a real one. Roughly 342 of those empty results were a broken query
+whose true answer was non-zero, and every one of them reached a user as "there is no data".
+
 ### Added
 
 - **`run_sparql` now diagnoses an empty result instead of returning a bare header.**
@@ -2127,6 +2137,7 @@ _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
 [Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.8...HEAD
+[2.10.0]: https://github.com/dbcls/togomcp/compare/v2.9.1...v2.10.0
 [2.9.1]: https://github.com/dbcls/togomcp/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/dbcls/togomcp/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/dbcls/togomcp/compare/v2.7.8...v2.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,62 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Added
+
+- **`run_sparql` now diagnoses an empty result instead of returning a bare header.**
+  This is the server's largest failure mode and it was invisible: across 2026-07-27..08-29,
+  `run_sparql` raised 163 times and returned HTTP 200 with an empty result **1,237 times**.
+  Agents did not react to the second — abandonment after a zero-row result (50.0%) barely
+  exceeded abandonment after a *successful* one (43.8%), and only 6.9% re-read the MIE
+  afterwards, the same rate as after a success.
+
+  An empty result is now prefixed with `#` comment lines (the CSV body is preserved
+  verbatim below them, so nothing that parsed before stops parsing). The block does not
+  merely say "0 rows" — it names the fork the wire format cannot express: **(A)** the
+  pattern is right and the data is genuinely absent, which on a sparse database *is* the
+  answer, versus **(B)** one triple pattern matches nothing and the real answer is
+  non-zero. Of those 1,237, roughly 816 were (A) and 342 were (B), and every (B) was
+  reported to a user as if it were (A). The block gives the single `ASK` probe that
+  settles it, worded as the pivot the 2-consecutive-SPARQL rule already reserves rather
+  than as a third query.
+
+  Two subtler cases are handled deliberately. An **aggregate that is 0 over an empty
+  match** — `SELECT (COUNT(*) AS ?n)` with no `GROUP BY` returns one row of `0`, so it is
+  structurally fine and invisible to any row-count test — gets the same treatment and the
+  same message; add `GROUP BY` and the identical query returns 0 rows instead (both
+  verified live 2026-08-29). An **`ASK` that is false** is left alone: it is an answer,
+  not an absence, and flagging it would teach agents to distrust it.
+
+  Up to two shape-aware lines are appended, ranked by measured lift in those logs: a
+  `VALUES` block of IRIs (17.6% empty vs 8.6% for literal `VALUES`) points at trap #11;
+  a query of >=1,200 chars (25.7% empty vs 8.0% at 400-700) gets bisection advice; quoted
+  literals point at trap #7. Capped at two, because past that the block stops being read.
+
+  Implemented at the tool layer, not in `execute_sparql` — `chembl.py` and `get_graph_list`
+  both parse that CSV, and prose in its return value would corrupt both. Follows the
+  existing ChEMBL convention that an empty result is not an endpoint failure and must not
+  be reported as one. MINOR when released: behaviour on a success path changes, all
+  existing calls still work.
+
+- **Usage Guide: silent-failure trap #11 — cross-namespace joins through TogoID relation
+  graphs.** A relation graph (`dataset/togoid/relation/<a>-<b>`) keys each side by TogoID's
+  canonical IRI for that dataset, which is frequently *not* the form the source database's own
+  graph mints: `chembl` uses `rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25`, the relation
+  graph holds `identifiers.org/chembl.compound/CHEMBL25`. The join finds no shared RDF term and
+  returns 0 rows with HTTP 200. Production logs (2026-07-27..08-29) show a MassBank spectra
+  lookup failing this way for every compound it asked about.
+
+  The rule is **not** "always use identifiers.org" — the form varies per dataset, and assuming
+  it would introduce the same bug in the other direction. Verified 2026-08-29: `ncbigene-go`
+  and `ensembl_transcript-go` key on `identifiers.org/`, while `chebi-inchi_key` keys ChEBI as
+  an OBO PURL and `nando-mondo` pairs an OBO PURL with a `nanbyodata.jp` IRI. The guide gives a
+  one-row probe that reports both sides before the join is written.
+
+  This was documented only in `massbank.yaml`, so it reached an agent only if it happened to
+  open that file first; the convention belongs to the relation graphs, not to any one database.
+  A matching TROUBLESHOOTING row notes that on a sparse database the empty join is
+  indistinguishable from a true negative.
+
 ## [2.9.1] - 2026-08-26
 
 <!-- whatsnew: 2026-08-26 | The per-database schema guides that steer every SPARQL query are now <strong>re-checked against the live endpoints automatically</strong>, weekly. The first full audit corrected <strong>28 incorrect warnings</strong> across the corpus — most of them claimed a query would time out when it in fact returns a plausible but <em>wrong</em> answer in seconds, which is the failure that actually costs you. -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.9.1"
+version = "2.10.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_empty_result_note.py
+++ b/tests/test_empty_result_note.py
@@ -1,0 +1,179 @@
+"""`run_sparql` must diagnose an empty result rather than return a bare header.
+
+Why this exists: in the 2026-07-27..08-29 production logs, `run_sparql` raised 163
+times and returned HTTP 200 with an empty result 1,237 times. Agents did not react
+to the second — abandonment after a zero-row result (50.0%) barely exceeded
+abandonment after a SUCCESSFUL one (43.8%), and only 6.9% re-read the MIE, the same
+rate as after a success. An empty body is indistinguishable from an answer.
+
+The bodies asserted below were captured from a live Virtuoso endpoint on 2026-08-29
+(`Accept: text/csv`), because the whole feature turns on which shapes are and are
+not "empty" on the wire.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from togo_mcp.rdf_portal import _empty_result_note
+
+# --- exact bodies, verified live 2026-08-29 -------------------------------- #
+NO_ROWS = '"s","p"\n'                    # SELECT matching nothing
+ASK_FALSE = '"bool"\n0\n'                # ASK {} that is false — a real ANSWER
+COUNT_ZERO = '"n"\n0\n'                  # SELECT (COUNT(*) AS ?n), no GROUP BY
+COUNT_SUM_ZERO = '"n","t"\n0,\n'         # SUM over an empty match is UNBOUND, not 0
+HAS_DATA = '"s"\n"urn:x"\n'
+
+
+def test_no_rows_is_diagnosed() -> None:
+    note = _empty_result_note(NO_ROWS, "SELECT ?s ?p WHERE { ?s ?p ?o }")
+    assert note is not None
+    assert note.startswith("#")
+    assert "0 rows" in note
+    assert "not an endpoint error" in note
+
+
+def test_note_names_both_causes_and_the_probe() -> None:
+    """The point is not "0 rows" — an agent can see that. It is which of the two
+    causes it is, since they need opposite answers."""
+    note = _empty_result_note(NO_ROWS, "SELECT ?s WHERE { ?s ?p ?o }")
+    assert "TRUE NEGATIVE" in note and "BROKEN PATTERN" in note
+    assert "ASK {" in note, "must give the probe that distinguishes the two causes"
+
+
+def test_ask_false_is_not_empty() -> None:
+    """`ASK` false is an ANSWER. Flagging it would teach agents to distrust it."""
+    assert _empty_result_note(ASK_FALSE, "ASK { ?s ?p ?o }") is None
+
+
+@pytest.mark.parametrize("body", [COUNT_ZERO, COUNT_SUM_ZERO])
+def test_zero_aggregate_is_diagnosed(body: str) -> None:
+    """A structurally-fine, semantically-empty row: `COUNT` over nothing is one row
+    of 0, so a row-count test cannot see it. This is the aggregate half of the same
+    failure and gets the SAME message — that consistency is the point."""
+    q = "SELECT (COUNT(*) AS ?n) WHERE { GRAPH <g> { ?s <p> ?o } }"
+    note = _empty_result_note(body, q)
+    assert note is not None
+    assert "EMPTY match" in note
+    assert "TRUE NEGATIVE" in note and "BROKEN PATTERN" in note
+
+
+def test_aggregate_with_group_by_is_left_alone() -> None:
+    """With GROUP BY the same query returns 0 rows instead (verified live), so the
+    no-rows branch owns it; the aggregate branch must not double-fire."""
+    q = "SELECT ?s (COUNT(*) AS ?n) WHERE { ?s ?p ?o } GROUP BY ?s"
+    assert _empty_result_note('"s","n"\n0,0\n', q) is None
+
+
+def test_real_data_is_untouched() -> None:
+    assert _empty_result_note(HAS_DATA, "SELECT ?s WHERE { ?s ?p ?o }") is None
+
+
+def test_nonzero_aggregate_is_untouched() -> None:
+    q = "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }"
+    assert _empty_result_note('"n"\n42\n', q) is None
+
+
+# --- shape-aware additions ------------------------------------------------- #
+
+def test_values_iri_block_gets_the_namespace_warning() -> None:
+    """VALUES-with-IRIs was 17.6% empty vs 8.6% for literals, and is the verified
+    MassBank/ChEMBL cross-namespace trap."""
+    q = 'SELECT ?x WHERE { VALUES ?c { <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25> } ?c ?p ?x }'
+    note = _empty_result_note(NO_ROWS, q)
+    assert "DIFFERENT IRIs in different graphs" in note
+    assert "trap #11" in note
+
+
+def test_values_of_literals_does_not_get_the_iri_warning() -> None:
+    q = 'SELECT ?x WHERE { VALUES ?n { "Trp53" "Cd4" } ?s ?p ?n }'
+    note = _empty_result_note(NO_ROWS, q)
+    assert "DIFFERENT IRIs in different graphs" not in note
+
+
+def test_long_query_gets_the_bisect_advice() -> None:
+    q = "SELECT ?s WHERE { ?s ?p ?o . " + "?s ?p2 ?o2 . " * 120 + "}"
+    assert len(q) >= 1200
+    note = _empty_result_note(NO_ROWS, q)
+    assert "Bisect" in note
+
+
+def test_at_most_two_shape_hints() -> None:
+    """Past two the block stops being read, so the cap is load-bearing."""
+    q = ('SELECT ?x WHERE { VALUES ?c { <http://example.org/a> } '
+         'FILTER(?l = "x") ' + "?s ?p ?o . " * 120 + "}")
+    note = _empty_result_note(NO_ROWS, q)
+    assert note.count("SEEN HERE:") <= 2
+
+
+def test_note_is_all_comment_lines() -> None:
+    """Every line must be `#`-prefixed so the CSV body below stays parseable."""
+    q = 'SELECT ?x WHERE { VALUES ?c { <http://example.org/a> } ?c ?p ?x }'
+    note = _empty_result_note(NO_ROWS, q)
+    assert all(ln.startswith("# ") for ln in note.splitlines())
+
+
+# --- the tool actually prepends it, and clients are told ------------------- #
+
+def test_run_sparql_prepends_the_note_and_keeps_the_csv(monkeypatch) -> None:
+    """End-to-end through the tool: the note rides ABOVE the body, and the body
+    survives. Prepending rather than replacing is what lets the aggregate case keep
+    its real `0` while both empty kinds share one output shape."""
+    import asyncio
+
+    from togo_mcp import rdf_portal
+
+    async def _fake(query, database="", endpoint_name="", endpoint_url=""):
+        return NO_ROWS
+
+    monkeypatch.setattr(rdf_portal, "execute_sparql", _fake)
+    # `run_sparql` is a bare function under some FastMCP versions and a FunctionTool
+    # under others; `.fn` unwraps the latter (cf. the note in CLAUDE.md).
+    call = getattr(rdf_portal.run_sparql, "fn", rdf_portal.run_sparql)
+    out = asyncio.run(
+        call(sparql_query="SELECT ?s ?p WHERE { ?s ?p ?o }", database="uniprot")
+    )
+    assert out.endswith(NO_ROWS), "the CSV body must be preserved verbatim"
+    assert out.startswith("# "), "the diagnosis must come first, where it is read"
+    assert "TRUE NEGATIVE" in out
+
+
+def test_run_sparql_leaves_a_populated_result_untouched(monkeypatch) -> None:
+    import asyncio
+
+    from togo_mcp import rdf_portal
+
+    async def _fake(query, database="", endpoint_name="", endpoint_url=""):
+        return HAS_DATA
+
+    monkeypatch.setattr(rdf_portal, "execute_sparql", _fake)
+    call = getattr(rdf_portal.run_sparql, "fn", rdf_portal.run_sparql)
+    out = asyncio.run(
+        call(sparql_query="SELECT ?s WHERE { ?s ?p ?o }", database="uniprot")
+    )
+    assert out == HAS_DATA
+
+
+def test_served_description_states_the_empty_result_contract() -> None:
+    """Asserted on what CLIENTS receive, not on `__doc__`.
+
+    `run_sparql` carries an explicit `description=`, and FastMCP serves that INSTEAD
+    of the docstring — it drops `Returns:` entirely. A return contract written in the
+    docstring reaches nobody (that exact failure shipped once, fixed 2026-08-26).
+    """
+    import asyncio
+
+    from togo_mcp.main import setup
+    from togo_mcp.server import mcp
+
+    async def _collect():
+        await setup()
+        return await mcp._list_tools()
+
+    tool = next(t for t in asyncio.run(_collect()) if t.name == "run_sparql")
+    desc = (tool.description or "").lower()
+    assert "empty" in desc, "clients must be told the empty-result contract exists"
+    assert "not an endpoint" in desc, (
+        "the description must say an empty result is NOT an endpoint failure — an "
+        "agent that reads it as one reports a false negative to the user"
+    )

--- a/tests/test_regex_two_arg_guard.py
+++ b/tests/test_regex_two_arg_guard.py
@@ -28,6 +28,17 @@ been *tested*, not a proof that nothing else is affected.
 The rule itself lives in `usage_guide_v6/03_workflows.md` (SILENT-FAILURE TRAPS
 #10) and in the mie-generator skill's `query-strategy.md`; this test enforces it
 against the corpus that ships.
+
+ONE narrow exemption, added 2026-08-29: a `check:` block whose `kind` is
+`zero_rows` or `error` (MIE v3 spec §3.6) asserts that its query FAILS, and a
+gotcha *about* two-argument REGEX cannot be tested by any other means — the
+broken form is the thing under test. Such queries are not "shipped SPARQL" in
+the sense this guard protects: `get_MIE_file` strips every `check:` block before
+serving (`rdf_portal._strip_check_blocks`), so no agent ever sees one to copy.
+The exemption is deliberately not extended to `kind: count`/`ratio`/`absent`,
+whose queries are meant to return real values — a two-arg REGEX there would
+silently corrupt the figure the check certifies, which is exactly the original
+bug in a new costume.
 """
 
 from __future__ import annotations
@@ -126,13 +137,40 @@ def test_mie_dir_is_populated():
     assert len(mie_files()) >= 30, f"expected the full MIE corpus, found {len(mie_files())}"
 
 
+def failure_expecting_check_paths(node, path: str = "") -> set[str]:
+    """Dotted paths of `check:` blocks that assert their query FAILS (spec §3.6).
+
+    Only `zero_rows` and `error` qualify; those two kinds pass precisely when the
+    query returns nothing / does not run, so a deliberately-broken pattern is the
+    payload rather than a defect.
+    """
+    found: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child = f"{path}.{key}"
+            if (
+                key == "check"
+                and isinstance(value, dict)
+                and value.get("kind") in {"zero_rows", "error"}
+            ):
+                found.add(child)
+            found |= failure_expecting_check_paths(value, child)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found |= failure_expecting_check_paths(value, f"{path}[{index}]")
+    return found
+
+
 @pytest.mark.parametrize("mie_path", mie_files(), ids=lambda p: p.stem)
 def test_no_two_arg_regex_in_executable_sparql(mie_path: Path):
     """Every REGEX() inside an executable `sparql` field must pass a flags argument."""
     document = yaml.safe_load(mie_path.read_text())
+    exempt = failure_expecting_check_paths(document)
     offenders: list[str] = []
     for path, text in walk_strings(document):
         if not EXECUTABLE_FIELD.search(path):
+            continue
+        if any(path.startswith(prefix + ".") for prefix in exempt):
             continue
         for call, n_args in find_regex_calls(text):
             if n_args < 3:

--- a/togo_mcp/data/docs/togomcp-intro.html
+++ b/togo_mcp/data/docs/togomcp-intro.html
@@ -786,6 +786,10 @@
     <ul class="whatsnew-list">
       <!-- WHATSNEW:START -->
       <li>
+        <span class="whatsnew-date">2026-08-29</span>
+        <span>When a SPARQL query comes back <strong>empty</strong>, the server now says so and explains why. An empty result has two causes that need opposite answers — the data is genuinely absent, or one line of the query is wrong and the real answer is not zero — and the reply now names the fork and the one probe that settles it. In a month of production logs, empty results outnumbered errors <strong>7.6 to 1</strong> and were mostly going unnoticed.</span>
+      </li>
+      <li>
         <span class="whatsnew-date">2026-08-26</span>
         <span>The per-database schema guides that steer every SPARQL query are now <strong>re-checked against the live endpoints automatically</strong>, weekly. The first full audit corrected <strong>28 incorrect warnings</strong> across the corpus — most of them claimed a query would time out when it in fact returns a plausible but <em>wrong</em> answer in seconds, which is the failure that actually costs you.</span>
       </li>
@@ -800,10 +804,6 @@
       <li>
         <span class="whatsnew-date">2026-08-01</span>
         <span><strong>ChatGPT users: refresh your connector.</strong> ChatGPT records TogoMCP's tool list when the connector is added and never refetches it, so tools added since then are invisible to it — re-run <em>Scan Tools</em>, or remove and re-add the connector. New databases are unaffected; those arrive through the live usage guide.</span>
-      </li>
-      <li>
-        <span class="whatsnew-date">2026-07-31</span>
-        <span>New database: the <strong>NHGRI-EBI GWAS Catalog</strong> — 955,930 SNP–trait associations across 89,981 studies, with p-values, effect sizes, risk alleles and mapped genes, joinable to EFO trait terms. Ask things like "which variants are associated with QT interval, and how strong is the evidence?"</span>
       </li>
       <!-- WHATSNEW:END -->
     </ul>

--- a/togo_mcp/data/mie/clinvar.yaml
+++ b/togo_mcp/data/mie/clinvar.yaml
@@ -1,10 +1,16 @@
-# MIE v3 — ClinVar (NCBI clinical variation archive). AGENT-authored 2026-07-22 on `mie-redesign`.
-# Format: togo_mcp/data/docs/MIE_v3_spec.md. Every verified count/result re-run live on the clinvar
-# endpoint 2026-07-22. Tier-B in enumeration_audit.md: the significance-value enumeration is already a
-# first-class v2 route — carried across here as `enum_significance`, with its TWO load-bearing caveats
-# (the THREE classification branches + the ~3.7x disease-bnode inflation) kept inline with the queries.
-# Byte count vs v2 (spec §5 item 7): v2 togo_mcp/data/mie/clinvar.yaml = 42,101 bytes; this v3 file
-# = 20,307 bytes → 51.8% smaller. Exact `wc -c` figures in the footer.
+# MIE v3 — ClinVar (NCBI clinical variation archive). AGENT-authored 2026-07-22 on `mie-redesign`;
+# REVISED 2026-08-29 (§3.6 check: sweep + 2g re-probe). Format: togo_mcp/data/docs/MIE_v3_spec.md.
+# Every count/result below re-run live on the clinvar endpoint 2026-08-29 — the underlying ClinVar
+# snapshot has NOT moved since 2026-07-22 (every figure re-measured identical), so a future re-run
+# that disagrees is a genuine data refresh, not noise.
+# What the 2026-08-29 pass CHANGED (all four were untested prose, now checked):
+#   - `from_clause` said an unpinned query "can 0-row or return wrong data". Re-measured: ClinVar's
+#     IRIs are re-declared by NOBODY (2g, all legs) and class-anchored joins are ×1.00 pinned-vs-not.
+#     The pin earns its keep for a DIFFERENT reason, now stated and checked (silent aggregate truncation).
+#   - `source_case` claimed filtering one spelling "silently misses ~half". FALSE for MeSH (MESH = 180
+#     rows, 0.02%); TRUE and worse for HP (68.3% missed). Corrected to the measured split.
+#   - `gene_bnode` and `included_no_classrec` carried real figures with nothing to re-decide them.
+#   - NEW example `enum_xref_source` — the 153-vocabulary xref enumeration had no first-class route.
 mie_spec: 3                        # format version — see MIE_v3_spec.md §2
 database: clinvar
 
@@ -20,53 +26,149 @@ discovery:
   categories: [variant, disease]
 
 # ── provenance + database-wide truths (get_MIE_file only) ──
-endpoint: https://rdfportal.org/ncbi/sparql   # the shared NCBI endpoint (~58 graphs); ClinVar is one dataset on it
+endpoint: https://rdfportal.org/ncbi/sparql   # the shared NCBI endpoint (59 graphs); ClinVar is one dataset on it
 base_uri: http://ncbi.nlm.nih.gov/clinvar/
 graphs:
   primary: http://rdfportal.org/dataset/clinvar   # the ONLY graph that types cvo:VariationArchiveType / cvo:Gene / the classification bnodes
-  co_hosted:                       # same NCBI endpoint. Reverse-probe (v2, 2026-07-17): NO co-hosted graph
-                                   # re-types or re-labels a ClinVar IRI → zero row-inflation. All are JOIN targets, not traps.
+  # get_graph_list → 59 graphs, so the 2g re-declaration probe is MANDATORY. It was run, and it is CLEAN:
+  probed_clean: >
+    2g reverse probe re-run 2026-08-29 (?p UNBOUND, no type filter) over 7 nodes spanning every leg:
+    the variant IRI …/clinvar/variation/856461, ClinVar's gene IRI …/gene/672, NCBI Gene's
+    identifiers.org/ncbigene/672, BOTH MedGen IRI forms of C0677776, and MeSH descriptors D061325 +
+    D001943. EVERY node resolves in exactly ONE graph — variant 21 triples and gene 1,075 triples in
+    dataset/clinvar and nowhere else; ncbigene/medgen/mesh nodes only in their own graphs. So NO
+    co-hosted graph re-types, re-labels or re-declares any ClinVar IRI: row-inflation kind 1 and
+    value-conflict kind 2 are BOTH ruled out for ClinVar-minted IRIs, and a class-anchored join
+    measures ×1.00 pinned vs unpinned (see gotcha from_clause, which is about kind 3 — scope bleed on
+    the generic predicates — not about re-declaration).
+  co_hosted:                       # same NCBI endpoint. All are JOIN TARGETS, not inflation traps.
     dataset/medgen: >
       JOIN target — ClinVar's disease TypeXref rdfs:seeAlso points at MedGen concepts, BUT ClinVar writes
       http://ncbi.nlm.nih.gov/medgen/C* (no www) while MedGen types http://www.ncbi.nlm.nih.gov/medgen/C*
-      (WITH www). A direct-IRI join silently 0-rows; swap www→no-www (example xdb_medgen). No inflation.
+      (WITH www). Measured 2026-08-29: the no-www IRI carries 74,605 seeAlso links inside dataset/clinvar
+      and ZERO triples in ANY graph as a subject (it is a pure link target that nothing describes); the
+      www IRI carries 413 triples in dataset/medgen and zero in clinvar. Swap www→no-www (example
+      xdb_medgen). No inflation. NOTE medgen also asserts 5 triples on identifiers.org/ncbigene/672.
     dataset/ncbigene: >
       JOIN target — ClinVar's gene IRIs are http://ncbi.nlm.nih.gov/gene/{id}; NCBI Gene RDF types
-      http://identifiers.org/ncbigene/{id} (disjoint namespace). Join on the shared integer gene id, not the IRI.
+      http://identifiers.org/ncbigene/{id} (disjoint namespace, confirmed 2026-08-29: 472 triples on the
+      identifiers.org form in dataset/ncbigene, 0 on ClinVar's form). Join on the shared integer gene id.
     dataset/pubtator_central + dataset/pubmed: >
       Literature reach (co-mention → PubMed), but only via a MedGen→MeSH bridge two hops out — a single
-      ClinVar+PubTator+PubMed join TIMES OUT; run the MedGen-CUI discovery step separately first.
+      ClinVar+PubTator+PubMed join TIMES OUT; run the MedGen-CUI discovery step separately first. Both
+      graphs are also heavy users of dct:source (39.0M and 3.8M triples) — see gotcha from_clause.
     "id.nlm.nih.gov/mesh (+12 year graphs)": >
-      MeSH descriptors. ClinVar asserts NOTHING on MeSH IRIs (probed) — reach MeSH only through the disease
-      TypeXref dct:identifier ("D061325"), not by expecting ClinVar triples on a mesh: IRI.
+      MeSH descriptors. ClinVar asserts NOTHING on MeSH IRIs (re-probed 2026-08-29 — D061325 and D001943
+      resolve ONLY in id.nlm.nih.gov/mesh, and not in the 12 year graphs either). Reach MeSH through the
+      disease TypeXref dct:identifier ("D061325"), not by expecting ClinVar triples on a mesh: IRI.
 
-entity_counts:                     # graph-pinned, COUNT(DISTINCT), live 2026-07-22
+entity_counts:                     # graph-pinned, COUNT(DISTINCT), all re-run live 2026-08-29 (unchanged since 2026-07-22)
   classified_variants: 3588257     # cvo:record_type "classified" — HAVE cvo:classified_record
   included_variants: 712           # cvo:record_type "included" — LACK cvo:classified_record (gotcha included_no_classrec)
   total_variants: 3588969
-  gene_entities: 92318             # IRI-typed cvo:Gene ONLY — see gene_bnode gotcha; raw cvo:Gene = 4,964,971 (mostly per-record bnodes)
+  gene_entities: 92318             # IRI-typed cvo:Gene ONLY — see gene_bnode gotcha
+  gene_bnodes: 4872653             # per-record BLANK nodes ALSO typed cvo:Gene; 92,318 + 4,872,653 = 4,964,971 raw
   pathogenic_germline: 200004      # DISTINCT variants with germline cvo:description "Pathogenic" (example enum_significance)
+  xref_source_vocabularies: 153    # DISTINCT dct:source values on TypeXref nodes (example enum_xref_source)
+  date: "2026-08-29"
 
-global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-07-22
+global_gotchas:                    # the few that bite ANY query on this DB — all re-verified 2026-08-29
   - id: from_clause
     say: >
-      Always FROM (or GRAPH-pin) <http://rdfportal.org/dataset/clinvar>. The NCBI endpoint co-hosts ~58
-      graphs; an unpinned pattern mixes them and can 0-row or return wrong data. Every example pins the graph.
+      Always FROM (or GRAPH-pin) <http://rdfportal.org/dataset/clinvar> — but NOT for the reason you
+      may expect, and the real reason is nastier. No co-hosted graph re-declares a ClinVar IRI (2g
+      probed clean, all legs), so a query anchored on a cvo: class or a ClinVar IRI measures ×1.00
+      pinned vs unpinned: `?v a cvo:VariationArchiveType ; rdfs:label ?l ; cvo:variation_type ?t`
+      returns 3,588,969 either way. The danger is patterns anchored on the GENERIC predicates ClinVar
+      shares with its co-tenants (dct:source, dct:identifier, dct:references, rdfs:label): dct:source
+      alone is 72.2M triples in clinvar, 39.0M in pubmed, 3.8M in pubtator_central, 3.5M in medgen.
+      Unpinned, such an aggregate does TWO wrong things at once and reports neither. (1) It mixes in
+      MedGen's IRI-valued vocabulary — `?ref dct:source ?source ; dct:identifier ?id` GROUP BY ?source
+      returns http://med2rdf/ontology/medgen#GTR, #NCI, #OMIM, #MSH, #HPO, terms that do not exist in
+      ClinVar at all, at the TOP of the list. (2) Virtuoso silently TRUNCATES the aggregate: it reports
+      its largest group as 806,529 when the true largest group ("MedGen") is 19,973,218 — a ×24.8
+      UNDER-count, deterministic (identical on repeat runs), delivered ORDER BY DESC with no error and
+      no warning. Pinned, the same query returns complete counts over 153 source vocabularies. Do not
+      read a fast, well-ordered aggregate as a correct one.
+    check:
+      kind: ratio
+      date: "2026-08-29"
+      # Each leg returns ONE scalar: the largest group the engine reports for the same aggregate.
+      numerator: |
+        PREFIX dct: <http://purl.org/dc/terms/>
+        SELECT ?n FROM <http://rdfportal.org/dataset/clinvar> WHERE {
+          { SELECT (COUNT(*) AS ?n) WHERE { ?ref dct:source ?source ; dct:identifier ?id . }
+            GROUP BY ?source ORDER BY DESC(?n) LIMIT 1 }
+        }
+      denominator: |
+        PREFIX dct: <http://purl.org/dc/terms/>
+        SELECT ?n WHERE {
+          { SELECT (COUNT(*) AS ?n) WHERE { ?ref dct:source ?source ; dct:identifier ?id . }
+            GROUP BY ?source ORDER BY DESC(?n) LIMIT 1 }
+        }
+      expect: {ratio: 24.76, tolerance: 0.25}
+
   - id: included_no_classrec
     say: >
-      The 712 cvo:record_type "included" variants have NO cvo:classified_record, so ANY classification /
-      gene-link / significance traversal silently drops them (and, worse, if you forget the type filter you
-      may traverse into nothing). Add cvo:record_type "classified" whenever you navigate a classified_record bnode.
+      The 712 cvo:record_type "included" variants have NO cvo:classified_record — not "few", zero: the
+      join `?v cvo:record_type "included" ; cvo:classified_record ?cr` returns 0 rows. So ANY
+      classification / gene-link / significance traversal silently drops them. Add cvo:record_type
+      "classified" whenever you navigate a classified_record bnode, so the exclusion is explicit
+      rather than an accident of the join.
+    check:
+      kind: absent
+      date: "2026-08-29"
+      query: |
+        PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+        WHERE { ?v a cvo:VariationArchiveType ; cvo:record_type "included" ; cvo:classified_record ?cr . }
+
   - id: gene_bnode
     say: >
-      cvo:Gene is applied to 4,964,971 nodes but only 92,318 are IRI gene entities — the other ~4.87M are
-      per-record BLANK nodes. `COUNT(?g WHERE ?g a cvo:Gene)` massively over-counts "how many genes". Count
-      genes as isIRI(?g), or count DISTINCT gene IRIs reached via med2rdf:gene. The IRI is ncbi.nlm.nih.gov/gene/{id}.
+      cvo:Gene is applied to 4,964,971 nodes but only 92,318 are IRI gene entities — the other
+      4,872,653 are per-record BLANK nodes. `COUNT(?g WHERE ?g a cvo:Gene)` over-counts "how many
+      genes" by ×53.8. Count genes with FILTER(isIRI(?g)), or count DISTINCT gene IRIs reached via
+      med2rdf:gene; the IRI is ncbi.nlm.nih.gov/gene/{id}. CRITICAL — do NOT reach for the arithmetic
+      form instead: on this Virtuoso, `SUM(IF(isIRI(?g),1,0))` returns 4,964,971, i.e. it counts every
+      blank node as an IRI, while `FILTER(isIRI(?g))` on the identical data returns 92,318. The tell is
+      that IF() is self-inconsistent — in one query SUM(IF(isIRI)) = 4,964,971 and SUM(IF(isBlank)) =
+      4,872,653, which sum to more than the 4,964,971 rows scanned. Only the FILTER form is correct.
+    check:
+      kind: ratio
+      date: "2026-08-29"
+      # numerator = the broken IF() form; denominator = the correct FILTER form. Same data, same graph.
+      numerator: |
+        PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+        SELECT (SUM(IF(isIRI(?g),1,0)) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+        WHERE { ?g a cvo:Gene . }
+      denominator: |
+        PREFIX cvo: <http://purl.jp/bio/10/clinvar/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+        WHERE { ?g a cvo:Gene . FILTER(isIRI(?g)) }
+      expect: {ratio: 53.78, tolerance: 0.05}
+
   - id: source_case
     say: >
-      dct:source on disease TypeXref nodes has case-inconsistent duplicates: both "MeSH" and "MESH" exist,
-      and "HP" vs "Human Phenotype Ontology" coexist. Filtering one spelling silently misses ~half. Use
-      VALUES ?source { "MeSH" "MESH" } (etc.) when selecting a source.
+      dct:source on disease TypeXref nodes has case- and spelling-inconsistent duplicates, but they are
+      NOT equally costly and an earlier version of this file overstated it. Measured 2026-08-29: the
+      MeSH split is negligible — "MeSH" 834,628 vs "MESH" 180 (0.02%), so filtering "MeSH" alone is
+      safe. The PHENOTYPE split is the one that bites: "Human Phenotype Ontology" 722,578 vs "HP"
+      336,084 vs "HPO" 64, so `dct:source "HP"` alone silently returns only 31.7% of phenotype xrefs —
+      it misses 68.3%. Use VALUES ?source { "HP" "Human Phenotype Ontology" "HPO" } for phenotypes. The
+      general fix is to enumerate the 153 source values first (example enum_xref_source) rather than
+      guessing a spelling — the vocabulary is not documented anywhere and not case-normalized.
+    check:
+      kind: ratio
+      date: "2026-08-29"
+      numerator: |
+        PREFIX dct: <http://purl.org/dc/terms/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+        WHERE { ?ref dct:source ?s . FILTER(?s IN ("HP","Human Phenotype Ontology","HPO")) }
+      denominator: |
+        PREFIX dct: <http://purl.org/dc/terms/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+        WHERE { ?ref dct:source "HP" . }
+      expect: {ratio: 3.15, tolerance: 0.05}
 
 # ── examples: verified, executable atoms. Central entity = cvo:VariationArchiveType (IRI
 #    …/clinvar/variation/{id}). Classification & gene links hang off a cvo:classified_record BLANK node;
@@ -82,10 +184,10 @@ examples:
       FROM <http://rdfportal.org/dataset/clinvar>
       WHERE { <http://ncbi.nlm.nih.gov/clinvar/variation/856461> ?property ?value . }
       LIMIT 50
-    verified: {result_rows: 21, date: "2026-07-22", note: "VCV000856461 = NM_007294.4(BRCA1):c.2244dup, Duplication, record_type classified; carries 2 med2rdf:disease bnodes"}
+    verified: {result_rows: 21, date: "2026-08-29", note: "VCV000856461 = NM_007294.4(BRCA1):c.2244dup (p.Asp749fs), Duplication, record_type classified, 1 submission; carries 2 med2rdf:disease bnodes"}
     teaches: "The variation IRI tail = cvo:variation_id (integer); cvo:accession is the VCV string. Direct properties are flat literals; classification/gene/disease all sit BEHIND blank nodes (following examples)."
     traps_avoided:
-      - "A variant carries MULTIPLE med2rdf:disease bnodes pointing at the SAME disease (one per SCV submission) — visible here as two nodeIDs. This is the seed of the ~3.7x inflation (see disease_xref_count)."
+      - "A variant carries MULTIPLE med2rdf:disease bnodes pointing at the SAME disease (one per SCV submission) — visible here as two nodeIDs on a variant with only ONE submission. This is the seed of the ~3.7x inflation (see disease_xref_count)."
 
   - id: variants_by_gene
     intent: variants linked to specific genes via the NCBI Gene IRI (the structured, non-text route)
@@ -112,7 +214,7 @@ examples:
                  cvo:classified_record ?classrec .
       }
       LIMIT 10
-    verified: {result_rows: 10, date: "2026-07-22", first_row: "variation/856461 NM_007294.4(BRCA1):c.2244dup"}
+    verified: {result_rows: 10, date: "2026-08-29", first_row: "variation/856461 NM_007294.4(BRCA1):c.2244dup"}
     teaches: "Variant→gene is a 2-hop blank-node walk: variant --cvo:classified_record--> ?classrec --sio:SIO_000628--> ?gene_bn --med2rdf:gene--> gene IRI. VALUES on gene IRIs prunes 3.5M variants to the target gene(s) up front."
     traps_avoided:
       - "rdfs:label is HGVS free text, not a gene symbol — never text-match it to find a gene's variants; resolve the gene id first and use the IRI. bif:contains on the label is exploratory only."
@@ -137,12 +239,44 @@ examples:
       GROUP BY ?significance
       ORDER BY DESC(?n)
       LIMIT 20
-    verified: {top: "Uncertain significance 1,821,577; Likely benign 993,150; Benign 213,802; Pathogenic 200,004; Likely pathogenic 107,204", date: "2026-07-22"}
+    verified: {result_rows: 20, date: "2026-08-29", top: "Uncertain significance 1,821,577; Likely benign 993,150; Benign 213,802; Pathogenic 200,004; Conflicting classifications of pathogenicity 145,497; Likely pathogenic 107,204"}
     teaches: "THE set-level significance enumeration: the controlled value lives on cvo:description of the germline classification bnode, reached variant → classified_record → cvo:classifications → cvo:germline_classification → cvo:description. Pin the exact string (e.g. \"Pathogenic\") to count/list one class; COUNT(DISTINCT ?variant) because a variant can have multiple submissions."
     traps_avoided:
       - "THREE classification BRANCHES exist under cvo:classifications: cvo:germline_classification, cvo:oncogenicity_classification, cvo:somatic_clinical_impact. This query enumerates ONLY germline; a cancer/somatic variant classified 'Oncogenic' has NO germline node and is silently absent (see oncogenicity_kras for the other two branches)."
-      - "Omitting cvo:record_type \"classified\" lets the 712 'included' variants (no classified_record) enter the pattern and adds nothing but risk (gotcha included_no_classrec)."
-
+      - say: |-
+          The vocabulary is NOT just the 5 headline classes — it includes compound values ('Benign/Likely benign', 'Pathogenic/Likely pathogenic'), semicolon-joined values ('Pathogenic; drug response', 'Pathogenic; other') and non-pathogenicity values ('drug response', 'risk factor', 'Affects'). An equality test on "Pathogenic" therefore EXCLUDES the 34,673 'Pathogenic/Likely pathogenic' and the 80 'Pathogenic; other' variants. Decide deliberately between = and a CONTAINS/IN set; do not assume the 5 classes are exhaustive.
+        check:
+          kind: count
+          date: '2026-08-29'
+          expect:
+            value: 34673
+          query: "PREFIX cvo: <http://purl.jp/bio/10/clinvar/>\nSELECT (COUNT(DISTINCT ?variant) AS ?n) FROM <http://rdfportal.org/dataset/clinvar> WHERE {\n  ?variant a cvo:VariationArchiveType ; cvo:record_status \"current\" ; cvo:record_type \"classified\" ; cvo:classified_record ?cr .\n  ?cr cvo:classifications ?cl . ?cl cvo:germline_classification ?g .\n  ?g cvo:description \"Pathogenic/Likely pathogenic\" . }"
+  - id: enum_xref_source
+    intent: enumerate the controlled vocabulary of disease-xref SOURCES (the set-level xref route)
+    question: "Which cross-reference vocabularies does ClinVar link its diseases to, and how heavily?"
+    complexity: aggregation
+    sparql: |
+      PREFIX dct: <http://purl.org/dc/terms/>
+      # The graph pin is LOAD-BEARING here, not decorative — see gotcha from_clause.
+      SELECT ?source (COUNT(*) AS ?n)
+      FROM <http://rdfportal.org/dataset/clinvar>
+      WHERE { ?ref dct:source ?source ; dct:identifier ?id . }
+      GROUP BY ?source
+      ORDER BY DESC(?n)
+      LIMIT 15
+    verified: {result_rows: 15, distinct_sources_total: 153, date: "2026-08-29", top: "MedGen 19,973,218; PubMed 15,835,938; OMIM 11,822,932; MONDO 4,650,710; BookShelf 3,006,575; dbSNP 2,978,968; Genetic Testing Registry (GTR) 2,967,616; ClinGen 2,893,282; Orphanet 2,453,877"}
+    teaches: "Run this FIRST before filtering on any dct:source value. The source vocabulary is 153 free-text strings with no controlled list published anywhere and no case normalization, so the only safe way to pick a filter value is to read the actual values off the data. It also reveals xref targets not advertised elsewhere in this file (dbSNP, ClinGen, GeneReviews, SNOMED CT)."
+    traps_avoided:
+      - say: |-
+          Dropping the FROM clause here does not error — it returns a DIFFERENT, wrong list: MedGen's IRI-valued sources (http://med2rdf/ontology/medgen#GTR, #NCI, #OMIM, #MSH, #HPO) occupy 5 of the top 8 slots, and every count is silently truncated (largest group reported as 806,529 against a true 19,973,218). The unpinned form is FASTER and looks tidier. See gotcha from_clause.
+        check:
+          kind: absent
+          date: '2026-08-29'
+          query: 'PREFIX dct: <http://purl.org/dc/terms/>
+          
+            SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+          
+            WHERE { ?ref dct:source <http://med2rdf/ontology/medgen#GTR> . }'
   - id: sig_by_gene
     intent: significance breakdown for ONE gene — the gene pin and the classification walk composed in one query
     question: "How many EGFR variants fall in each germline clinical-significance class?"
@@ -169,10 +303,15 @@ examples:
       GROUP BY ?significance
       ORDER BY DESC(?n)
       LIMIT 20
-    verified: {result_rows: 12, date: "2026-07-30", top: "Uncertain significance 1,570; Likely benign 1,309; Conflicting classifications of pathogenicity 155; Benign/Likely benign 120; Benign 107; Pathogenic 80", runtime: "0.3s"}
+    verified: {result_rows: 12, date: "2026-08-29", top: "Uncertain significance 1,570; Likely benign 1,309; Conflicting classifications of pathogenicity 155; Benign/Likely benign 120; Benign 107; Pathogenic 80", runtime: "0.3s"}
     teaches: "The per-gene significance question is the two walks COMPOSED, both hanging off the SAME ?classrec bnode: enter at the gene (med2rdf:gene → sio:SIO_000628 → ?classrec) and read the classification off that same node. Anchoring on the gene IRI first prunes 3.59M variants before the classification join, so the whole query runs in well under a second."
     traps_avoided:
-      - "DO NOT reach significance via cvo:TypeAlleleDescr + cvo:clinical_significance — it is a near-empty dead end that returns 0 rows with NO error for almost every gene. Verified 2026-07-30: of 26,161 cvo:TypeAlleleDescr nodes only 280 carry cvo:clinical_significance, and those 280 cover BRCA2 (190) and BRCA1 (90) and NOTHING ELSE — so the identical query for EGFR (or any other gene) returns 0. Significance lives on the classification bnode reached through cvo:classified_record, as above. This shape accounted for 340 of 341 zero-row ClinVar queries in the 2026-07-27..29 production logs."
+      - say: |-
+          DO NOT reach significance via cvo:TypeAlleleDescr + cvo:clinical_significance — it is a near-empty dead end that returns 0 rows with NO error for almost every gene. Re-verified 2026-08-29: of 26,161 cvo:TypeAlleleDescr nodes only 280 carry cvo:clinical_significance, and those 280 cover EXACTLY two genes — BRCA2 (190) and BRCA1 (90) — so the identical query for EGFR (or any other gene) returns 0. Significance lives on the classification bnode reached through cvo:classified_record, as above. This shape accounted for 340 of 341 zero-row ClinVar queries in the 2026-07-27..29 production logs.
+        check:
+          kind: zero_rows
+          date: '2026-08-29'
+          query: "PREFIX cvo: <http://purl.jp/bio/10/clinvar/>\nSELECT ?sig (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>\nWHERE { ?d a cvo:TypeAlleleDescr ; cvo:name ?name ; cvo:clinical_significance ?sig .\n        FILTER(STRSTARTS(STR(?name), \"EGFR:\")) }\nGROUP BY ?sig"
       - "cvo:name on a TypeAlleleDescr node is \"SYMBOL:c.HGVS\" (e.g. \"BTK:c.1899C>T\"), which makes STRSTARTS(?name, \"EGFR:\") LOOK like a valid gene filter. It is not a substitute for the gene IRI — besides the sparsity above, it is free text with no controlled vocabulary."
 
   - id: count_variation_type
@@ -191,8 +330,8 @@ examples:
       GROUP BY ?variation_type
       ORDER BY DESC(?count)
       LIMIT 30
-    verified: {top: "single nucleotide variant 3,236,823; Deletion 160,620; Duplication 73,448; Microsatellite 36,328", date: "2026-07-22"}
-    teaches: "cvo:variation_type is a flat literal directly on the variant (no bnode) — the cheapest categorical facet. Because it needs no classification traversal, this aggregation completes without a per-gene pre-filter."
+    verified: {result_rows: 21, date: "2026-08-29", top: "single nucleotide variant 3,236,823; Deletion 160,620; Duplication 73,448; Microsatellite 36,328; copy number gain 24,800; copy number loss 22,592"}
+    teaches: "cvo:variation_type is a flat literal directly on the variant (no bnode) — the cheapest categorical facet, and the full vocabulary is only 21 values. Because it needs no classification traversal, this aggregation completes without a per-gene pre-filter."
 
   - id: disease_xref_count
     intent: variant→disease xref navigation AND correct counting past the duplicate-bnode inflation
@@ -217,11 +356,19 @@ examples:
         ?dis dct:references ?ref .
         ?ref dct:source "MedGen" ; dct:identifier ?cui .
       }
-    verified: {variants: 3989, diseases: 45, date: "2026-07-22"}
+    verified: {variants: 3989, diseases: 45, date: "2026-08-29"}
     teaches: "Disease xrefs live on TypeXref bnodes: med2rdf:disease → dct:references → node with dct:source (\"MedGen\"/\"OMIM\"/\"Orphanet\"/\"MONDO\"/\"MeSH\") + dct:identifier + optional rdfs:seeAlso. Always aggregate with COUNT(DISTINCT ?variant) / COUNT(DISTINCT ?cui)."
     traps_avoided:
-      - "The IDENTICAL query with COUNT(*) returns 14,769 — ~3.7x inflation — because med2rdf:disease emits one duplicate bnode PER SCV submission, all pointing to the same disease. DISTINCT on the bnode (?dis) does NOT help (each bnode is already unique); you MUST de-dup on ?variant and on dct:identifier. Verified 14,769 raw vs 3,989 variants / 45 CUIs, 2026-07-22."
-
+      - say: |-
+          The IDENTICAL query with COUNT(*) returns 14,769 — a x3.70 inflation — because med2rdf:disease emits one duplicate bnode PER SCV submission, all pointing to the same disease. DISTINCT on the bnode (?dis) does NOT help (each bnode is already unique); you MUST de-dup on ?variant and on dct:identifier. Re-verified 2026-08-29: 14,769 raw rows vs 3,989 variants / 45 CUIs.
+        check:
+          kind: ratio
+          date: '2026-08-29'
+          numerator: "PREFIX cvo: <http://purl.jp/bio/10/clinvar/>\nPREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>\nPREFIX sio: <http://semanticscience.org/resource/>\nPREFIX dct: <http://purl.org/dc/terms/>\nSELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar> WHERE {\n  ?gene_bn med2rdf:gene <http://ncbi.nlm.nih.gov/gene/672> .\n  ?classrec sio:SIO_000628 ?gene_bn .\n  ?variant cvo:record_type \"classified\" ; cvo:classified_record ?classrec ; med2rdf:disease ?dis .\n  ?classrec cvo:classifications ?cls .\n  ?cls cvo:germline_classification/cvo:description \"Pathogenic\" .\n  ?dis dct:references ?ref . ?ref dct:source \"MedGen\" ; dct:identifier ?cui . }"
+          denominator: "PREFIX cvo: <http://purl.jp/bio/10/clinvar/>\nPREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>\nPREFIX sio: <http://semanticscience.org/resource/>\nPREFIX dct: <http://purl.org/dc/terms/>\nSELECT (COUNT(DISTINCT ?variant) AS ?n) FROM <http://rdfportal.org/dataset/clinvar> WHERE {\n  ?gene_bn med2rdf:gene <http://ncbi.nlm.nih.gov/gene/672> .\n  ?classrec sio:SIO_000628 ?gene_bn .\n  ?variant cvo:record_type \"classified\" ; cvo:classified_record ?classrec ; med2rdf:disease ?dis .\n  ?classrec cvo:classifications ?cls .\n  ?cls cvo:germline_classification/cvo:description \"Pathogenic\" .\n  ?dis dct:references ?ref . ?ref dct:source \"MedGen\" ; dct:identifier ?cui . }"
+          expect:
+            ratio: 3.7
+            tolerance: 0.05
   - id: oncogenicity_kras
     intent: the somatic/oncogenicity branches (NOT germline) — the classifications a germline query misses
     question: "What is the oncogenicity classification and somatic clinical-impact tier of KRAS variants?"
@@ -246,8 +393,10 @@ examples:
         OPTIONAL { ?classi cvo:somatic_clinical_impact ?sci . ?sci cvo:description ?somatic_impact . }
       }
       LIMIT 50
-    verified: {result_rows: 19, date: "2026-07-22", first_row: "KRAS c.183A>C (p.Gln61His) → Oncogenic / Tier II - Potential"}
+    verified: {result_rows: 19, date: "2026-08-29", first_row: "KRAS c.183A>C (p.Gln61His) → Oncogenic / Tier II - Potential", note: "only 1 of the 19 carries a somatic_clinical_impact value — hence the OPTIONAL"}
     teaches: "cvo:oncogenicity_classification (\"Oncogenic\"/\"Likely oncogenic\"/…) and cvo:somatic_clinical_impact (\"Tier I–IV\") are SIBLINGS of cvo:germline_classification under the same cvo:classifications node — each on its own bnode with its own cvo:description. Somatic impact is sparse → OPTIONAL it. This is why a germline-only enumeration undercounts cancer variants."
+    traps_avoided:
+      - "The oncogenicity vocabulary is NOT disjoint from the germline one — the same cvo:description predicate on this branch also yields 'Likely benign' and 'Uncertain significance' (both present among these 19 KRAS rows). So you cannot tell which branch a value came from by inspecting the value; you must read it from the branch predicate you traversed."
 
   - id: xdb_medgen
     intent: "cross-DB: ClinVar variants → MedGen disease-concept label, across the co-hosted NCBI endpoint"
@@ -259,7 +408,7 @@ examples:
       PREFIX med2rdf: <http://med2rdf.org/ontology/med2rdf#>
       PREFIX mo: <http://med2rdf/ontology/medgen#>
       PREFIX dct: <http://purl.org/dc/terms/>
-      SELECT ?var_label ?var_type ?medgen_cui ?medgen_label
+      SELECT DISTINCT ?var_label ?var_type ?medgen_cui ?medgen_label
       WHERE {
         GRAPH <http://rdfportal.org/dataset/medgen> {
           VALUES ?medgen_concept { <http://www.ncbi.nlm.nih.gov/medgen/C0677776> }
@@ -274,15 +423,21 @@ examples:
         }
       }
       LIMIT 10
-    verified: {result_rows: 10, date: "2026-07-22", first_row: "NM_007294.4(BRCA1):c.453T>G → 'Hereditary breast ovarian cancer syndrome'"}
-    teaches: "MedGen is co-hosted on the ncbi endpoint — a direct two-GRAPH join, no TogoID. Anchor a MedGen ConceptID, convert its www IRI to ClinVar's no-www form with REPLACE, then match on the TypeXref rdfs:seeAlso. Pre-selecting the concept (VALUES) keeps it fast."
+    verified: {result_rows: 10, date: "2026-08-29", first_row: "NM_007294.4(BRCA1):c.453T>G (p.Ser151Arg) → 'Hereditary breast ovarian cancer syndrome'"}
+    teaches: "MedGen is co-hosted on the ncbi endpoint — a direct two-GRAPH join, no TogoID. Anchor a MedGen ConceptID, convert its www IRI to ClinVar's no-www form with REPLACE, then match on the TypeXref rdfs:seeAlso. Pre-selecting the concept (VALUES) keeps it fast. SELECT DISTINCT is required, not cosmetic: without it the duplicate disease bnodes return each variant twice."
     traps_avoided:
-      - "Using the MedGen www IRI directly inside the ClinVar graph returns 0 rows — MedGen = http://www.ncbi.nlm.nih.gov/medgen/, ClinVar seeAlso = http://ncbi.nlm.nih.gov/medgen/. The www→no-www swap is mandatory (co_hosted dataset/medgen)."
-
+      - say: |-
+          Using the MedGen www IRI directly inside the ClinVar graph returns 0 rows — MedGen = http://www.ncbi.nlm.nih.gov/medgen/, ClinVar seeAlso = http://ncbi.nlm.nih.gov/medgen/. Measured 2026-08-29 for C0677776: the www form matches 0 seeAlso triples in dataset/clinvar, the no-www form matches 74,605. The www→no-www swap is mandatory (co_hosted dataset/medgen).
+        check:
+          kind: zero_rows
+          date: '2026-08-29'
+          query: 'SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/clinvar>
+          
+            WHERE { ?ref rdfs:seeAlso <http://www.ncbi.nlm.nih.gov/medgen/C0677776> . }'
 # ── schema_delta: non-obvious predicates/structure NO example above already demonstrates. ──
 schema_delta:
-  - "GENE ENTITY (the 92,318 IRI cvo:Gene, distinct from the ~4.87M per-record bnodes): the IRI gene carries cvo:symbol, cvo:full_name, cvo:hgnc_id (\"HGNC:1100\", string), cvo:omim (integer, ~4,000 genes), cvo:cytogenetic_location. Reach a gene entity directly at http://ncbi.nlm.nih.gov/gene/{id} — no traversal."
-  - "REVIEW STATUS / evidence tier: the germline (and each) classification bnode also carries cvo:review_status — a controlled vocabulary (\"reviewed by expert panel\", \"practice guideline\", \"criteria provided, single submitter\", \"criteria provided, multiple submitters, no conflicts\", \"no assertion criteria provided\"). This is the evidence-quality filter; add it beside cvo:description to keep only high-confidence calls."
+  - "GENE ENTITY (the 92,318 IRI cvo:Gene, distinct from the 4,872,653 per-record bnodes): the IRI gene carries cvo:symbol, cvo:full_name, cvo:hgnc_id (\"HGNC:1100\", string), cvo:omim (integer, ~4,000 genes), cvo:cytogenetic_location. Reach a gene entity directly at http://ncbi.nlm.nih.gov/gene/{id} — no traversal. It also carries bulk positional data (BRCA1 alone: 528 faldo:location, 264 cvo:haploinsufficiency, 264 cvo:triplosensitivity triples), so SELECT * on a gene IRI is not the cheap lookup it looks like."
+  - "REVIEW STATUS / evidence tier: the germline (and each) classification bnode also carries cvo:review_status — a controlled vocabulary of 11 values (verified 2026-08-29). This is the evidence-quality filter; add it beside cvo:description to keep only high-confidence calls. The distribution is extremely skewed, so the filter changes answers a lot: \"criteria provided, single submitter\" 11,685,046 / \"criteria provided, multiple submitters, no conflicts\" 920,255 / \"no assertion criteria provided\" 791,487 / \"criteria provided, conflicting classifications\" 203,516 / \"reviewed by expert panel\" 59,621 / \"practice guideline\" 7,703 (the two gold-standard tiers are together under 0.5% of assertions)."
   - "DATE TYPING: cvo:date_created / cvo:date_last_updated are xsd:date; dct:created / dct:modified carry the SAME dates but as xsd:string — filter on the cvo: (typed date) ones for range queries."
   - "TEXT SEARCH (exploratory only): rdfs:label = cvo:variation_name = HGVS free text with no controlled vocabulary. Virtuoso bif:contains works (?label bif:contains \"'EGFR'\") but only for discovery — resolve to a gene IRI (variants_by_gene) for any real/count query."
 
@@ -295,16 +450,23 @@ id_join_map:
     medgen:   "disease TypeXref rdfs:seeAlso → ncbi.nlm.nih.gov/medgen/C* ; MedGen types the www.ncbi form — apply the www→no-www REPLACE swap (example xdb_medgen)"
     ncbigene: "med2rdf:gene → ncbi.nlm.nih.gov/gene/{id}; NCBI Gene RDF uses identifiers.org/ncbigene/{id} — join on the shared integer id (BIND the id as a string), not the IRI"
     pubtator/pubmed: "literature co-mention, reachable only via a MedGen-CUI → MeSH-IRI bridge two hops out; run the discovery step separately (a single 3+ graph join times out)"
-  xrefs:                          # outbound, on disease TypeXref nodes (dct:source + dct:identifier [+ rdfs:seeAlso]) or on the Gene entity
-    omim:     "dct:source \"OMIM\" on a TypeXref; also cvo:omim (integer) directly on the Gene entity"
-    orphanet: "dct:source \"Orphanet\", dct:identifier the ORPHA number"
-    mondo:    "dct:source \"MONDO\", dct:identifier \"MONDO:0007254\""
-    mesh:     "dct:source \"MeSH\"/\"MESH\" (case-split — VALUES both), dct:identifier the MeSH descriptor id (e.g. \"D061325\")"
-    hpo:      "dct:source \"HP\"/\"Human Phenotype Ontology\" (also split)"
+  xrefs:                          # outbound, on disease TypeXref nodes (dct:source + dct:identifier [+ rdfs:seeAlso]) or on the Gene entity.
+                                  # 153 source vocabularies exist — enumerate them with example enum_xref_source before picking a filter value.
+    omim:     "dct:source \"OMIM\" (11,822,932 xref rows) on a TypeXref; also cvo:omim (integer) directly on the Gene entity"
+    orphanet: "dct:source \"Orphanet\" (2,453,877), dct:identifier the ORPHA number"
+    mondo:    "dct:source \"MONDO\" (4,650,710), dct:identifier \"MONDO:0007254\""
+    mesh:     "dct:source \"MeSH\" (834,628); a \"MESH\" spelling also exists but is only 180 rows (0.02%) — safe to ignore, unlike the HP split below. dct:identifier is the MeSH descriptor id (e.g. \"D061325\")"
+    hpo:      "dct:source is SPLIT three ways and this one DOES matter: \"Human Phenotype Ontology\" 722,578 / \"HP\" 336,084 / \"HPO\" 64 — filtering \"HP\" alone returns 31.7% of the rows (gotcha source_case)"
+    dbsnp:    "dct:source \"dbSNP\" (2,978,968), dct:identifier the rs number without the \"rs\" prefix"
+    clingen:  "dct:source \"ClinGen\" (2,893,282) — variant-level curation, surfaced by enum_xref_source"
     hgnc:     "cvo:hgnc_id \"HGNC:NNNN\" on the Gene entity (~100% of genes)"
   bridged_via_togoid:             # for DBs NOT co-hosted on the ncbi endpoint
-    - "dbSNP rs / TogoVar / other RDF Portal DBs: convert the ClinVar variation id or the gene id via togoid_convertId when no same-endpoint graph carries the target."
+    - "TogoVar / other RDF Portal DBs: convert the ClinVar variation id or the gene id via togoid_convertId when no same-endpoint graph carries the target. (dbSNP rs numbers are already present natively — see xrefs.dbsnp — so no bridge is needed for those.)"
 
-# ── byte-count footer (spec §5 item 7) ──
-# v2: `wc -c togo_mcp/data/mie/clinvar.yaml` = 42101 bytes
-# v3: `wc -c benchmark/studies/redesign/mie_v3/clinvar.yaml` = 20307 bytes → 51.8% smaller than v2.
+# ── byte-count footer (spec §5 item 7; measured over the SERVED form, i.e. check: blocks stripped) ──
+# v2 (superseded): 42,101 bytes. v3 2026-07-22: 19,904 bytes served, examples 70.5%.
+# v3 2026-08-29 (this revision): 28,038 bytes served, examples 61.4% (37,764 on disk incl. check: fixtures).
+# The share moved -9.0 pts, which is the spec-§5i HEADER-CORRECTION carve-out, not crowding-out:
+# `examples` GREW +3,190 bytes (new enum_xref_source + checked traps) while the header grew +4,908
+# (2g probe evidence, the corrected from_clause/source_case gotchas, 4 more xref vocabularies). No
+# verified content was compressed to recover the ratio; 61.5% is inside the corpus range (53-73%).

--- a/togo_mcp/data/mie/massbank.yaml
+++ b/togo_mcp/data/mie/massbank.yaml
@@ -22,7 +22,25 @@
 # No test leakage (§4.6): illustrative subjects are Nylidrin, Phenazone, fentanyl/sufentanil/alfentanil,
 # paracetamol, aspirin, caffeine, cholic acid, malate. The massbank benchmark questions
 # q056/q059/q061/q068/q097 use PLP / thiamine-PP / decarboxylase / vitamin A / carotenoids — grep-confirmed
-# disjoint 2026-08-14.
+# disjoint 2026-08-14. CORRECTION 2026-08-29: that sweep checked the TOPIC list but not the literal
+# strings — the screen_inchikey_skeleton caveat illustrated its point with the InChIKey skeleton
+# AYEKOFBPNLCAJY, which is exactly thiamine diphosphate's, named in massbank question q059's answer.
+# Swapped to paracetamol's RZVAJINKPMORJF (already used by that example, non-benchmark, same behaviour:
+# 1 distinct key, STRSTARTS on a constant prefix still fast). Grep the accessions, not just the themes.
+#
+# REVISED 2026-08-29 — §3.6 check: sweep. Every falsifiable claim now carries an executable check, and the
+# sweep caught one substantially WRONG gotcha that every prior gate had passed (its examples were clean,
+# because examples get executed and prose did not):
+#   * `numeric_double_bnode` claimed "equality on a double silently returns 0 rows". FALSE — mb:mz 135.08
+#     returns 130. It also named three predicates that do not exist (mb:exact_mass, mb:precursor_mz,
+#     mb:ppm_error; really mb:ch_exact_mass, mb:precursor_mz_value, mb:error->rdf:value) and typed
+#     precursor m/z as double when it is xsd:FLOAT. Rewritten as numeric_rounding_float_double around the
+#     two hazards that ARE real: result cells display ROUNDED values (229.048 shown, 229.0479 stored), and
+#     float equality can never match at all. New example precursor_product_transition carries the fix.
+#   * Everything else re-measured CORRECT and unchanged: all counts/coverage (117,295 / 17,921 / 49; CAS
+#     69.63%, PubChem 55.32%, ChemSpider 38.38%, InChIKey 98.81%), the three REGEX figures (0/30/44), the
+#     misspelling, lowercase-class and schema-prefix 0-row traps, the x1.00 graph-pin ratio, and the
+#     ChEMBL relation-graph IRI form. 2g re-probed via get_graph_list (~430 co-tenants) — still clean.
 mie_spec: 3                        # format version — see MIE_v3_spec.md §2
 database: massbank
 
@@ -65,11 +83,12 @@ graphs:
       (c) Hub leg: unbound-?p probe on two <identifiers.org/inchikey/…> IRIs returned only tid:TIO_000021 from
       the four togoid relation graphs above. No re-declaration, no union inflation on any leg.
 
-entity_counts:                     # graph-pinned, COUNT(DISTINCT), live 2026-08-14 (unchanged since 2026-07-22)
+entity_counts:                     # graph-pinned, COUNT(DISTINCT), re-run live 2026-08-29 (unchanged since 2026-07-22)
   mass_spectra:            117295  # = COUNT of spectrum IRIs; ALSO = COUNT of compound bnodes (not deduplicated!)
   distinct_structures:     17921   # = COUNT(DISTINCT ?inchikey) — the real number of unique molecules
   distinct_instrument_types: 49    # controlled vocabulary on mb:instrument_type
-  coverage: "InChIKey ~98.8% of spectra · rdfs:seeAlso xrefs: CAS ~69.6% / PubChem CID ~55.3% / ChemSpider ~38.4%"
+  coverage: "InChIKey 115,901/117,295 = 98.81% of spectra · rdfs:seeAlso xrefs: CAS 81,668 = 69.63% / PubChem CID 64,892 = 55.32% / ChemSpider 45,023 = 38.38%"
+  date: "2026-08-29"
   size_caveat: >
     17,921 distinct structures is SMALL next to a chemistry database (ChEMBL ~2.4M compounds). Screening an
     arbitrary drug-like compound list against MassBank returns mostly misses BY DESIGN — measured on the
@@ -77,44 +96,115 @@ entity_counts:                     # graph-pinned, COUNT(DISTINCT), live 2026-08
     specific molecule is a real finding ("no reference spectrum published"), not a failed query. Report the
     hit rate; do not rewrite the query.
 
-global_gotchas:                    # the few that bite ANY query on this DB — verified 2026-08-14
+global_gotchas:                    # the few that bite ANY query on this DB — all re-verified 2026-08-29
   - id: mandatory_graph
     say: >
-      The primary endpoint co-hosts ~450 graphs in one Virtuoso store. Always scope to
-      GRAPH <http://rdfportal.org/dataset/massbank>. Omitting it does NOT inflate typed-class counts
-      (mb:* and schema:chemicalsubstance are single-tenant here) but it makes generic/untyped patterns
-      scan unrelated data — slow, or mixing MeSH/GO/BacDive/TogoID triples into an untyped result.
+      The primary endpoint co-hosts ~430 graphs in one Virtuoso store. Always scope to
+      GRAPH <http://rdfportal.org/dataset/massbank>. Re-measured 2026-08-29: omitting it does NOT inflate
+      typed-class counts — mb:MassSpectrum and schema:chemicalsubstance both return 117,295 pinned AND
+      unpinned (x1.00), and DISTINCT inChIKey returns 17,921 either way, because mb:* and the lowercase
+      schema:chemicalsubstance class are genuinely single-tenant here. The pin still earns its keep for
+      generic/untyped patterns, which otherwise scan MeSH/GO/BacDive/TogoID triples — slow, and mixing
+      foreign rows into an untyped result. Do not read this x1.00 as "the pin is optional".
+    check:
+      kind: ratio
+      date: "2026-08-29"
+      unpinned: |
+        PREFIX mb: <http://www.massbank.jp/ontology/>
+        SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s a mb:MassSpectrum }
+      pinned: |
+        PREFIX mb: <http://www.massbank.jp/ontology/>
+        SELECT (COUNT(DISTINCT ?s) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?s a mb:MassSpectrum }
+      expect: {ratio: 1.0, tolerance: 0.01}
+
   - id: regex_alternation
     say: >
       SILENT 0 ROWS — two-argument REGEX() mishandles alternation AND brace quantifiers. This is ENGINE
       behaviour, not a MassBank fact: both reproduce on all 10 endpoints in the registry, and the rule
       lives in the Usage Guide (SILENT-FAILURE TRAPS #10) — ALWAYS pass a third (flags) argument, even "".
-      Recorded here because MassBank is where it was caught and compound-name
-      search is a common entry point: verified 2026-08-14 on rdfs:label in the massbank graph,
-      REGEX(STR(?n), "Fentanyl|Sufentanil") returns 0 while REGEX(STR(?n), "(Fentanyl)|(Sufentanil)")
-      returns 30 and the "i"-flagged form returns 44. A real session read the 0 as "MassBank has no
-      fentanyls"; it has 44 matching compound nodes. Example find_compound_by_name uses the safe form.
+      Recorded here because MassBank is where it was caught and compound-name search is a common entry
+      point. Re-verified 2026-08-29 on rdfs:label in the massbank graph, all four forms in one query:
+      REGEX(STR(?n), "Fentanyl|Sufentanil") returns 0; the parenthesised "(Fentanyl)|(Sufentanil)" returns
+      30; adding an empty third argument to the BARE pattern also returns 30; and the "i"-flagged form
+      returns 44. A real session read the 0 as "MassBank has no fentanyls"; it has 44 matching compound
+      nodes. Example find_compound_by_name uses the safe form.
+    check:
+      kind: zero_rows
+      date: "2026-08-29"
+      query: |
+        PREFIX schema: <https://schema.org/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?c a schema:chemicalsubstance ; rdfs:label ?lab .
+                FILTER(REGEX(STR(?lab), "Fentanyl|Sufentanil")) }
+
   - id: spectram_misspelling
     say: >
       The metadata class + predicate are misspelled "Spectram" in the source ontology and are canonical
-      verbatim: mb:MassSpectramMetaData / mb:mass_spectram_meta_data. (The spectrum class itself is correctly
-      mb:MassSpectrum.) The corrected spelling mass_spectrum_meta_data silently returns 0 rows.
+      verbatim: mb:MassSpectramMetaData / mb:mass_spectram_meta_data (117,295 instances). (The spectrum class
+      itself is correctly mb:MassSpectrum.) The corrected spelling mb:MassSpectrumMetaData /
+      mass_spectrum_meta_data silently returns 0 rows.
+    check:
+      kind: zero_rows
+      date: "2026-08-29"
+      query: |
+        PREFIX mb: <http://www.massbank.jp/ontology/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?s a mb:MassSpectrumMetaData }
+
   - id: lowercase_class_and_iri_inchikey
     say: >
-      Two 0-row traps on the compound node: (1) the chemical-substance class is <https://schema.org/chemicalsubstance>
-      ALL LOWERCASE — canonical schema:ChemicalSubstance returns 0 rows. (2) schema:inChIKey is an IRI
-      <http://identifiers.org/inchikey/KEY> (note http, not https) — matching it as a plain string literal returns 0 rows.
-  - id: numeric_double_bnode
+      Two 0-row traps on the compound node, both re-verified 2026-08-29: (1) the chemical-substance class is
+      <https://schema.org/chemicalsubstance> ALL LOWERCASE (117,295 instances) — the canonical CamelCase
+      schema:ChemicalSubstance returns 0 rows. (2) schema:inChIKey is an IRI
+      <http://identifiers.org/inchikey/KEY> (note http, not https) — matching it as a plain string literal
+      ("VEQOALNAAJBPNY-UHFFFAOYSA-N") returns 0 rows.
+    check:
+      kind: zero_rows
+      date: "2026-08-29"
+      query: |
+        PREFIX schema: <https://schema.org/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?s a schema:ChemicalSubstance }
+
+  - id: numeric_rounding_float_double
     say: >
-      m/z, intensity, exact mass, precursor m/z and ppm error are xsd:double literals on BLANK NODES reached via
-      mb:has_peak / mb:compound / mb:mass_spectram_meta_data / mb:has_peak_annotations — never on the spectrum IRI.
-      Equality on a double (?p mb:mz 135.08) silently returns 0 rows; use a range filter or a typed literal
-      ("135.08"^^xsd:double). Only mb:relative_intensity / mb:peak_sequential_number / mb:pk_num_peak are xsd:integer.
+      NUMERIC MATCHING IS THE #1 SILENT-WRONG-ANSWER TRAP HERE, and the previous version of this file got it
+      backwards — corrected 2026-08-29 by measurement. Two independent hazards compound:
+      (1) THE DISPLAYED VALUE IS ROUNDED AND IS USUALLY NOT THE STORED TERM. A result cell reading 229.048 is
+      stored as 229.0479 (STR() shows the truth); copying the displayed number into an equality gives 0 rows —
+      mb:ch_exact_mass 229.048 returns 0. Always read the real value with STR(?x) before matching one.
+      (2) THE DATATYPE DECIDES WHETHER EQUALITY CAN EVER WORK. mb:mz, mb:intensity, mb:ch_exact_mass and
+      mb:base_peak are xsd:DOUBLE, and equality does match an exactly-stored value (mb:mz 135.08 returns 130 —
+      NOT 0, as this file previously claimed). But mb:precursor_mz_value is xsd:FLOAT, where NO literal form
+      matches: 195.088 returns 0, and so does the full binary expansion 195.0877075195312, because one
+      displayed value hides three distinct stored terms (195.0877075195312 / 195.0881652832031 /
+      195.087646484375). The correct names matter too — it is mb:ch_exact_mass (not mb:exact_mass),
+      mb:precursor_mz_value (not mb:precursor_mz), and the ppm error is mb:error -> rdf:value (there is no
+      mb:ppm_error). THE RULE: never match a mass or m/z by equality; always use a range filter (example
+      precursor_product_transition). Only mb:relative_intensity / mb:peak_sequential_number / mb:pk_num_peak
+      are xsd:integer and safe to match exactly.
+    check:
+      kind: zero_rows
+      date: "2026-08-29"
+      query: |
+        PREFIX mb: <http://www.massbank.jp/ontology/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?m mb:precursor_mz_value 195.0877075195312 }
+
   - id: schema_prefix
     say: >
       MassBank's `schema:` IS real schema.org <https://schema.org/> (https). The endpoint auto-declares it, but if
-      you hand-type `PREFIX schema: <http://schema.org/>` (http, no trailing slash mismatch) every schema:* pattern
-      0-rows. Copy the https://schema.org/ form exactly. (Contrast the co-hosted DSMZ dbs whose schema: is purl.dsmz.de.)
+      you hand-type `PREFIX schema: <http://schema.org/>` (http) every schema:* pattern 0-rows — verified
+      2026-08-29: http://schema.org/inChIKey matches 0 triples where the https form matches 115,901.
+      Copy the https://schema.org/ form exactly. (Contrast the co-hosted DSMZ dbs whose schema: is purl.dsmz.de.)
+    check:
+      kind: zero_rows
+      date: "2026-08-29"
+      query: |
+        PREFIX schemahttp: <http://schema.org/>
+        SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+        WHERE { ?s schemahttp:inChIKey ?o }
 
 # ── examples: verified, executable atoms. Central entity = mb:MassSpectrum (~117k). Each owns exactly one
 #    compound / AnalyticalMethods / MassSpectramMetaData BLANK NODE; peaks are untyped blank nodes. Access
@@ -282,7 +372,22 @@ examples:
     verified: {compound_nodes: 117295, distinct_molecules: 17921, date: "2026-08-14"}
     teaches: "Compounds are NOT deduplicated: every spectrum owns a fresh chemicalsubstance blank node, so COUNT(?c) = the spectrum count (117,295), NOT the molecule count. COUNT(DISTINCT ?inchikey) = 17,921 gives unique structures. (bibo:Article literature refs are likewise per-spectrum — dedup on the citation.)"
     traps_avoided:
-      - "COUNT(?c) or COUNT(?c a schema:chemicalsubstance) returns 117,295 — a plausible-looking 'compound total' that is really the spectrum count. Always dedup molecules on the InChIKey."
+      - say: |-
+          COUNT(?c) over schema:chemicalsubstance returns 117,295 — a plausible-looking 'compound total' that
+          is really the spectrum count, x6.55 the true molecule count of 17,921. Always dedup molecules on the
+          InChIKey. DISTINCT on ?c does NOT help: every bnode is already unique.
+        check:
+          kind: ratio
+          date: "2026-08-29"
+          numerator: |
+            PREFIX schema: <https://schema.org/>
+            SELECT (COUNT(?c) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+            WHERE { ?c a schema:chemicalsubstance }
+          denominator: |
+            PREFIX schema: <https://schema.org/>
+            SELECT (COUNT(DISTINCT ?k) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+            WHERE { ?c schema:inChIKey ?k }
+          expect: {ratio: 6.55, tolerance: 0.05}
 
   - id: facet_method
     intent: filter spectra by the controlled method vocabularies (instrument_type + ion_mode + ms_type)
@@ -362,8 +467,89 @@ examples:
       The result is compound-level (GROUP BY the InChIKey) because one molecule owns many spectra.
     traps_avoided:
       - "The intuitive forms are 30-50x slower or fatal: `VALUES ?target { … } FILTER(ABS(?mz - ?target) <= …)` over the whole graph took 47-52 s in production when it finished at all, and a UNION of four bare m/z ranges timed out at 90 s repeatedly. The correlated VALUES defeats the m/z index; the UNION also returns one row per (spectrum, ion), which reads as an inflated spectrum count."
-      - "A `{ FILTER(?mz >= a && ?mz <= b) BIND('ion' AS ?ion) }` UNION branch whose ?mz is bound in the ENCLOSING group is silently NOT filtered — verified: it returned 117,295 (the entire spectrum count) for two different ion windows. Put the triple patterns INSIDE each UNION branch."
+      - say: |-
+          A `{ FILTER(?mz >= a && ?mz <= b) BIND('ion' AS ?ion) }` UNION branch whose ?mz is bound in the
+          ENCLOSING group is silently NOT filtered — re-verified 2026-08-29: it returns 117,295, the ENTIRE
+          spectrum count, for two different ion windows. Put the triple patterns INSIDE each UNION branch.
+        check:
+          kind: count
+          date: "2026-08-29"
+          expect: {value: 117295}
+          query: |
+            PREFIX mb: <http://www.massbank.jp/ontology/>
+            SELECT (COUNT(DISTINCT ?spectrum) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+            WHERE {
+              ?spectrum mb:has_peak ?p . ?p mb:mz ?mz .
+              { FILTER(?mz >= 188.1424 && ?mz <= 188.1444) BIND("A" AS ?ion) }
+              UNION
+              { FILTER(?mz >= 105.0694 && ?mz <= 105.0704) BIND("B" AS ?ion) }
+            }
       - "Virtuoso rejects HAVING(COUNT(DISTINCT ?bucket) = 4) over a BIND-only group with `SQ200: Aggregate function not allowed in context`, and evaluates BOTH arms of IF(cond, ?x, 1/0), raising `SR084: Division by 0`. Both are real production 500s from agents trying to count matched ions per spectrum — count with FILTER EXISTS instead, as above."
+
+  - id: precursor_product_transition   # the precursor-m/z route; the float-matching trap has its fix here
+    intent: find spectra by a precursor->product TRANSITION (precursor m/z + a diagnostic product ion)
+    question: "Which compounds have MS/MS spectra with precursor m/z 195.088 that fragment to m/z 138.066?"
+    complexity: advanced
+    sparql: |
+      PREFIX mb: <http://www.massbank.jp/ontology/>
+      PREFIX schema: <https://schema.org/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      SELECT ?inchikey (SAMPLE(?nm) AS ?name) (COUNT(DISTINCT ?spectrum) AS ?n_spectra)
+      FROM <http://rdfportal.org/dataset/massbank>
+      WHERE {
+        {                                    # anchor on the PRECURSOR window, in its own subquery
+          SELECT DISTINCT ?spectrum WHERE {
+            ?spectrum mb:mass_spectram_meta_data ?meta .   # note the "Spectram" misspelling
+            ?meta mb:precursor_mz_value ?prec .            # xsd:FLOAT — a range is MANDATORY, see below
+            FILTER(?prec >= 195.0827 && ?prec <= 195.0927) # 195.0877 +- 5 mDa -> 87 spectra
+          }
+        }
+        # the product ion as a FILTER EXISTS against that small anchor set
+        FILTER EXISTS { ?spectrum mb:has_peak ?p . ?p mb:mz ?m . FILTER(?m >= 138.0612 && ?m <= 138.0712) }
+        ?spectrum mb:compound ?c .
+        ?c schema:inChIKey ?inchikey ; rdfs:label ?nm .
+      }
+      GROUP BY ?inchikey
+      ORDER BY DESC(?n_spectra) ?inchikey
+    verified: {result_rows: 3, date: "2026-08-29", rows: "Caffeine (RYYVLZVUVIJVGH-UHFFFAOYSA-N) 43 spectra; Isocaffeine (LPHGQDQBBGAPDZ-UHFFFAOYSA-N) 6; 1,3-Benzenedicarboxylic acid dihydrazide 1", precursor_window_spectra: 87, precursor_coverage: "93,795 of 117,295 spectra (80.0%)"}
+    teaches: >
+      The precursor half of a transition lives on the mass_spectram_meta_data blank node
+      (mb:precursor_mz_value), the product half on the peak blank nodes (mb:mz) — two different scaffolds,
+      joined only through the spectrum. Same shape as peak_diagnostic_ions: anchor the most selective
+      constraint in a DISTINCT subquery, then FILTER EXISTS the rest. That the result separates Caffeine (43)
+      from its isomer Isocaffeine (6) is the point of a transition query — both share the precursor AND the
+      product ion, so a transition alone does not identify a compound; it shortlists candidates.
+    traps_avoided:
+      - say: |-
+          mb:precursor_mz_value is xsd:FLOAT, and NO literal equality form matches it — not the value the
+          result cell displays (195.088 -> 0 rows) and not even the full binary expansion of a value you read
+          back with STR() (195.0877075195312 -> 0 rows). One displayed "195.088" is three distinct stored
+          terms (195.0877075195312 = 54 spectra, 195.0881652832031 = 4, 195.087646484375 = 1), so equality
+          could not return the right answer even if it matched one of them. A range filter is the only
+          correct route, and it is what makes this query return 87 anchor spectra instead of 0. (Contrast
+          the xsd:DOUBLE mb:mz, where equality DOES match — and still gives a wrong-looking-right answer:
+          gotcha numeric_rounding_float_double.)
+        check:
+          kind: zero_rows
+          date: "2026-08-29"
+          query: |
+            PREFIX mb: <http://www.massbank.jp/ontology/>
+            SELECT (COUNT(*) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+            WHERE { ?m mb:precursor_mz_value 195.088 }
+      - say: |-
+          Coverage is partial: mb:precursor_mz_value is present on 93,795 of 117,295 spectra (80.0%), so a
+          precursor-anchored query silently excludes 20% of the library — including ALL 11,804 EI-B (GC-MS)
+          records, of which exactly 0 carry a precursor, since electron ionisation has no precursor selection
+          by definition. For a fragment-only question use peak_diagnostic_ions instead. (Count spectra, not
+          triples: there are 94,831 precursor triples because ~1,000 spectra carry more than one value.)
+        check:
+          kind: absent
+          date: "2026-08-29"
+          query: |
+            PREFIX mb: <http://www.massbank.jp/ontology/>
+            SELECT (COUNT(DISTINCT ?s) AS ?n) FROM <http://rdfportal.org/dataset/massbank>
+            WHERE { ?s mb:analytical_methods_and_conditions ?a . ?a mb:instrument_type "EI-B" .
+                    ?s mb:mass_spectram_meta_data ?m . ?m mb:precursor_mz_value ?p }
 
   - id: screen_inchikey_skeleton
     intent: stereo/salt-agnostic structure screening via the 14-character InChIKey skeleton block
@@ -392,7 +578,7 @@ examples:
       which Virtuoso hash-joins. Use this whenever your source IDs may differ from MassBank's in stereo
       descriptor, salt or protonation state.
     traps_avoided:
-      - "Do NOT screen a LIST of skeletons with FILTER(STRSTARTS(STR(?ik), CONCAT('http://identifiers.org/inchikey/', ?skel))) — the CONCAT is correlated with ?skel, so it is rebuilt per row and forces a full scan. Measured on an identical 178-skeleton batch, both returning the same answer: STRSTARTS+CONCAT 80.7 s, the BIND(SUBSTR)+VALUES form above 1.07 s (~75x). A SINGLE skeleton with a constant literal prefix — FILTER(STRSTARTS(STR(?ik), 'http://identifiers.org/inchikey/AYEKOFBPNLCAJY')) — has no CONCAT and is perfectly fast; the trap is only the multi-skeleton correlated form."
+      - "Do NOT screen a LIST of skeletons with FILTER(STRSTARTS(STR(?ik), CONCAT('http://identifiers.org/inchikey/', ?skel))) — the CONCAT is correlated with ?skel, so it is rebuilt per row and forces a full scan. Measured on an identical 178-skeleton batch, both returning the same answer: STRSTARTS+CONCAT 80.7 s, the BIND(SUBSTR)+VALUES form above 1.07 s (~75x). A SINGLE skeleton with a constant literal prefix — FILTER(STRSTARTS(STR(?ik), 'http://identifiers.org/inchikey/RZVAJINKPMORJF')) — has no CONCAT and is perfectly fast; the trap is only the multi-skeleton correlated form."
       - "The join here is INNER, so a skeleton absent from MassBank drops out silently (XZQMGGFIVXLGME above). That is fine for 'what does MassBank have', but if you need explicit misses use the OPTIONAL shape from screen_inchikey_batch."
       - "Skeleton matching widens coverage only modestly — on the production log's 191 InChIKeys it lifted 31 exact hits to 32 skeletons (47 full keys). It recovers stereo variants, not an order of magnitude; do not expect it to rescue a mostly-empty screen."
 
@@ -449,7 +635,21 @@ examples:
       validation before the query is ever sent.
     traps_avoided:
       - "The relation triple is <target-ID> tid:TIO_000020 <inchikey-IRI> — the InChIKey IRI is the OBJECT, the DB ID is the SUBJECT. (The inverse tid:TIO_000021 also exists with the InChIKey as SUBJECT — verified 2026-08-14 — and is the more natural direction when starting from MassBank.) Binding the InChIKey once (BIND) and reusing it keeps the join exact and avoids the per-spectrum compound-bnode fan-out (187 spectra -> use DISTINCT)."
-      - "The returned IDs are FULL IRIs in the forms listed in id_join_map.same_endpoint_joins, NOT bare accessions. In particular ChEMBL here is http://identifiers.org/chembl.compound/CHEMBLnnn — the rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBLnnn form used by the `chembl` database itself does NOT exist in this graph and returns 0 rows silently."
+      - say: |-
+          The returned IDs are FULL IRIs in the forms listed in id_join_map.same_endpoint_joins, NOT bare
+          accessions. In particular ChEMBL here is http://identifiers.org/chembl.compound/CHEMBLnnn — the
+          rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBLnnn form used by the `chembl` database ITSELF does not
+          exist in this graph and returns 0 rows silently (re-verified 2026-08-29 for CHEMBL25: 1 triple on
+          the identifiers.org form, 0 on the rdf.ebi.ac.uk form). This is the general TogoID relation-graph
+          rule — each side is keyed by TogoID's canonical form for that dataset, which is often but NOT always
+          identifiers.org; probe one row of the relation graph before writing the join.
+        check:
+          kind: zero_rows
+          date: "2026-08-29"
+          query: |
+            SELECT (COUNT(*) AS ?n) WHERE {
+              GRAPH <http://rdfportal.org/dataset/togoid/relation/chembl_compound-inchi_key> {
+                <http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25> ?p ?o . } }
 
   - id: xdb_ids_to_spectra         # cross_db — the direction real traffic uses: external ID list -> spectra
     intent: "cross-DB (intra-primary): start from a ChEMBL/PubChem compound list and find their MassBank spectra"
@@ -492,7 +692,7 @@ examples:
 
 # ── schema_delta: non-obvious predicates/structure NO example above already demonstrates. ──
 schema_delta:
-  - "SPECTRUM-LEVEL METADATA blank node (note the misspelling): ?spectrum mb:mass_spectram_meta_data ?m . ?m a mb:MassSpectramMetaData ; mb:precursor_mz_value (double, 80.0%) ; mb:precursor_type_value ('[M+H]+' string, 78.4%) ; mb:base_peak (double, 37.4%). This is where precursor m/z lives — distinct from the AnalyticalMethods node. Pair it with peak_diagnostic_ions to turn a fragment hit into a precursor->product transition."
+  - "SPECTRUM-LEVEL METADATA blank node (note the misspelling): ?spectrum mb:mass_spectram_meta_data ?m . ?m a mb:MassSpectramMetaData ; mb:precursor_mz_value (xsd:FLOAT — NOT double, which is what decides that equality can never match it; 93,795 spectra = 80.0%) ; mb:precursor_type_value ('[M+H]+' string, 91,912 = 78.4%) ; mb:base_peak (xsd:double, 43,869 = 37.4%). This is where precursor m/z lives — distinct from the AnalyticalMethods node. Pair it with peak_diagnostic_ions to turn a fragment hit into a precursor->product transition."
   - >
     COLLISION ENERGY is free text and heavily non-uniform — do NOT match it exactly without checking.
     Verified 2026-08-14: 769 DISTINCT strings across 95,772 spectra, top values
@@ -531,5 +731,9 @@ id_join_map:
 
 # ── byte-count footer (spec §5 item 7) ──
 # v2 (superseded): 35,167 bytes. v3 as authored 2026-07-22: 19,023 bytes, examples 66.0%.
-# v3 revised 2026-08-14: see the Phase-5i figure in the changelog/PR — 5 examples added (14 total),
-# 1 global_gotcha added; examples share must not fall below the 66.0% baseline by >5 pts.
+# v3 revised 2026-08-14: 37,091 bytes served, examples 72.2% (14 examples).
+# v3 revised 2026-08-29 (§3.6 check: sweep): 43,214 bytes served, examples 71.8% (15 examples);
+# 53,946 on disk including the check: fixtures, which are stripped before serving and excluded here.
+# Share moved only -0.4 pts and for the RIGHT reason: `examples` grew +4,245 bytes (the new
+# precursor_product_transition + four traps upgraded to checked mappings) against +1,878 in the header,
+# so the load-bearing section absorbed most of the growth. No §5i carve-out needed.

--- a/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
+++ b/togo_mcp/data/resources/usage_guide_v6/03_workflows.md
@@ -52,6 +52,11 @@ cross-DB → `ncbi_esummary` for detail → one concise paragraph. Each fact onc
   many narrow queries.
 - **On failure:** max 2 consecutive. At #3: pivot to search, `ncbi_esearch`, TogoID, or
   partial synthesis.
+- **On an empty result:** `run_sparql` prefixes it with a `#` diagnosis block — read it.
+  An empty result is **not** an endpoint failure, and it has two causes needing opposite
+  answers: the data is genuinely absent (report that), or one triple pattern is wrong and
+  the real answer is non-zero. The single `ASK` probe the block names **is** the pivot,
+  not a third query — spend it rather than re-running a variant of the same SELECT.
 
 ---
 
@@ -128,6 +133,30 @@ OMA**, dropping every protein with no OMA record. It returned a wrong count (248
     escapes, `(?:…)`. That asymmetry is why it survives review: the filter works until someone
     widens it to a family or adds a `{n,m}` count, and the empty result reads as "the database
     doesn't have those." A production session concluded MassBank had no fentanyls; it has 44.
+11. **The same entity carries different IRIs in different graphs — the join returns 0, and it
+    reads as "no data".** A TogoID relation graph (`dataset/togoid/relation/<a>-<b>`) keys each
+    side by TogoID's canonical form for that dataset, which is frequently **not** the form the
+    source database's own graph mints. ChEMBL: the `chembl` database uses
+    `http://rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25`; the relation graph holds
+    `http://identifiers.org/chembl.compound/CHEMBL25`. Same molecule, no shared RDF term,
+    empty join, HTTP 200.
+
+    **Do not assume `identifiers.org` either** — the form varies per dataset. Verified
+    2026-08-29: `ncbigene-go` and `ensembl_transcript-go` key on `identifiers.org/`, but
+    `chebi-inchi_key` keys ChEBI as `purl.obolibrary.org/obo/CHEBI_15858`, and `nando-mondo`
+    pairs `purl.obolibrary.org/obo/MONDO_…` with `nanbyodata.jp/ontology/NANDO_…`. One row
+    tells you both sides before you write the join:
+
+    ```sparql
+    SELECT ?s ?o WHERE {
+      GRAPH <http://rdfportal.org/dataset/togoid/relation/chembl_compound-inchi_key> { ?s ?p ?o }
+    } LIMIT 1
+    ```
+
+    Why it survives review: on a sparse database an empty join is indistinguishable from a true
+    negative. A production MassBank lookup (2026-08 logs) pinned `VALUES` with native ChEMBL
+    IRIs and returned 0 for every compound — which is also exactly what MassBank returns for a
+    compound it genuinely has no spectra for.
 
 ---
 

--- a/togo_mcp/data/resources/usage_guide_v6/04_reference.md
+++ b/togo_mcp/data/resources/usage_guide_v6/04_reference.md
@@ -29,8 +29,10 @@
 | Stuck on one DB (≥4 calls in EXPLORATION) | Pivot to the next unexplored DB from your entity→DB map. UniProt annotations don't substitute for direct Rhea/Taxonomy/ChEMBL/PubChem calls. |
 | 3rd consecutive SPARQL | Stop. Pivot to search / NCBI / TogoID / partial synthesis. |
 | Cross-DB SPARQL fails | Check endpoints; use TogoID or NCBI bridge. |
-| Empty SPARQL results | Use structured predicates from MIE; extract IRIs via search first. Typed literal missing (`^^xsd:string`)? Predicate applied to the wrong node? |
+| Empty SPARQL results | **Read the `#` diagnosis block `run_sparql` prepends** — it names the two causes and the probe. Not an endpoint failure. Then: structured predicates from MIE; extract IRIs via search first. Typed literal missing (`^^xsd:string`)? Predicate applied to the wrong node? |
+| Aggregate came back `0` | Same thing in aggregate form — `COUNT` over an empty match is one row of `0`, so it *looks* structurally fine. The diagnosis block fires here too; decide true-negative vs broken-pattern before reporting a zero. |
 | `REGEX` filter returns nothing (pattern uses `A\|B` or `{n,m}`) | Two-arg `REGEX()` mishandles alternation and brace quantifiers on **every** endpoint. Always pass a third argument: `REGEX(?x, "A\|B", "")`. See SILENT-FAILURE TRAPS #10. |
+| Cross-DB join through a TogoID relation graph returns 0 | The two graphs mint **different IRIs for the same entity**. A relation graph uses TogoID's canonical form per dataset — often, but **not always**, `identifiers.org/` — not the source DB's own form (`chembl` mints `rdf.ebi.ac.uk/resource/chembl/molecule/…`, the relation graph holds `identifiers.org/chembl.compound/…`). Probe one row of the relation graph for both IRI forms before joining. Indistinguishable from a true negative on a sparse DB. See SILENT-FAILURE TRAPS #11. |
 | SPARQL timeout | Add LIMIT; replace `bif:contains` with structured IRIs. |
 | Wrong count | Master reactions only? Correct keyword IRI (not EC prefix)? |
 | **Count inflated** (2×, 4×, 8×) — or right but unproven | Co-tenancy. `GRAPH ?g` the pattern with its subject bound: >1 graph → re-declared; none of yours → foreign predicate, i.e. a silent intersection. Pin **every** pattern. `DISTINCT` hides it, doesn't fix it. |

--- a/togo_mcp/rdf_portal.py
+++ b/togo_mcp/rdf_portal.py
@@ -169,7 +169,13 @@ async def get_sparql_endpoints() -> dict[str, Any]:
         "Invalid database/endpoint_name values fail immediately with a deterministic "
         "error — do not retry. "
         "RETURNS the query results as a CSV-formatted string (first row is the "
-        "header of SELECT variable names)."
+        "header of SELECT variable names). An EMPTY result — no rows, or an "
+        "aggregate that is 0 over an empty match — is prefixed with `#` comment "
+        "lines diagnosing it. READ THEM: an empty result is NOT an endpoint "
+        "failure and must not be reported as one, and it has two causes needing "
+        "opposite answers (the data is genuinely absent, or one triple pattern "
+        "is wrong and the real answer is non-zero). The block names the probe "
+        "that tells them apart."
     ),
 )
 async def run_sparql(
@@ -252,7 +258,154 @@ async def run_sparql(
         raise ValueError(
             "Missing SPARQL query. Pass it as `sparql_query` (canonical) or `query`."
         )
-    return await execute_sparql(sparql_query, database, endpoint_name, endpoint_url)
+    csv_text = await execute_sparql(sparql_query, database, endpoint_name, endpoint_url)
+    # Prepend rather than replace: the aggregate case carries a real `0` the caller
+    # may want, and preserving the body keeps ONE output shape for both empty kinds.
+    note = _empty_result_note(csv_text, sparql_query)
+    return f"{note}{csv_text}" if note else csv_text
+
+
+# --------------------------------------------------------------------------- #
+# Empty-result diagnosis for run_sparql
+#
+# The largest failure mode on this server is not an error. In the 2026-07-27..08-29
+# production logs, 163 `run_sparql` calls raised; 1,237 returned HTTP 200 with an
+# empty result set. Agents do not notice: abandonment after a zero-row result (50.0%)
+# is barely above abandonment after a SUCCESSFUL one (43.8%), and only 6.9% re-read
+# the MIE afterwards — the same rate as after a success.
+#
+# Worse, an empty result has TWO causes needing OPPOSITE responses, and the wire
+# format cannot tell them apart:
+#   (A) true negative  — the pattern is right, the data is genuinely absent. On a
+#       sparse database this IS the answer. 816 of those 1,237 were this.
+#   (B) broken pattern — one triple pattern matches nothing and empties the join.
+#       342 were this, and every one was reported to a user as if it were (A).
+#
+# So this block does not merely say "0 rows": it names the fork and gives the probe
+# that settles it. Follows the ChEMBL convention (chembl.py: an empty result is NOT
+# an endpoint failure and must not be reported as one).
+#
+# Deliberately at the TOOL layer, not in execute_sparql(): chembl.py and
+# get_graph_list() both parse execute_sparql's CSV, and prose in that return value
+# would corrupt both.
+# --------------------------------------------------------------------------- #
+
+# COUNT/SUM/... in the projection with no GROUP BY collapses an empty match to ONE
+# row rather than zero — `SELECT (COUNT(*) AS ?n)` over nothing returns `"n"\n0\n`.
+# Structurally fine, semantically empty, and invisible to a row-count test. Add
+# GROUP BY and the same query returns 0 rows instead (both verified live 2026-08-29).
+# scripts/check_mie_gotchas.py reaches the same rule from the other side ("a lone
+# scalar aggregate returns ONE row even when it counts nothing — read the value, not
+# the row"); keep the two in step if either changes.
+_AGGREGATE_RE = _re.compile(r"\b(count|sum|avg|min|max|sample|group_concat)\s*\(", _re.I)
+_GROUP_BY_RE = _re.compile(r"\bgroup\s+by\b", _re.I)
+# A quoted literal inside a VALUES block, i.e. the literal-typing trap's worst spot.
+_VALUES_IRI_RE = _re.compile(r"\bvalues\b[^{]*\{[^}]*<https?://", _re.I | _re.S)
+_QUOTED_LITERAL_RE = _re.compile(r'"[^"]*"')
+
+_LONG_QUERY_CHARS = 1200
+
+
+def _csv_rows(csv_text: str) -> list[list[str]]:
+    """Parse the endpoint's CSV body.
+
+    A real parse, not a newline count: a literal containing a newline makes
+    `text.count("\n")` over-report. That only matters in the 0-vs-1 direction here,
+    but the log metric `n_rows` is computed the cheap way and is a slight
+    over-estimate for the same reason.
+    """
+    return [r for r in _csv.reader(_io.StringIO(csv_text))]
+
+
+def _empty_result_note(csv_text: str, sparql_query: str) -> str | None:
+    """Return a `#`-prefixed diagnosis block, or None if the result carries data.
+
+    Two shapes count as empty, and they get the SAME message because they pose the
+    same question to the caller:
+      - no data rows at all;
+      - one data row whose every field is `0` or unbound, from an aggregate with no
+        GROUP BY (SUM over an empty match is unbound, not 0 — hence the `""` case).
+
+    ASK is excluded: `ASK {}` returning false is `"bool"\n0\n`, which is a real
+    answer, not an empty result.
+    """
+    try:
+        rows = _csv_rows(csv_text)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    header, data = rows[0], rows[1:]
+    query = sparql_query or ""
+    # `ASK` bodies look like a single zero row; they are an answer, not an absence.
+    if _re.search(r"\bask\b", query, _re.I) and not _re.search(r"\bselect\b", query, _re.I):
+        return None
+
+    if not data:
+        kind = "no_rows"
+    elif (
+        len(data) == 1
+        and _AGGREGATE_RE.search(query)
+        and not _GROUP_BY_RE.search(query)
+        and all(f.strip() in ("0", "") for f in data[0])
+    ):
+        kind = "zero_aggregate"
+    else:
+        return None
+
+    cols = ", ".join(c for c in header if c) or "(none)"
+    if kind == "no_rows":
+        opening = "0 rows. The query EXECUTED SUCCESSFULLY — this is not an endpoint error."
+    else:
+        opening = (
+            "The aggregate is 0 over an EMPTY match — no row satisfied the WHERE "
+            "clause. The query executed successfully; this is not an endpoint error."
+        )
+
+    lines = [
+        opening,
+        f"Columns: {cols}",
+        "Do NOT report this as a failure, and do NOT retry the same text.",
+        "TWO causes, needing OPPOSITE answers — decide which BEFORE you answer:",
+        "  (A) TRUE NEGATIVE — pattern correct, data genuinely absent. On a sparse",
+        "      database (spectra, variants, structures) this IS the answer: say so.",
+        "  (B) BROKEN PATTERN — one triple pattern matches nothing and empties the",
+        "      whole join. The real answer is non-zero and you have not found it.",
+        "Settle it with ONE probe — this is the pivot the 2-consecutive-SPARQL rule",
+        "reserves, not a third query: drop to the single most specific pattern, e.g.",
+        "  ASK { GRAPH <the-graph> { <your-anchor-IRI> ?p ?o } }",
+        "false => (A), the entity is absent. true => (B), a later pattern is wrong.",
+    ]
+
+    # Shape-aware additions, ranked by measured zero-row lift in the production logs.
+    # Capped at two: past that the block stops being read.
+    extra: list[str] = []
+    if _VALUES_IRI_RE.search(query):
+        extra.append(
+            "SEEN HERE: a VALUES block of IRIs (17.6% empty vs 8.6% for literals). "
+            "The same entity has DIFFERENT IRIs in different graphs — a TogoID "
+            "relation graph uses TogoID's canonical form, often not the source DB's "
+            "(chembl mints rdf.ebi.ac.uk/resource/chembl/molecule/CHEMBL25; the "
+            "relation graph holds identifiers.org/chembl.compound/CHEMBL25). Probe "
+            "one row of the joined graph for its IRI form. Usage Guide trap #11."
+        )
+    if len(query) >= _LONG_QUERY_CHARS and len(extra) < 2:
+        extra.append(
+            f"SEEN HERE: a long query ({len(query)} chars; >=1200 is 25.7% empty vs "
+            "8.0% at 400-700). A long conjunction gives no partial credit. Bisect: "
+            "re-run with the last two patterns removed, then add them back one at a time."
+        )
+    if _QUOTED_LITERAL_RE.search(query) and len(extra) < 2:
+        extra.append(
+            "SEEN HERE: quoted literals. One predicate can carry mixed forms (plain, "
+            "^^xsd:string, @en) — distinct RDF terms, so an exact match on the wrong "
+            "form returns 0 silently. Compare with STR(?x), or check the MIE's "
+            "global_gotchas. Usage Guide trap #7."
+        )
+    lines.extend(extra)
+
+    return "\n".join(f"# {line}" for line in lines) + "\n"
 
 
 # --- Tools for exploring RDF databases ---

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.9.1"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What this ships

Empty SPARQL results outnumber errors on this server **7.6 to 1** — 1,237 vs 163 across 2026-07-27..08-29 — and they were the failure nobody saw. Agents abandoned the task at 50.0% after a zero-row result versus **43.8% after a successful one**, and re-read the MIE at 6.9% either way. An empty body was indistinguishable from an answer.

`run_sparql` now prefixes an empty result with a `#` diagnosis block. It doesn't just say "0 rows" — it names the fork the wire format cannot express:

- **(A) true negative** — pattern right, data genuinely absent. On a sparse database this *is* the answer.
- **(B) broken pattern** — one triple pattern matches nothing and empties the join; the real answer is non-zero.

Roughly 816 of the 1,237 were (A) and 342 were (B), and every (B) reached a user as "there is no data". The block gives the single `ASK` probe that settles it, framed as the pivot the 2-consecutive-SPARQL rule already reserves.

Two subtler cases, both verified live 2026-08-29:
- An **aggregate that is 0 over an empty match** — `SELECT (COUNT(*) AS ?n)` with no `GROUP BY` returns one row of `0`, structurally fine and invisible to any row-count test. Same treatment, same message.
- An **`ASK` that is false** is left alone: it is an answer, not an absence.

Up to two shape-aware lines are appended, ranked by measured lift: `VALUES` of IRIs (17.6% empty vs 8.6% for literals), queries ≥1,200 chars (25.7% vs 8.0% at 400–700), quoted literals.

## Also in this release

- **Usage Guide trap #11** — cross-namespace joins through TogoID relation graphs. The rule is *not* "always use identifiers.org": verified 2026-08-29, `ncbigene-go` and `ensembl_transcript-go` key on identifiers.org while `chebi-inchi_key` uses an OBO PURL and `nando-mondo` pairs an OBO PURL with a `nanbyodata.jp` IRI. The guide gives a one-row probe instead.
- **`check:` sweep on `clinvar.yaml` and `massbank.yaml`** — the two largest silent-failure clusters in the logs were documented in prose that nothing re-tested. Corpus `zero_rows` checks go 7 → 16, so both are now inside the weekly `mie-drift` run.

## Implementation note

Built at the tool layer, not in `execute_sparql`: `chembl.py` and `get_graph_list` both parse that CSV, and prose in its return value would corrupt both. The CSV body is preserved verbatim below the `#` lines, so nothing that parsed before stops parsing.

## Versioning

**MINOR** under the agent-pragmatic policy — success-path behaviour changes; no tool, parameter or return shape removed or renamed; every existing call still works.

## Verification

- 679 tests pass (16 new in `tests/test_empty_result_note.py`).
- Verified against the live endpoint, not only mocks: empty `SELECT` fires; `COUNT`-over-empty fires and keeps its `0`; the real MassBank production bug fires *and* draws the trap #11 hint; the namespace-fixed query and a genuine `COUNT` of 29,889,091 both stay silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)