### PR TITLE
release: 2.12.1 — correct before and after TogoID's next deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-09-01
+
+Housekeeping ahead of an upstream deploy. TogoID fixed the malformed `hgnc_symbol`
+pattern we reported ([togoid-config#396](https://github.com/togoid/togoid-config/issues/396),
+commit `352910c0`), but has not yet published it. Our ranking reads collision scores
+from the live config and so needs no change — verified by running `identifyId` against a
+config carrying the revised pattern. What did need changing was one guard and one
+number, both armed for the moment that fix lands.
+
 ### Fixed
 
 - **`getAllDataset`/`getDataset` no longer overwrite a `regex_flavor` TogoID publishes
@@ -2290,6 +2299,7 @@ _MIE database onboarding and revisions land continuously and are summarised per
 release above; see git history for the full detail._
 
 [Unreleased]: https://github.com/dbcls/togomcp/compare/v2.7.8...HEAD
+[2.12.1]: https://github.com/dbcls/togomcp/compare/v2.12.0...v2.12.1
 [2.12.0]: https://github.com/dbcls/togomcp/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/dbcls/togomcp/compare/v2.10.0...v2.11.0
 [2.10.0]: https://github.com/dbcls/togomcp/compare/v2.9.1...v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ dominant client re-reads the schema each session. Only a removal/rename is MAJOR
 
 ## [Unreleased]
 
+### Fixed
+
+- **`getAllDataset`/`getDataset` no longer overwrite a `regex_flavor` TogoID publishes
+  itself.** We asked upstream to add exactly that field
+  ([togoid/togoid-config#396](https://github.com/togoid/togoid-config/issues/396)), so
+  asserting `"ecmascript"` over the top was a latent bug waiting on our own request
+  being granted: if TogoID ever switches the published form to `(?P<...)` and labels it
+  `"python"`, clobbering that would make us the source of a false claim about someone
+  else's data. We now defer to an upstream value and only fill in the default when the
+  field is absent. `regex_python` stays correct either way — the rewrite is a no-op on a
+  pattern that is already Python-shaped.
+
+### Changed
+
+- **Docs stop hard-coding collision figures that upstream controls.** `hgnc_symbol`'s
+  `pattern_collisions` was quoted as `1474` in the client-visible `identifyId`
+  description. Ikeda fixed the malformed pattern we reported
+  (togoid-config `352910c0`, 2026-09-01), which takes the score to ~1,115 and stops it
+  matching CURIEs like `CHEBI:15377`. Scores are read from the live config, so the code
+  needed no change — but a docstring quoting a stale number is a docstring lying to the
+  model reading it. The description now gives magnitudes and says the figures move.
+
+  No behavioral change on our side, before or after that fix deploys: verified by
+  running `identifyId` against a config carrying the revised pattern. Ranking is
+  identical for `AEK21611`, `P38398`, `2HHB` and `672`; `CHEBI:15377` simply stops
+  offering a spurious `hgnc_symbol` candidate and resolves to `chebi` alone.
+
 ## [2.12.0] - 2026-09-01
 
 A same-week follow-up to 2.11.0, from the same reporter testing the thing we shipped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ togo_mcp = [
 
 [project]
 name = "togo-mcp"
-version = "2.12.0"
+version = "2.12.1"
 description = "MCP Servers for using the RDF Portal"
 authors = [
     {name = "Akira R. Kinjo"},

--- a/tests/test_togoid_id_resolution.py
+++ b/tests/test_togoid_id_resolution.py
@@ -54,10 +54,13 @@ _UNIPROT_REGEX = (
     r"^(?:(?<id1>[A-NR-Z][0-9](?:[A-Z][A-Z0-9][A-Z0-9][0-9]){1,2}(?:-\d+)?)"
     r"|(?<id2>[OPQ][0-9][A-Z0-9][A-Z0-9][A-Z0-9][0-9](?:-\d+)?)(?:\.\d+)?)$"
 )
-# Upstream bug: the `(?:orf)` was meant as an alternation but sits inside the
-# character class, so `(`, `?`, `:`, `o`, `r`, `f`, `)` are literal members and
-# the pattern matches nearly any token.
-_HGNC_SYMBOL_REGEX = r"^(?<id>[A-Z0-9_(?:orf)\-]+\@?)$"
+# Upstream, as of togoid-config 352910c0 (2026-09-01). The previous form was
+# `^(?<id>[A-Z0-9_(?:orf)\-]+\@?)$`, where the `(?:orf)` was meant as an
+# alternation but sat inside the character class, making `(`, `?`, `:`, `o`,
+# `r`, `f`, `)` literal members — so it matched even `CHEBI:15377`. We reported
+# it (togoid/togoid-config#396) and it was fixed. Still a catch-all for bare
+# uppercase alphanumeric tokens, which is the property these tests rely on.
+_HGNC_SYMBOL_REGEX = r"^(?<id>[A-Z0-9_\-]+(?:orf[0-9]+[A-Z0-9\-]+)?\@?)$"
 _INSDC_REGEX = (
     r"^(?:insdc:)?(?<id>[A-Z]\d{5}|[A-Z]{2}\d{6}|[A-Z]{4}\d{8}"
     r"|[A-J][A-Z]{2}\d{5}|[A-Z]{4,}\d{9})(?:\.\d+)?$"
@@ -167,6 +170,19 @@ class TestRegexPortability:
         assert augmented["regex"] == _INSDC_CDS_REGEX
         assert augmented["regex_flavor"] == "ecmascript"
         assert re.compile(augmented["regex_python"]).fullmatch("AEK21611")
+
+    def test_upstream_regex_flavor_is_not_overwritten(self) -> None:
+        """If TogoID starts publishing `regex_flavor` — what we asked for in
+        togoid/togoid-config#396 — asserting "ecmascript" over the top would
+        make us the source of a false claim about their data."""
+        augmented = _augment_dataset(
+            {"regex": r"^(?P<id>\d+)$", "regex_flavor": "python"}
+        )
+        assert augmented["regex_flavor"] == "python"
+        assert re.compile(augmented["regex_python"]).fullmatch("672")
+
+    def test_regex_flavor_defaults_when_upstream_omits_it(self) -> None:
+        assert _augment_dataset({"regex": r"^(?<id>\d+)$"})["regex_flavor"] == "ecmascript"
 
     def test_augment_does_not_mutate_input(self) -> None:
         original = dict(_DATASET_CONFIG["uniprot"])

--- a/togo_mcp/togoid.py
+++ b/togo_mcp/togoid.py
@@ -125,7 +125,14 @@ def _augment_dataset(config: dict) -> dict:
     if not isinstance(pattern, str):
         return config
     augmented = dict(config)
-    augmented["regex_flavor"] = "ecmascript"
+    # If TogoID starts publishing its own `regex_flavor` — which is what we asked
+    # for in togoid/togoid-config#396 — believe it rather than asserting
+    # "ecmascript" over the top. Should they ever switch the published form to
+    # `(?P<...)` and label it "python", overwriting that would make us the
+    # source of a false claim about someone else's data. The rewrite below is a
+    # no-op on an already-Python pattern, so `regex_python` stays correct either
+    # way.
+    augmented.setdefault("regex_flavor", "ecmascript")
     augmented["regex_python"] = _to_python_regex(pattern)
     return augmented
 
@@ -442,14 +449,25 @@ def _collision_scores(config: dict) -> dict[str, int]:
     1,840 probe IDs; running all 119 patterns over all of them takes ~0.03s and
     is memoised for the process.
 
-    The result separates the genuinely specific from the catch-all: `uniprot`
-    collides with 10, `insdc_cds` with 73, and `hgnc_symbol` with 1,474 —
-    upstream authored it as `^(?<id>[A-Z0-9_(?:orf)\\-]+\\@?)$`, where the
-    `(?:orf)` was meant as an alternation but sits INSIDE the character class,
-    making `(`, `?`, `:`, `o`, `r`, `f`, `)` literal members. It matches almost
-    any token, `CHEBI:15377` included. Bare-numeric datasets (ncbigene, pubmed,
-    chebi, ...) all score 170 because they genuinely cannot be told apart by
-    shape — the tie is the honest answer, not a ranking failure.
+    The result separates the genuinely specific from the catch-all: as of
+    2026-09-01, `uniprot` collides with 10, `insdc_cds` with 73, and
+    `hgnc_symbol` with 1,474. Bare-numeric datasets (ncbigene, pubmed, chebi,
+    ...) all score 170 because they genuinely cannot be told apart by shape —
+    the tie is the honest answer, not a ranking failure.
+
+    Scores are derived from whatever the live config says, so they move when
+    TogoID revises a pattern; treat any figure here as illustrative. The
+    `hgnc_symbol` number is a case in point. It was 1,474 because upstream had
+    authored the pattern as `^(?<id>[A-Z0-9_(?:orf)\\-]+\\@?)$`, where the
+    `(?:orf)` was meant as an alternation but sat INSIDE the character class,
+    making `(`, `?`, `:`, `o`, `r`, `f`, `)` literal members — so it matched
+    almost any token, `CHEBI:15377` included. We reported that
+    (togoid/togoid-config#396) and it is fixed in the config repo as of
+    2026-09-01, not yet on api.togoid.dbcls.jp. When the fix lands the score
+    drops to ~1,115 and the spurious CURIE matches disappear: still a catch-all
+    for bare uppercase alphanumeric tokens, so this measure keeps earning its
+    place. Nothing here needs changing when that happens — the numbers are read,
+    not written.
     """
     global _collision_cache
     if _collision_cache is not None:
@@ -537,8 +555,10 @@ async def identifyId(ids: str | list[str], category: str | None = None) -> str:
       accession sorts above the gene-level dataset.
     - `pattern_collisions` — how many of the OTHER 118 datasets' example IDs
       this dataset's pattern also matches, used to break ties. Low means a
-      distinctive format (`uniprot`: 10); high means a catch-all
-      (`hgnc_symbol`: 1474, which matches nearly any token).
+      distinctive format (`uniprot`: ~10); high means a catch-all
+      (`hgnc_symbol`: over a thousand — it matches nearly any bare uppercase
+      alphanumeric token). Scores are computed from the live config, so the
+      exact figures move when TogoID revises a pattern.
 
     On the 1,840 published example IDs, that ordering puts the right dataset
     first 82% of the time (leave-one-out).

--- a/uv.lock
+++ b/uv.lock
@@ -1820,7 +1820,7 @@ wheels = [
 
 [[package]]
 name = "togo-mcp"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Housekeeping ahead of an upstream deploy. Follows #216.

TogoID fixed the malformed `hgnc_symbol` pattern we reported
([togoid-config#396](https://github.com/togoid/togoid-config/issues/396), commit
`352910c0`):

```diff
- ^(?<id>[A-Z0-9_(?:orf)\-]+\@?)$
+ ^(?<id>[A-Z0-9_\-]+(?:orf[0-9]+[A-Z0-9\-]+)?\@?)$
```

It is **not deployed** — `api.togoid.dbcls.jp` still serves the old config, and items 1,
3 and 5 of that issue remain open.

## Our ranking needs no change

Collision scores are computed from whatever the live config says. Verified by running
`identifyId` against a config carrying the revised pattern:

```
AEK21611     -> insdc_cds(73), insdc(63), hgnc_symbol(1115)   unchanged
P38398       -> uniprot(10), insdc(63), insdc_cds(73)          unchanged
672          -> homologene, iuphar_ligand, pubchem_compound    unchanged
CHEBI:15377  -> chebi(170)                                     spurious match gone
C1orf21-DT   -> hgnc_symbol(1115)                              now matches
```

Leave-one-out top-1 accuracy is 82.1% either way. Our `(?<` → `(?P<` rewrite compiles
their new pattern unchanged (`(?:orf)` is a non-capturing group; the rewrite only
touches named-group openers).

## What did change

- **`_augment_dataset` no longer overwrites an upstream `regex_flavor`.** Adding that
  field is precisely what we asked for in #396 item 1, so asserting `"ecmascript"` over
  the top was a latent bug waiting on our own request being granted: if TogoID publishes
  `(?P<...)` labelled `"python"`, clobbering it would make us the source of a false
  claim about their data. One line — `setdefault` instead of assignment.

- **The client-visible `identifyId` description stops hard-coding `hgnc_symbol: 1474`.**
  That becomes ~1,115 on deploy. The code reads the number; only the prose pinned it,
  and a stale figure in a tool description is one the model reads. It now gives
  magnitudes and says the values track the live config. The `(?:orf)` explanation is
  kept as dated history — it is still the clearest illustration of why the measure
  exists.

The test fixture now carries Ikeda's pattern rather than the broken one, with the
history in a comment.

## Verification

729 tests pass (2 new, covering both directions of the `regex_flavor` guard). PATCH: no
tool, parameter, or return-shape change.

Note this has no user-visible effect today — both changes are armed for the same event.
Shipping now so nothing has to be remembered when TogoID deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)