### PR TITLE
release: 2.12.0 — the right candidates, in the right order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Changed
+
+- **`togoid_identifyId` now ranks candidates per-ID, not per-pattern.**
+  Reported on [#213](https://github.com/dbcls/togomcp/issues/213) after 2.11.0 shipped:
+  `pattern_collisions` is a property of a pattern alone and cannot know anything about
+  the ID in hand, so for the protein accession `AEK21611` the gene-level `insdc` (63)
+  outranked `insdc_cds` (73) — a client taking `candidates[0]` got the wrong dataset
+  for the exact case that motivated the tool.
+
+  Candidates are now sorted first on `shape_matches_examples` — whether the ID's
+  character-class shape (`AEK21611` → `L3D5`) is one the dataset's *own* published
+  examples take (`insdc_cds`: all `L3D5`; `insdc`: `L1D5`/`L2D6`) — with
+  `pattern_collisions` breaking ties within a tier. Measured leave-one-out over all
+  1,840 published example IDs, top-1 accuracy rises from **73.3% to 82.1%**. Shape only
+  ever re-orders; nothing that matched is dropped, so an ID whose shape is absent from a
+  dataset's ~10 examples costs a rank, never a result.
+
+  The remaining 18% is irreducible and the tool says so more bluntly than before: a bare
+  `672` is a well-formed ncbigene, pubmed, chebi *and* homologene ID, and no property of
+  the string can separate them. The description now tells clients outright not to take
+  `candidates[0]` blindly — the previous wording said order was "evidence, not an answer"
+  and was read past, which is itself the argument for fixing the ranking rather than the
+  prose.
+
+### Added
+
+- **`shape_matches_examples` on each `identifyId` candidate**, so a client can see *why*
+  something ranked where it did rather than trusting an opaque order.
+
+### Upstream
+
+`catalog` is the literal string `"FIXME"` in **20 of 119** datasets (`affy_probeset`,
+`atc`, `uberon`, `rnacentral`, …), also spotted on #213. We pass the field through
+untouched — inventing a value would be fabricating metadata about someone else's
+registry — so this is reported at
+[togoid/togoid-config#396](https://github.com/togoid/togoid-config/issues/396).
+
 ## [2.11.0] - 2026-08-31
 
 <!-- whatsnew: 2026-08-31 | TogoID ID conversion stopped misleading callers: a new <code>togoid_identifyId</code> turns a bare accession like <code>AEK21611</code> into the dataset key a conversion route needs, <code>getRelation</code> no longer reports a working route as nonexistent, and dataset ID patterns now ship in a form Python can actually compile. <strong>ChatGPT users must re-run <em>Scan Tools</em></strong> to see the new tool. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-09-01
+
+A same-week follow-up to 2.11.0, from the same reporter testing the thing we shipped
+them. `identifyId` answered their question with the right *set* of candidates in the
+wrong *order* — which for a client that reads `candidates[0]` is indistinguishable from
+being wrong. The fix is a better signal, not better prose: the previous release already
+warned against trusting rank, in the description the reporter was reading.
+
 ### Changed
 
 - **`togoid_identifyId` now ranks candidates per-ID, not per-pattern.**
@@ -2255,6 +2263,7 @@ _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
 [Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.8...HEAD
+[2.12.0]: https://github.com/dbcls/togomcp/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/dbcls/togomcp/compare/v2.10.0...v2.11.0
 [2.10.0]: https://github.com/dbcls/togomcp/compare/v2.9.1...v2.10.0
 [2.9.1]: https://github.com/dbcls/togomcp/compare/v2.9.0...v2.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.11.0"
+version = "2.12.0"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_togoid_id_resolution.py
+++ b/tests/test_togoid_id_resolution.py
@@ -32,6 +32,7 @@ from togo_mcp import togoid
 from togo_mcp.togoid import (
     _augment_dataset,
     _collision_scores,
+    _shape_signature,
     _suggest_datasets,
     _to_python_regex,
     convertId,
@@ -57,6 +58,10 @@ _UNIPROT_REGEX = (
 # character class, so `(`, `?`, `:`, `o`, `r`, `f`, `)` are literal members and
 # the pattern matches nearly any token.
 _HGNC_SYMBOL_REGEX = r"^(?<id>[A-Z0-9_(?:orf)\-]+\@?)$"
+_INSDC_REGEX = (
+    r"^(?:insdc:)?(?<id>[A-Z]\d{5}|[A-Z]{2}\d{6}|[A-Z]{4}\d{8}"
+    r"|[A-J][A-Z]{2}\d{5}|[A-Z]{4,}\d{9})(?:\.\d+)?$"
+)
 
 _DATASET_CONFIG = {
     "insdc_cds": {
@@ -64,6 +69,16 @@ _DATASET_CONFIG = {
         "category": "Protein",
         "regex": _INSDC_CDS_REGEX,
         "examples": [["ABU85686", "BAH11229", "DAA12165"]],
+    },
+    # Gene-level INSDC. Its `[A-J][A-Z]{2}\d{5}` branch also matches the protein
+    # accession AEK21611, and it collides with FEWER foreign examples than
+    # insdc_cds — which is precisely how it outranked insdc_cds under the
+    # collisions-only ordering shipped in 2.11.0.
+    "insdc": {
+        "label": "GenBank/ENA/DDBJ",
+        "category": "Gene",
+        "regex": _INSDC_REGEX,
+        "examples": [["U10991", "AF116914", "AK056978", "DQ440258"]],
     },
     "uniprot": {
         "label": "UniProt",
@@ -97,9 +112,11 @@ def _clear_caches():
     """The dataset config and collision table are memoised for the process."""
     togoid._dataset_config_cache = None
     togoid._collision_cache = None
+    togoid._shape_cache = None
     yield
     togoid._dataset_config_cache = None
     togoid._collision_cache = None
+    togoid._shape_cache = None
 
 
 def _mock_dataset_config(router: respx.Router) -> None:
@@ -446,6 +463,75 @@ class TestIdentifyId:
         with respx.mock(using="httpx"):
             with pytest.raises(ValueError, match="no identifiers"):
                 await identifyId(ids="   ")
+
+    @pytest.mark.asyncio
+    async def test_shape_beats_collisions_for_the_reported_case(self) -> None:
+        """The regression Yuna reported on #213: `pattern_collisions` alone put
+        the gene-level `insdc` (63) ahead of `insdc_cds` (73) for a PROTEIN
+        accession, so a client taking candidates[0] got the wrong dataset for
+        the exact case that motivated the tool."""
+        with respx.mock(using="httpx") as router:
+            _mock_dataset_config(router)
+            result = json.loads(await identifyId(ids="AEK21611"))
+        keys = [c["dataset"] for c in result[0]["candidates"]]
+        assert keys[0] == "insdc_cds"
+        assert keys.index("insdc_cds") < keys.index("insdc")
+
+    @pytest.mark.asyncio
+    async def test_shape_match_is_exposed(self) -> None:
+        with respx.mock(using="httpx") as router:
+            _mock_dataset_config(router)
+            result = json.loads(await identifyId(ids="AEK21611"))
+        by_key = {c["dataset"]: c for c in result[0]["candidates"]}
+        assert by_key["insdc_cds"]["shape_matches_examples"] is True
+        assert by_key["hgnc_symbol"]["shape_matches_examples"] is False
+
+    @pytest.mark.asyncio
+    async def test_shape_reorders_but_never_drops_a_match(self) -> None:
+        """Shape is a tie-break, not a filter: a dataset whose ~10 examples
+        happen not to cover the ID's shape must still be offered."""
+        with respx.mock(using="httpx") as router:
+            _mock_dataset_config(router)
+            result = json.loads(await identifyId(ids="AEK21611"))
+        keys = {c["dataset"] for c in result[0]["candidates"]}
+        assert "insdc" in keys and "hgnc_symbol" in keys
+
+    @pytest.mark.asyncio
+    async def test_collisions_still_break_ties_within_a_shape_tier(self) -> None:
+        """P38398's shape matches both uniprot and insdc_cds examples, so the
+        tie falls to collisions — uniprot (fewer) must win."""
+        with respx.mock(using="httpx") as router:
+            _mock_dataset_config(router)
+            result = json.loads(await identifyId(ids="P38398"))
+        tier = [c for c in result[0]["candidates"] if c["shape_matches_examples"]]
+        assert [c["pattern_collisions"] for c in tier] == sorted(
+            c["pattern_collisions"] for c in tier
+        )
+        assert result[0]["candidates"][0]["dataset"] == "uniprot"
+
+    @pytest.mark.asyncio
+    async def test_ranking_is_per_token_not_shared(self) -> None:
+        """Ordering depends on the ID, so two IDs in one call must not share a
+        single precomputed order."""
+        with respx.mock(using="httpx") as router:
+            _mock_dataset_config(router)
+            result = json.loads(await identifyId(ids=["AEK21611", "P38398"]))
+        assert result[0]["candidates"][0]["dataset"] == "insdc_cds"
+        assert result[1]["candidates"][0]["dataset"] == "uniprot"
+
+    @pytest.mark.parametrize(
+        "identifier,signature",
+        [
+            ("AEK21611", "L3D5"),
+            ("P38398", "L1D5"),
+            ("2HHB", "D1L3"),
+            ("NP_009225", "L2_1D6"),
+            ("CHEBI:15377", "L5:1D5"),
+            ("", ""),
+        ],
+    )
+    def test_shape_signature(self, identifier: str, signature: str) -> None:
+        assert _shape_signature(identifier) == signature
 
     def test_collision_scores_rank_the_catch_all_highest(self) -> None:
         scores = _collision_scores(_DATASET_CONFIG)

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -173,10 +173,11 @@ async def _dataset_config(*, refresh: bool = False) -> dict:
     key we are about to reject is exactly the case where staleness matters, and
     nothing else pays for it.
     """
-    global _dataset_config_cache, _collision_cache
+    global _dataset_config_cache, _collision_cache, _shape_cache
     if refresh:
         _dataset_config_cache = None
         _collision_cache = None
+        _shape_cache = None
     if _dataset_config_cache is not None:
         return _dataset_config_cache
     try:
@@ -476,6 +477,43 @@ def _collision_scores(config: dict) -> dict[str, int]:
     return scores
 
 
+_shape_cache: dict[str, set[str]] | None = None
+
+
+def _shape_signature(identifier: str) -> str:
+    """Collapse an ID to its character-class shape: `AEK21611` -> `L3D5`.
+
+    Letters become `L`, digits `D`, everything else stays literal (so
+    `NP_009225` -> `L2_1D6`), then runs are counted.
+    """
+    classified = "".join(
+        "L" if c.isalpha() else ("D" if c.isdigit() else c) for c in identifier
+    )
+    runs: list[list] = []
+    for char in classified:
+        if runs and runs[-1][0] == char:
+            runs[-1][1] += 1
+        else:
+            runs.append([char, 1])
+    return "".join(f"{char}{count}" for char, count in runs)
+
+
+def _example_shapes(config: dict) -> dict[str, set[str]]:
+    """The set of shapes each dataset's own published example IDs take."""
+    global _shape_cache
+    if _shape_cache is not None:
+        return _shape_cache
+    shapes: dict[str, set[str]] = {}
+    for key, cfg in config.items():
+        seen = set()
+        for group in cfg.get("examples") or []:
+            for example in group if isinstance(group, list) else [group]:
+                seen.add(_shape_signature(str(example)))
+        shapes[key] = seen
+    _shape_cache = shapes
+    return shapes
+
+
 @togoid_mcp.tool(annotations=READ_ONLY_TOOL)
 async def identifyId(ids: str | list[str], category: str | None = None) -> str:
     """Resolve a bare accession to the TogoID dataset key(s) it could belong to.
@@ -487,21 +525,32 @@ async def identifyId(ids: str | list[str], category: str | None = None) -> str:
 
     RETURNS a JSON string of a bare array, one object per input ID, each with
     `id` and `candidates` (possibly empty). Each candidate carries `dataset`
-    (the key to put in a route), `label`, `category`, and `pattern_collisions`.
+    (the key to put in a route), `label`, `category`, `shape_matches_examples`,
+    and `pattern_collisions`.
 
-    Candidates are ordered most-specific first, by `pattern_collisions` — how
-    many of the OTHER 118 datasets' published example IDs this dataset's ID
-    pattern also matches. Low means a distinctive format (`uniprot`: 10); high
-    means a catch-all (`hgnc_symbol`: 1474, which matches nearly any token).
+    Candidates are ordered best-first on two pieces of evidence:
 
-    ⚠️ ORDER IS EVIDENCE, NOT AN ANSWER. Accession formats genuinely collide:
-    `P38398` is a valid UniProt accession AND a valid GenBank CDS accession,
-    and all the bare-numeric datasets (ncbigene, pubmed, chebi, ...) are
-    indistinguishable by shape — they tie at 170 for that reason. When two
-    candidates are close, disambiguate with `category`, with what you know
-    about where the ID came from, or by running countId on each and keeping the
-    one that resolves. An empty `candidates` list means no registered dataset's
-    pattern matches — that ID is not convertible by TogoID.
+    - `shape_matches_examples` — whether the ID's character-class shape
+      (`AEK21611` → `L3D5`) is one the dataset's OWN published examples take.
+      This is the per-ID signal, and it does most of the work: `insdc_cds`'s
+      examples are all `L3D5` while `insdc`'s are `L1D5`/`L2D6`, so a protein
+      accession sorts above the gene-level dataset.
+    - `pattern_collisions` — how many of the OTHER 118 datasets' example IDs
+      this dataset's pattern also matches, used to break ties. Low means a
+      distinctive format (`uniprot`: 10); high means a catch-all
+      (`hgnc_symbol`: 1474, which matches nearly any token).
+
+    On the 1,840 published example IDs, that ordering puts the right dataset
+    first 82% of the time (leave-one-out).
+
+    ⚠️ THE OTHER 18% IS IRREDUCIBLE — ORDER IS EVIDENCE, NOT AN ANSWER. Some
+    accession formats simply do not distinguish: a bare `672` is a well-formed
+    ncbigene, pubmed, chebi and homologene ID, and nothing about the string can
+    say which. **Do not build a client that blindly takes `candidates[0]`.**
+    Pass `category=` when you know what kind of thing the ID names, use what you
+    know about where the ID came from, or run countId on the top candidates and
+    keep the one that resolves. An empty `candidates` list means no registered
+    dataset's pattern matches — that ID is not convertible by TogoID.
 
     Matching uses each dataset's published ID pattern, rewritten to Python
     syntax (see getAllDataset's `regex_python`). A CURIE or full IRI
@@ -518,9 +567,10 @@ async def identifyId(ids: str | list[str], category: str | None = None) -> str:
 
     Example:
         >>> identifyId("AEK21611")
-        # insdc (63), insdc_cds (73), hgnc_symbol (1474)
-        >>> identifyId("AEK21611", category="Protein")
-        # narrows to insdc_cds — the key convertId wants
+        # insdc_cds first (shape L3D5 matches its examples), then insdc,
+        # then hgnc_symbol
+        >>> identifyId("672")
+        # a true tie: several bare-numeric datasets, none distinguishable
     """
     tokens = _ids_to_tokens(ids)
     if not tokens:
@@ -544,7 +594,8 @@ async def identifyId(ids: str | list[str], category: str | None = None) -> str:
         )
 
     collisions = _collision_scores(config)
-    compiled: list[tuple[int, str, re.Pattern, dict]] = []
+    shapes = _example_shapes(config)
+    compiled: list[tuple[str, re.Pattern, dict]] = []
     for key, cfg in config.items():
         pattern = cfg.get("regex")
         if not isinstance(pattern, str):
@@ -557,25 +608,39 @@ async def identifyId(ids: str | list[str], category: str | None = None) -> str:
             # A pattern we cannot compile even after rewriting is upstream's to
             # fix; skip it rather than failing every lookup.
             continue
-        score = collisions.get(key, 0)
-        compiled.append((score, key, matcher, {
+        compiled.append((key, matcher, {
             "dataset": key,
             "label": cfg.get("label"),
             "category": cfg.get("category"),
-            "pattern_collisions": score,
+            "pattern_collisions": collisions.get(key, 0),
         }))
-    compiled.sort(key=lambda entry: (entry[0], entry[1]))
 
-    resolved = [
-        {
-            "id": token,
-            "candidates": [
-                meta for _, _, matcher, meta in compiled if matcher.fullmatch(token)
-            ],
-        }
-        for token in tokens
-    ]
-    return json.dumps(resolved)
+    def _candidates(token: str) -> list[dict]:
+        # Ranking is PER TOKEN: `pattern_collisions` is a property of the
+        # pattern alone and cannot know anything about the ID in hand, which is
+        # how the gene-level `insdc` (63) came to outrank `insdc_cds` (73) for a
+        # protein accession. Whether the token's shape appears among a dataset's
+        # OWN examples is a per-ID signal, and a strong one: as first sort key
+        # it lifts leave-one-out top-1 accuracy over the 1,840 published example
+        # IDs from 73.3% to 82.1%. It only ever re-orders — no candidate that
+        # matched is dropped — so a shape absent from a dataset's ~10 examples
+        # costs a rank, never a result.
+        signature = _shape_signature(token)
+        matched = []
+        for key, matcher, meta in compiled:
+            if not matcher.fullmatch(token):
+                continue
+            shape_match = signature in shapes.get(key, ())
+            matched.append((
+                0 if shape_match else 1,
+                meta["pattern_collisions"],
+                key,
+                dict(meta, shape_matches_examples=shape_match),
+            ))
+        matched.sort(key=lambda entry: entry[:3])
+        return [entry[3] for entry in matched]
+
+    return json.dumps([{"id": t, "candidates": _candidates(t)} for t in tokens])
 
 
 @togoid_mcp.tool(annotations=READ_ONLY_TOOL)

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Follow-up to #214, from the same reporter on #213 testing what we shipped them.

`togoid_identifyId` returned the right *set* of candidates in the wrong *order*:
`pattern_collisions` is a property of a pattern alone and cannot know anything about the
ID in hand, so for the protein accession `AEK21611` the gene-level `insdc` (63)
outranked `insdc_cds` (73). For a client that reads `candidates[0]`, the right set in
the wrong order is indistinguishable from wrong.

## What ships

- **Per-ID ranking.** Candidates sort first on `shape_matches_examples` — whether the
  ID's character-class shape (`AEK21611` → `L3D5`) is one the dataset's *own* published
  examples take (`insdc_cds`: all `L3D5`; `insdc`: `L1D5`/`L2D6`) — with
  `pattern_collisions` breaking ties within a tier. Leave-one-out over all 1,840
  published example IDs: top-1 **73.3% → 82.1%**.

  ```
  AEK21611     -> insdc_cds, insdc, hgnc_symbol        (was insdc first)
  CHEBI:15377  -> chebi, hgnc_symbol                   (was hgnc_symbol first)
  NP_009225    -> refseq_protein, hgnc_symbol
  P38398       -> uniprot, insdc, insdc_cds
  672          -> irreducible tie among bare-numeric datasets
  ```

  Shape only re-orders; nothing that matched is dropped, so an ID whose shape is absent
  from a dataset's ~10 examples costs a rank, never a result.

- **`shape_matches_examples`** on each candidate, so clients can see why something
  ranked where it did instead of trusting an opaque order. (This field is why the
  release is MINOR rather than PATCH.)

## Why not the fix that was suggested

The reporter proposed documenting that order reflects specificity rather than
likelihood. That text already shipped verbatim in the description they were reading —
"⚠️ ORDER IS EVIDENCE, NOT AN ANSWER … disambiguate with `category`" — and they hit the
problem anyway. Documentation that is already correct and already prominent failing to
prevent the mistake is the argument for fixing the ranking, not the prose. The
description now also says outright not to take `candidates[0]` blindly.

## Verification

727 tests pass (11 new). The fixture gained the real `insdc` pattern and examples so it
reproduces the inversion: under collisions-only ordering it still puts `insdc` first, so
the regression test would catch a revert.

Also reported upstream this cycle: `catalog` is the literal string `"FIXME"` in 20 of
119 datasets — [togoid/togoid-config#396](https://github.com/togoid/togoid-config/issues/396#issuecomment-5485476308).
We pass the field through untouched.

No What's New marker: the 2026-08-31 entry already describes this tool accurately, and a
second consecutive item about it would push out the ChatGPT connector-refresh advisory
that entry carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)